### PR TITLE
Add MCP server report pages and SEO sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "vitest run",
     "validate-catalog": "node scripts/validate-catalog.js",
     "prebuild": "node scripts/generate-version.js",
-    "build": "vite build",
+    "build": "vite build && npm run generate-seo",
+    "generate-seo": "node scripts/generate-seo-pages.js",
     "deploy-worker": "wrangler deploy"
   },
   "dependencies": {

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const SITE_URL = 'https://mcptest.io';
+const projectRoot = path.join(__dirname, '..');
+const distRoot = path.join(projectRoot, 'dist');
+const indexPath = path.join(distRoot, 'index.html');
+const catalogPath = path.join(projectRoot, 'src', 'data', 'serverCatalog.json');
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function escapeXml(value) {
+  return escapeHtml(value).replace(/'/g, '&apos;');
+}
+
+function serverPath(serverId) {
+  return `/servers/${encodeURIComponent(serverId)}/`;
+}
+
+function transportLabel(transport) {
+  if (transport === 'streamable-http') return 'Streamable HTTP';
+  if (transport === 'legacy-sse') return 'Legacy HTTP+SSE';
+  return 'MCP';
+}
+
+function truncate(value, maxLength = 158) {
+  return value.length <= maxLength
+    ? value
+    : `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function replaceOrInsertHead(html, pattern, replacement) {
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement);
+  }
+  return html.replace('</head>', `    ${replacement}\n  </head>`);
+}
+
+function setPropertyMeta(html, property, content) {
+  const pattern = new RegExp(`<meta\\s+[^>]*property=["']${property}["'][^>]*>`, 'i');
+  return replaceOrInsertHead(
+    html,
+    pattern,
+    `<meta property="${property}" content="${escapeHtml(content)}" />`
+  );
+}
+
+function setNamedMeta(html, name, content) {
+  const pattern = new RegExp(`<meta\\s+[^>]*name=["']${name}["'][^>]*>`, 'i');
+  return replaceOrInsertHead(
+    html,
+    pattern,
+    `<meta name="${name}" content="${escapeHtml(content)}" />`
+  );
+}
+
+function renderServerFallback(server) {
+  const homepageLink = server.homepageUrl
+    ? `<a href="${escapeHtml(server.homepageUrl)}">Product documentation</a>`
+    : '';
+  const sourceLink = server.sourceUrl
+    ? `<a href="${escapeHtml(server.sourceUrl)}">Source repository</a>`
+    : '';
+  const references = [homepageLink, sourceLink].filter(Boolean).join(' · ');
+
+  return [
+    `<article class="server-profile seo-server-fallback" data-server-id="${escapeHtml(server.id)}">`,
+    '  <nav class="server-profile-breadcrumb" aria-label="Breadcrumb"><a href="/catalog">Server Catalog</a></nav>',
+    '  <header class="server-profile-hero">',
+    '    <div class="server-profile-identity"><div>',
+    '      <div class="server-profile-eyebrow">MCP server report</div>',
+    `      <h1>${escapeHtml(server.name)}</h1>`,
+    `      <p>${escapeHtml(server.description)}</p>`,
+    '    </div></div>',
+    '  </header>',
+    '  <section class="card server-profile-section"><div class="card-body">',
+    '    <h2>Connection specification</h2>',
+    '    <dl class="server-spec-list">',
+    `      <div><dt>Remote endpoint</dt><dd><code>${escapeHtml(server.url)}</code></dd></div>`,
+    `      <div><dt>MCP transport</dt><dd>${escapeHtml(transportLabel(server.transport))}</dd></div>`,
+    `      <div><dt>Authentication</dt><dd>${server.requiresOAuth ? 'OAuth 2.1 authorization code flow with PKCE' : 'No authentication declared'}</dd></div>`,
+    `      <div><dt>Category</dt><dd>${escapeHtml(server.category)}</dd></div>`,
+    '    </dl>',
+    `    <p>${references}</p>`,
+    `    <p><a href="/catalog">Browse all MCP servers</a> · <a href="${escapeHtml(`/server/${server.url}`)}">Test this endpoint in the MCP Playground</a></p>`,
+    '  </div></section>',
+    '</article>',
+  ].join('\n');
+}
+
+function renderServerHtml(indexHtml, server) {
+  const canonicalUrl = `${SITE_URL}${serverPath(server.id)}`;
+  const title = `${server.name} MCP Server Report | mcptest.io`;
+  const description = truncate(
+    `${server.name} MCP server connection report: ${transportLabel(server.transport)}, ${server.requiresOAuth ? 'OAuth 2.1' : 'no authentication declared'}, endpoint details, live-test status, and playground compatibility.`
+  );
+  const imageUrl = server.logoUrl
+    ? (server.logoUrl.startsWith('http') ? server.logoUrl : `${SITE_URL}${server.logoUrl}`)
+    : `${SITE_URL}/logo.png`;
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebAPI',
+    name: `${server.name} MCP Server`,
+    description: server.description,
+    url: canonicalUrl,
+    endpointUrl: server.url,
+    applicationCategory: server.category,
+    keywords: server.tags.join(', '),
+    documentation: server.homepageUrl || canonicalUrl,
+    additionalProperty: [
+      { '@type': 'PropertyValue', name: 'MCP transport', value: transportLabel(server.transport) },
+      { '@type': 'PropertyValue', name: 'Authentication', value: server.requiresOAuth ? 'OAuth 2.1' : 'None declared' },
+    ],
+  };
+
+  let html = indexHtml.replace(/<title>[^<]*<\/title>/i, `<title>${escapeHtml(title)}</title>`);
+  html = setNamedMeta(html, 'description', description);
+  html = setNamedMeta(html, 'twitter:card', 'summary');
+  html = setNamedMeta(html, 'twitter:title', title);
+  html = setNamedMeta(html, 'twitter:description', description);
+  html = setPropertyMeta(html, 'og:title', title);
+  html = setPropertyMeta(html, 'og:description', description);
+  html = setPropertyMeta(html, 'og:url', canonicalUrl);
+  html = setPropertyMeta(html, 'og:image', imageUrl);
+  html = setPropertyMeta(html, 'og:type', 'website');
+  html = replaceOrInsertHead(
+    html,
+    /<link\s+[^>]*rel=["']canonical["'][^>]*>/i,
+    `<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`
+  );
+
+  const safeJson = JSON.stringify(structuredData).replace(/<\//g, '<\\/');
+  html = html.replace(
+    '</head>',
+    `    <script id="server-structured-data" type="application/ld+json">${safeJson}</script>\n  </head>`
+  );
+  html = html.replace(
+    '<div id="root"></div>',
+    `<div id="root">\n${renderServerFallback(server)}\n    </div>`
+  );
+
+  return html;
+}
+
+function writeServerPages(indexHtml, servers) {
+  for (const server of servers) {
+    const outputDirectory = path.join(distRoot, 'servers', server.id);
+    fs.mkdirSync(outputDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(outputDirectory, 'index.html'),
+      renderServerHtml(indexHtml, server),
+      'utf8'
+    );
+  }
+}
+
+function writeSitemap(servers) {
+  const staticPaths = [
+    '/',
+    '/catalog',
+    '/report',
+    '/docs/what-is-mcp',
+    '/docs/remote-vs-local',
+    '/docs/testing-guide',
+    '/docs/troubleshooting',
+  ];
+  const paths = [...staticPaths, ...servers.map((server) => serverPath(server.id))];
+  const lastModified = new Date().toISOString().slice(0, 10);
+  const entries = paths.map((pathname) => [
+    '  <url>',
+    `    <loc>${escapeXml(`${SITE_URL}${pathname === '/' ? '' : pathname}`)}</loc>`,
+    `    <lastmod>${lastModified}</lastmod>`,
+    '  </url>',
+  ].join('\n'));
+  const sitemap = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    '</urlset>',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(distRoot, 'sitemap.xml'), sitemap, 'utf8');
+  fs.writeFileSync(
+    path.join(distRoot, 'robots.txt'),
+    `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`,
+    'utf8'
+  );
+}
+
+function validateInputs(servers) {
+  const ids = new Set();
+  for (const server of servers) {
+    if (!server.id || !server.name || !server.url || !server.transport) {
+      throw new Error(`Catalog SEO generation requires id, name, url, and transport: ${JSON.stringify(server)}`);
+    }
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(server.id)) {
+      throw new Error(`Catalog server id must be a safe lowercase slug: ${server.id}`);
+    }
+    if (ids.has(server.id)) {
+      throw new Error(`Duplicate catalog server id: ${server.id}`);
+    }
+    ids.add(server.id);
+  }
+}
+
+function main() {
+  if (!fs.existsSync(indexPath)) {
+    throw new Error('dist/index.html is missing; run Vite before generating SEO pages.');
+  }
+
+  const servers = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+  validateInputs(servers);
+  const indexHtml = fs.readFileSync(indexPath, 'utf8');
+
+  writeServerPages(indexHtml, servers);
+  writeSitemap(servers);
+
+  console.log(`Generated ${servers.length} server profile documents, sitemap.xml, and robots.txt.`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { renderServerHtml, serverPath, transportLabel };

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -96,6 +96,11 @@ function detectedAuthenticationLabel(server) {
   return server.requiresOAuth ? 'OAuth 2.1 detected or required' : 'No OAuth requirement detected';
 }
 
+function playgroundPath(server) {
+  const transportMethod = server.declaredTransport === 'legacy-sse' ? 'sse' : 'mcp';
+  return `/server/${server.url}/${transportMethod}`;
+}
+
 function truncate(value, maxLength = 158) {
   return value.length <= maxLength
     ? value
@@ -157,7 +162,7 @@ function renderServerFallback(server) {
     `      <div><dt>Category</dt><dd>${escapeHtml(server.category)}</dd></div>`,
     '    </dl>',
     `    <p>${references}</p>`,
-    `    <p><a href="/catalog">Browse all MCP servers</a> · <a href="${escapeHtml(`/server/${server.url}`)}">Test this endpoint in the MCP Playground</a></p>`,
+    `    <p><a href="/catalog">Browse all MCP servers</a> · <a href="${escapeHtml(playgroundPath(server))}">Test this endpoint in the MCP Playground</a></p>`,
     '  </div></section>',
     '  <section class="card server-profile-section"><div class="card-body">',
     '    <h2>Latest validation evidence</h2>',

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -97,7 +97,10 @@ function detectedAuthenticationLabel(server) {
 }
 
 function playgroundPath(server) {
-  const transportMethod = server.declaredTransport === 'legacy-sse' ? 'sse' : 'mcp';
+  const transport = server.transport === 'unknown'
+    ? server.declaredTransport
+    : server.transport;
+  const transportMethod = transport === 'legacy-sse' ? 'sse' : 'mcp';
   return `/server/${server.url}/${transportMethod}`;
 }
 

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -8,6 +8,7 @@ const projectRoot = path.join(__dirname, '..');
 const distRoot = path.join(projectRoot, 'dist');
 const indexPath = path.join(distRoot, 'index.html');
 const catalogPath = path.join(projectRoot, 'src', 'data', 'serverCatalog.json');
+const validationPath = path.join(projectRoot, 'src', 'data', 'catalogValidation.json');
 
 function escapeHtml(value) {
   return String(value)
@@ -28,7 +29,71 @@ function serverPath(serverId) {
 function transportLabel(transport) {
   if (transport === 'streamable-http') return 'Streamable HTTP';
   if (transport === 'legacy-sse') return 'Legacy HTTP+SSE';
-  return 'MCP';
+  if (transport === 'both') return 'Streamable HTTP and legacy SSE';
+  return 'Not yet verified';
+}
+
+function isValidationTransport(transport) {
+  return (
+    transport === 'streamable-http' ||
+    transport === 'legacy-sse' ||
+    transport === 'both' ||
+    transport === 'unknown'
+  );
+}
+
+function mergeCatalogServers(seeds, validationResults) {
+  const validationByServerId = new Map(
+    validationResults.map((result) => [result.serverId, result])
+  );
+
+  return seeds.map((seed) => {
+    const validation = validationByServerId.get(seed.id);
+
+    return {
+      ...seed,
+      declaredTransport: seed.transport,
+      declaredRequiresOAuth: seed.requiresOAuth,
+      status: validation?.status ?? 'unknown',
+      transport: isValidationTransport(validation?.transport)
+        ? validation.transport
+        : 'unknown',
+      requiresOAuth:
+        typeof validation?.requiresOAuth === 'boolean'
+          ? validation.requiresOAuth
+          : seed.requiresOAuth,
+      checkedAt: validation?.checkedAt,
+      validationMessage: validation?.message,
+    };
+  });
+}
+
+function validationStatusLabel(server) {
+  if (server.status === 'online') return 'Online when last tested';
+  if (server.status === 'offline') return 'Offline when last tested';
+  if (server.checkedAt) return 'Latest validation was inconclusive';
+  return 'Validation pending — live status not yet verified';
+}
+
+function validationTransportNote(server) {
+  if (!server.checkedAt) return 'Validation pending — no validation result has been recorded';
+  if (server.transport === 'unknown') return 'Latest validation did not verify a transport';
+  return 'Observed by the latest catalog validation';
+}
+
+function validationDetail(server) {
+  if (server.validationMessage) return server.validationMessage;
+  if (server.checkedAt) return 'The latest automated probe completed without additional validation detail.';
+  return 'Validation pending — no automated probe result is stored yet.';
+}
+
+function authenticationLabel(requiresOAuth) {
+  return requiresOAuth ? 'OAuth 2.1' : 'None';
+}
+
+function detectedAuthenticationLabel(server) {
+  if (!server.checkedAt) return 'Validation pending — not yet checked';
+  return server.requiresOAuth ? 'OAuth 2.1 detected or required' : 'No OAuth requirement detected';
 }
 
 function truncate(value, maxLength = 158) {
@@ -85,22 +150,42 @@ function renderServerFallback(server) {
     '    <h2>Connection specification</h2>',
     '    <dl class="server-spec-list">',
     `      <div><dt>Remote endpoint</dt><dd><code>${escapeHtml(server.url)}</code></dd></div>`,
-    `      <div><dt>MCP transport</dt><dd>${escapeHtml(transportLabel(server.transport))}</dd></div>`,
-    `      <div><dt>Authentication</dt><dd>${server.requiresOAuth ? 'OAuth 2.1 authorization code flow with PKCE' : 'No authentication declared'}</dd></div>`,
+    `      <div><dt>Declared MCP transport</dt><dd>${escapeHtml(transportLabel(server.declaredTransport))}</dd></div>`,
+    `      <div><dt>Live-validated MCP transport</dt><dd>${escapeHtml(transportLabel(server.transport))} — ${escapeHtml(validationTransportNote(server))}</dd></div>`,
+    `      <div><dt>Declared authentication</dt><dd>${escapeHtml(authenticationLabel(server.declaredRequiresOAuth))}</dd></div>`,
+    `      <div><dt>Detected authentication</dt><dd>${escapeHtml(detectedAuthenticationLabel(server))}</dd></div>`,
     `      <div><dt>Category</dt><dd>${escapeHtml(server.category)}</dd></div>`,
     '    </dl>',
     `    <p>${references}</p>`,
     `    <p><a href="/catalog">Browse all MCP servers</a> · <a href="${escapeHtml(`/server/${server.url}`)}">Test this endpoint in the MCP Playground</a></p>`,
+    '  </div></section>',
+    '  <section class="card server-profile-section"><div class="card-body">',
+    '    <h2>Latest validation evidence</h2>',
+    '    <dl class="server-spec-list">',
+    `      <div><dt>Validation status</dt><dd>${escapeHtml(validationStatusLabel(server))}</dd></div>`,
+    `      <div><dt>Validation checked at</dt><dd>${escapeHtml(server.checkedAt || 'Not yet validated')}</dd></div>`,
+    `      <div><dt>Validation detail</dt><dd>${escapeHtml(validationDetail(server))}</dd></div>`,
+    '    </dl>',
     '  </div></section>',
     '</article>',
   ].join('\n');
 }
 
 function renderServerHtml(indexHtml, server) {
+  server = server.declaredTransport
+    ? {
+        ...server,
+        declaredRequiresOAuth:
+          typeof server.declaredRequiresOAuth === 'boolean'
+            ? server.declaredRequiresOAuth
+            : server.requiresOAuth,
+      }
+    : mergeCatalogServers([server], [])[0];
+
   const canonicalUrl = `${SITE_URL}${serverPath(server.id)}`;
   const title = `${server.name} MCP Server Report | mcptest.io`;
   const description = truncate(
-    `${server.name} MCP server connection report: ${transportLabel(server.transport)}, ${server.requiresOAuth ? 'OAuth 2.1' : 'no authentication declared'}, endpoint details, live-test status, and playground compatibility.`
+    `${server.name} MCP server connection report: ${transportLabel(server.declaredTransport)} declared, ${server.declaredRequiresOAuth ? 'OAuth 2.1' : 'no authentication declared'}, endpoint details, live-test status, and playground compatibility.`
   );
   const imageUrl = server.logoUrl
     ? (server.logoUrl.startsWith('http') ? server.logoUrl : `${SITE_URL}${server.logoUrl}`)
@@ -116,8 +201,13 @@ function renderServerHtml(indexHtml, server) {
     keywords: server.tags.join(', '),
     documentation: server.homepageUrl || canonicalUrl,
     additionalProperty: [
-      { '@type': 'PropertyValue', name: 'MCP transport', value: transportLabel(server.transport) },
-      { '@type': 'PropertyValue', name: 'Authentication', value: server.requiresOAuth ? 'OAuth 2.1' : 'None declared' },
+      { '@type': 'PropertyValue', name: 'Declared MCP transport', value: transportLabel(server.declaredTransport) },
+      { '@type': 'PropertyValue', name: 'Live-validated MCP transport', value: transportLabel(server.transport) },
+      { '@type': 'PropertyValue', name: 'Declared authentication', value: authenticationLabel(server.declaredRequiresOAuth) },
+      { '@type': 'PropertyValue', name: 'Detected authentication', value: detectedAuthenticationLabel(server) },
+      { '@type': 'PropertyValue', name: 'Validation status', value: validationStatusLabel(server) },
+      { '@type': 'PropertyValue', name: 'Validation checked at', value: server.checkedAt || 'Not yet validated' },
+      { '@type': 'PropertyValue', name: 'Validation detail', value: validationDetail(server) },
     ],
   };
 
@@ -217,8 +307,10 @@ function main() {
     throw new Error('dist/index.html is missing; run Vite before generating SEO pages.');
   }
 
-  const servers = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
-  validateInputs(servers);
+  const seeds = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+  const validationResults = JSON.parse(fs.readFileSync(validationPath, 'utf8'));
+  validateInputs(seeds);
+  const servers = mergeCatalogServers(seeds, validationResults);
   const indexHtml = fs.readFileSync(indexPath, 'utf8');
 
   writeServerPages(indexHtml, servers);
@@ -231,4 +323,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { renderServerHtml, serverPath, transportLabel };
+module.exports = { mergeCatalogServers, renderServerHtml, serverPath, transportLabel };

--- a/scripts/generate-seo-pages.test.js
+++ b/scripts/generate-seo-pages.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { parseServerUrl } from '../src/utils/urlUtils';
+import seoGenerator from './generate-seo-pages.js';
+
+const { renderServerHtml } = seoGenerator;
+const indexHtml = '<html><head><title>mcptest.io</title></head><body><div id="root"></div></body></html>';
+
+function catalogServer(url, declaredTransport) {
+  return {
+    id: 'example-server',
+    name: 'Example Server',
+    url,
+    description: 'An example MCP server.',
+    category: 'Testing',
+    tags: ['example'],
+    declaredTransport,
+    transport: declaredTransport,
+    requiresOAuth: false,
+    status: 'online',
+  };
+}
+
+describe('generated server report Playground links', () => {
+  it('preserves an endpoint ending in /mcp before the transport marker', () => {
+    const html = renderServerHtml(
+      indexHtml,
+      catalogServer('https://mcp.linear.app/mcp', 'streamable-http')
+    );
+
+    expect(html).toContain('href="/server/https://mcp.linear.app/mcp/mcp"');
+    expect(parseServerUrl('/server/https://mcp.linear.app/mcp/mcp')).toEqual({
+      serverUrl: 'https://mcp.linear.app/mcp',
+      transportMethod: 'mcp',
+    });
+  });
+
+  it('preserves an endpoint ending in /sse before the transport marker', () => {
+    const html = renderServerHtml(
+      indexHtml,
+      catalogServer('https://example.com/sse', 'legacy-sse')
+    );
+
+    expect(html).toContain('href="/server/https://example.com/sse/sse"');
+    expect(parseServerUrl('/server/https://example.com/sse/sse')).toEqual({
+      serverUrl: 'https://example.com/sse',
+      transportMethod: 'sse',
+    });
+  });
+});

--- a/scripts/generate-seo-pages.test.js
+++ b/scripts/generate-seo-pages.test.js
@@ -46,4 +46,17 @@ describe('generated server report Playground links', () => {
       transportMethod: 'sse',
     });
   });
+
+  it('uses the validated transport when it differs from the declaration', () => {
+    const server = catalogServer('https://example.com/endpoint', 'streamable-http');
+    server.transport = 'legacy-sse';
+
+    const html = renderServerHtml(indexHtml, server);
+
+    expect(html).toContain('href="/server/https://example.com/endpoint/sse"');
+    expect(parseServerUrl('/server/https://example.com/endpoint/sse')).toEqual({
+      serverUrl: 'https://example.com/endpoint',
+      transportMethod: 'sse',
+    });
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import SideNav from './components/SideNav'; // New
 import DashboardsView from './components/DashboardsView'; // New
 import ReportView from './components/ReportView'; // New
 import CatalogView from './components/CatalogView';
+import ServerProfileView from './components/ServerProfileView';
 import Tabs from './components/Tabs'; // New
 // Documentation components
 import WhatIsMcp from './components/docs/WhatIsMcp';
@@ -46,6 +47,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CorsAwareStreamableHTTPTransport } from './utils/corsAwareTransport';
 import { CorsAwareSSETransport } from './utils/corsAwareSseTransport';
 import { formatErrorForDisplay } from './utils/errorHandling';
+import { getCatalogServerById } from './utils/catalogUtils';
+import { getCatalogServerIdFromPath } from './utils/catalogSeo';
 
 // Constants for localStorage keys
 const SPACES_KEY = 'mcpSpaces'; // New key for dashboards
@@ -69,7 +72,7 @@ const getInitialTheme = (): 'light' | 'dark' => {
 };
 
 // Helper to determine initial view from URL
-const getInitialView = (): 'playground' | 'dashboards' | 'docs' | 'report' | 'catalog' => {
+const getInitialView = (): 'playground' | 'dashboards' | 'docs' | 'report' | 'catalog' | 'server-profile' => {
   const path = window.location.pathname;
   if (path.startsWith('/docs/')) {
     return 'docs';
@@ -79,6 +82,9 @@ const getInitialView = (): 'playground' | 'dashboards' | 'docs' | 'report' | 'ca
   }
   if (path.startsWith('/report')) {
     return 'report';
+  }
+  if (getCatalogServerIdFromPath(path)) {
+    return 'server-profile';
   }
   if (path.startsWith('/catalog')) {
     return 'catalog';
@@ -203,6 +209,10 @@ function App() {
       return { activeView: 'report' as const, activeDocPage: null };
     }
 
+    if (getCatalogServerIdFromPath(path)) {
+      return { activeView: 'server-profile' as const, activeDocPage: null };
+    }
+
     // Check for catalog routes
     if (path.startsWith('/catalog')) {
       return { activeView: 'catalog' as const, activeDocPage: null };
@@ -299,6 +309,14 @@ function App() {
     if (path.startsWith('/docs/')) {
       const docPage = path.replace('/docs/', '');
       pageTitle = `Docs: ${docPage.replace(/-/g, ' ')}`;
+      logPageView(path, pageTitle);
+      return;
+    }
+
+    const catalogServerId = getCatalogServerIdFromPath(path);
+    if (catalogServerId) {
+      const catalogServer = getCatalogServerById(catalogServerId);
+      pageTitle = catalogServer ? `${catalogServer.name} MCP Server Report` : 'MCP Server Not Found';
       logPageView(path, pageTitle);
       return;
     }
@@ -1586,6 +1604,10 @@ function App() {
 
  // --- Render Logic ---
   const selectedSpace = spaces.find(s => s.id === selectedSpaceId);
+  const selectedCatalogServerId = getCatalogServerIdFromPath(location.pathname);
+  const selectedCatalogServer = selectedCatalogServerId
+    ? getCatalogServerById(selectedCatalogServerId)
+    : undefined;
 
   // Check if we're on the OAuth callback page
   if (location.pathname === '/oauth/callback') {
@@ -1732,6 +1754,11 @@ function App() {
           {/* Catalog View */}
           <div className={`view-panel ${activeView === 'catalog' ? '' : 'd-none'}`} style={{ height: '100%' }}>
             <CatalogView onTestServer={handleCatalogTestServer} />
+          </div>
+
+          {/* Server Profile View */}
+          <div className={`view-panel ${activeView === 'server-profile' ? '' : 'd-none'}`} style={{ height: '100%' }}>
+            <ServerProfileView server={selectedCatalogServer} onTestServer={handleCatalogTestServer} />
           </div>
 
           {/* Playground View */}

--- a/src/components/CatalogServerCard.tsx
+++ b/src/components/CatalogServerCard.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import type { CatalogServer, CatalogServerStatus, CatalogValidationTransport } from '../types/catalog';
 import { checkServerLiveness, type LivenessResult } from '../utils/catalogLiveness';
+import { getCatalogServerPath, getEffectiveCatalogTransport } from '../utils/catalogSeo';
 
 export interface CatalogServerCardProps {
   server: CatalogServer;
@@ -78,7 +80,8 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
           : liveResult.detail,
       }
     : getStatusDetails(server.status, server.checkedAt);
-  const transportBadges = getTransportBadges(server.transport);
+  const transportIsDeclaredOnly = server.transport === 'unknown';
+  const transportBadges = getTransportBadges(getEffectiveCatalogTransport(server));
   const isOffline = effectiveStatus === 'offline';
 
   const handleLivenessCheck = async () => {
@@ -112,7 +115,11 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
           )}
           <div className="flex-grow-1" style={{ minWidth: 0 }}>
             <div className="d-flex align-items-center justify-content-between gap-2 mb-1">
-              <h5 className="mb-0 text-truncate flex-grow-1">{server.name}</h5>
+              <h5 className="mb-0 text-truncate flex-grow-1">
+                <Link className="catalog-server-title" to={getCatalogServerPath(server.id)}>
+                  {server.name}
+                </Link>
+              </h5>
               <div className="d-flex align-items-center gap-2 flex-shrink-0">
                 <span
                   className={`rounded-circle flex-shrink-0 ${statusDetails.className}`}
@@ -156,20 +163,29 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
             </span>
           )}
           {transportBadges.map((badge) => (
-            <span key={badge.label} className={`badge ${badge.className}`}>
-              {badge.label}
+            <span
+              key={badge.label}
+              className={`badge ${transportIsDeclaredOnly ? 'bg-secondary' : badge.className}`}
+              title={transportIsDeclaredOnly ? 'Catalog-declared transport; live validation pending' : undefined}
+            >
+              {badge.label}{transportIsDeclaredOnly ? ' listed' : ''}
             </span>
           ))}
         </div>
 
-        <button
-          type="button"
-          className="btn btn-primary mt-auto"
-          onClick={() => onTest(server)}
-          disabled={isOffline}
-        >
-          Test in Playground
-        </button>
+        <div className="d-flex gap-2 mt-auto">
+          <Link className="btn btn-outline-secondary flex-grow-1" to={getCatalogServerPath(server.id)}>
+            View report
+          </Link>
+          <button
+            type="button"
+            className="btn btn-primary flex-grow-1"
+            onClick={() => onTest(server)}
+            disabled={isOffline}
+          >
+            Test server
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ServerProfileView.tsx
+++ b/src/components/ServerProfileView.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import type { CatalogServer } from '../types/catalog';
-import {
-  formatCatalogTransport,
-  getEffectiveCatalogTransport,
-} from '../utils/catalogSeo';
+import { formatCatalogTransport } from '../utils/catalogSeo';
 
 interface ServerProfileViewProps {
   server?: CatalogServer;
@@ -23,7 +20,20 @@ const formatCheckedAt = (checkedAt?: string) => {
 const statusLabel = (server: CatalogServer) => {
   if (server.status === 'online') return 'Online when last tested';
   if (server.status === 'offline') return 'Offline when last tested';
-  return 'Live status not yet verified';
+  if (server.checkedAt) return 'Latest validation was inconclusive';
+  return 'Validation pending — live status not yet verified';
+};
+
+const validationTransportNote = (server: CatalogServer) => {
+  if (!server.checkedAt) return 'No validation result has been recorded';
+  if (server.transport === 'unknown') return 'Latest validation did not verify a transport';
+  return 'Observed by the latest catalog validation';
+};
+
+const validationDetail = (server: CatalogServer) => {
+  if (server.validationMessage) return server.validationMessage;
+  if (server.checkedAt) return 'The latest automated probe completed without additional validation detail.';
+  return 'No automated probe result is stored yet. Use the Playground to run a fresh browser-side connection test.';
 };
 
 const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestServer }) => {
@@ -44,8 +54,6 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
     );
   }
 
-  const effectiveTransport = getEffectiveCatalogTransport(server);
-  const transportWasValidated = server.transport !== 'unknown';
   const statusClass = server.status === 'online'
     ? 'server-status-online'
     : server.status === 'offline'
@@ -98,14 +106,21 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
           <small>{formatCheckedAt(server.checkedAt)}</small>
         </div>
         <div className="server-signal-card">
-          <span className="server-signal-label">Transport</span>
-          <strong>{formatCatalogTransport(effectiveTransport)}</strong>
-          <small>{transportWasValidated ? 'Observed by the catalog probe' : 'Declared by the catalog; validation pending'}</small>
+          <span className="server-signal-label">Declared transport</span>
+          <strong>{formatCatalogTransport(server.declaredTransport)}</strong>
+          <small>Declared by the catalog source</small>
+        </div>
+        <div className="server-signal-card">
+          <span className="server-signal-label">Live-validated transport</span>
+          <strong>{formatCatalogTransport(server.transport)}</strong>
+          <small>{validationTransportNote(server)}</small>
         </div>
         <div className="server-signal-card">
           <span className="server-signal-label">Authentication</span>
           <strong>{server.requiresOAuth ? 'OAuth 2.1' : 'No auth declared'}</strong>
-          <small>{server.requiresOAuth ? 'Interactive authorization required' : 'Connect without credentials based on current listing'}</small>
+          <small>{server.checkedAt
+            ? (server.requiresOAuth ? 'OAuth detected or required by latest evidence' : 'No OAuth requirement detected by latest validation')
+            : (server.requiresOAuth ? 'Interactive authorization declared' : 'No credentials declared by the current listing')}</small>
         </div>
         <div className="server-signal-card">
           <span className="server-signal-label">Category</span>
@@ -131,8 +146,12 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
                 <dd><code>{server.url}</code></dd>
               </div>
               <div>
-                <dt>MCP transport</dt>
-                <dd>{formatCatalogTransport(effectiveTransport)}</dd>
+                <dt>Declared MCP transport</dt>
+                <dd>{formatCatalogTransport(server.declaredTransport)}</dd>
+              </div>
+              <div>
+                <dt>Live-validated MCP transport</dt>
+                <dd>{formatCatalogTransport(server.transport)}</dd>
               </div>
               <div>
                 <dt>Credential flow</dt>
@@ -178,7 +197,7 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
               </div>
             </div>
             <p className="text-muted small mb-3">
-              {server.validationMessage || 'No automated probe result is stored yet. Use the Playground to run a fresh browser-side connection test.'}
+              {validationDetail(server)}
             </p>
             <button className="btn btn-outline-primary w-100" type="button" onClick={() => onTestServer(server)}>
               Run a compatibility test

--- a/src/components/ServerProfileView.tsx
+++ b/src/components/ServerProfileView.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { CatalogServer } from '../types/catalog';
+import {
+  formatCatalogTransport,
+  getEffectiveCatalogTransport,
+} from '../utils/catalogSeo';
+
+interface ServerProfileViewProps {
+  server?: CatalogServer;
+  onTestServer: (server: CatalogServer) => void;
+}
+
+const formatCheckedAt = (checkedAt?: string) => {
+  if (!checkedAt) {
+    return 'Awaiting a recorded validation run';
+  }
+
+  const parsed = new Date(checkedAt);
+  return Number.isNaN(parsed.getTime()) ? checkedAt : parsed.toLocaleString();
+};
+
+const statusLabel = (server: CatalogServer) => {
+  if (server.status === 'online') return 'Online when last tested';
+  if (server.status === 'offline') return 'Offline when last tested';
+  return 'Live status not yet verified';
+};
+
+const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestServer }) => {
+  if (!server) {
+    return (
+      <div className="server-profile-empty card">
+        <div className="card-body text-center py-5">
+          <div className="server-profile-empty-icon mb-3" aria-hidden="true">
+            <i className="bi bi-hdd-network"></i>
+          </div>
+          <h1 className="h3">MCP server not found</h1>
+          <p className="text-muted mb-4">
+            This server report does not exist, or its catalog identifier has changed.
+          </p>
+          <Link className="btn btn-primary" to="/catalog">Browse the server catalog</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const effectiveTransport = getEffectiveCatalogTransport(server);
+  const transportWasValidated = server.transport !== 'unknown';
+  const statusClass = server.status === 'online'
+    ? 'server-status-online'
+    : server.status === 'offline'
+      ? 'server-status-offline'
+      : 'server-status-unknown';
+
+  return (
+    <article className="server-profile">
+      <nav aria-label="Breadcrumb" className="server-profile-breadcrumb">
+        <ol className="breadcrumb mb-0">
+          <li className="breadcrumb-item"><Link to="/catalog">Server Catalog</Link></li>
+          <li className="breadcrumb-item active" aria-current="page">{server.name}</li>
+        </ol>
+      </nav>
+
+      <header className="server-profile-hero">
+        <div className="server-profile-glow" aria-hidden="true"></div>
+        <div className="server-profile-identity">
+          <div className="server-profile-logo" aria-hidden={!server.logoUrl}>
+            {server.logoUrl ? (
+              <img src={server.logoUrl} alt={`${server.name} logo`} />
+            ) : (
+              <i className="bi bi-cpu"></i>
+            )}
+          </div>
+          <div>
+            <div className="server-profile-eyebrow">MCP server report</div>
+            <h1>{server.name}</h1>
+            <p>{server.description}</p>
+          </div>
+        </div>
+
+        <div className="server-profile-actions">
+          <button className="btn btn-primary" type="button" onClick={() => onTestServer(server)}>
+            <i className="bi bi-play-fill me-1" aria-hidden="true"></i>
+            Test in Playground
+          </button>
+          {server.homepageUrl && (
+            <a className="btn btn-outline-secondary" href={server.homepageUrl} target="_blank" rel="noopener noreferrer">
+              Product site <i className="bi bi-box-arrow-up-right ms-1" aria-hidden="true"></i>
+            </a>
+          )}
+        </div>
+      </header>
+
+      <section className="server-profile-signal-grid" aria-label="Connection summary">
+        <div className="server-signal-card">
+          <span className="server-signal-label">Live status</span>
+          <strong className={statusClass}><span className="server-status-dot"></span>{statusLabel(server)}</strong>
+          <small>{formatCheckedAt(server.checkedAt)}</small>
+        </div>
+        <div className="server-signal-card">
+          <span className="server-signal-label">Transport</span>
+          <strong>{formatCatalogTransport(effectiveTransport)}</strong>
+          <small>{transportWasValidated ? 'Observed by the catalog probe' : 'Declared by the catalog; validation pending'}</small>
+        </div>
+        <div className="server-signal-card">
+          <span className="server-signal-label">Authentication</span>
+          <strong>{server.requiresOAuth ? 'OAuth 2.1' : 'No auth declared'}</strong>
+          <small>{server.requiresOAuth ? 'Interactive authorization required' : 'Connect without credentials based on current listing'}</small>
+        </div>
+        <div className="server-signal-card">
+          <span className="server-signal-label">Category</span>
+          <strong>{server.category}</strong>
+          <small>{server.tags.filter((tag) => tag !== 'suggested').slice(0, 3).join(' · ')}</small>
+        </div>
+      </section>
+
+      <div className="server-profile-content-grid">
+        <section className="card server-profile-section">
+          <div className="card-body">
+            <div className="server-section-heading">
+              <span className="server-section-icon"><i className="bi bi-diagram-3" aria-hidden="true"></i></span>
+              <div>
+                <div className="server-profile-eyebrow">Connection specification</div>
+                <h2>How to connect</h2>
+              </div>
+            </div>
+
+            <dl className="server-spec-list">
+              <div>
+                <dt>Remote endpoint</dt>
+                <dd><code>{server.url}</code></dd>
+              </div>
+              <div>
+                <dt>MCP transport</dt>
+                <dd>{formatCatalogTransport(effectiveTransport)}</dd>
+              </div>
+              <div>
+                <dt>Credential flow</dt>
+                <dd>{server.requiresOAuth ? 'OAuth 2.1 authorization code flow with PKCE' : 'No authentication advertised by the catalog entry'}</dd>
+              </div>
+              <div>
+                <dt>Client environment</dt>
+                <dd>Remote MCP clients with HTTP transport support</dd>
+              </div>
+            </dl>
+
+            <div className="server-endpoint-box">
+              <div>
+                <span>Endpoint</span>
+                <code>{server.url}</code>
+              </div>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-secondary"
+                onClick={() => navigator.clipboard?.writeText(server.url)}
+                aria-label={`Copy ${server.name} MCP endpoint`}
+              >
+                <i className="bi bi-copy" aria-hidden="true"></i>
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="card server-profile-section server-validation-panel">
+          <div className="card-body">
+            <div className="server-section-heading">
+              <span className="server-section-icon"><i className="bi bi-activity" aria-hidden="true"></i></span>
+              <div>
+                <div className="server-profile-eyebrow">Compatibility report</div>
+                <h2>Latest evidence</h2>
+              </div>
+            </div>
+            <div className={`server-validation-state ${statusClass}`}>
+              <span className="server-status-dot"></span>
+              <div>
+                <strong>{statusLabel(server)}</strong>
+                <span>{formatCheckedAt(server.checkedAt)}</span>
+              </div>
+            </div>
+            <p className="text-muted small mb-3">
+              {server.validationMessage || 'No automated probe result is stored yet. Use the Playground to run a fresh browser-side connection test.'}
+            </p>
+            <button className="btn btn-outline-primary w-100" type="button" onClick={() => onTestServer(server)}>
+              Run a compatibility test
+            </button>
+          </div>
+        </aside>
+      </div>
+
+      <section className="card server-profile-section">
+        <div className="card-body">
+          <div className="server-section-heading">
+            <span className="server-section-icon"><i className="bi bi-braces-asterisk" aria-hidden="true"></i></span>
+            <div>
+              <div className="server-profile-eyebrow">Capabilities and references</div>
+              <h2>Server context</h2>
+            </div>
+          </div>
+          <div className="d-flex flex-wrap gap-2 mb-4">
+            {server.tags.map((tag) => <span className="server-tag" key={tag}>{tag}</span>)}
+          </div>
+          <div className="d-flex flex-wrap gap-3">
+            {server.homepageUrl && <a href={server.homepageUrl} target="_blank" rel="noopener noreferrer">Product documentation <i className="bi bi-arrow-up-right"></i></a>}
+            {server.sourceUrl && <a href={server.sourceUrl} target="_blank" rel="noopener noreferrer">Source repository <i className="bi bi-arrow-up-right"></i></a>}
+            <Link to="/docs/testing-guide">MCP testing guide <i className="bi bi-arrow-right"></i></Link>
+          </div>
+        </div>
+      </section>
+    </article>
+  );
+};
+
+export default ServerProfileView;

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -6,7 +6,7 @@ import { VERSION_INFO, getGithubCommitUrl } from '../utils/versionInfo';
 import { useAuth } from '../context/AuthContext';
 
 interface SideNavProps {
-  activeView: 'playground' | 'dashboards' | 'docs' | 'report' | 'catalog';
+  activeView: 'playground' | 'dashboards' | 'docs' | 'report' | 'catalog' | 'server-profile';
   spaces: Space[];
   selectedSpaceId: string | null;
   handleSelectSpace: (id: string) => void;
@@ -261,7 +261,7 @@ const SideNav: React.FC<SideNavProps> = ({
       {/* Server Catalog Link */}
       <Link
         to="/catalog"
-        className={`nav-link ${activeView === 'catalog' ? 'active fw-bold' : ''}`}
+        className={`nav-link ${activeView === 'catalog' || activeView === 'server-profile' ? 'active fw-bold' : ''}`}
         onClick={handleCatalogClick}
       >
         <i className="bi bi-grid me-2"></i> Server Catalog

--- a/src/hooks/useMetaTags.ts
+++ b/src/hooks/useMetaTags.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import { getCatalogServerById } from '../utils/catalogUtils';
+import { getCatalogServerIdFromPath, getCatalogServerSeo, SITE_URL } from '../utils/catalogSeo';
 import { parseResultShareUrl } from '../utils/urlUtils';
 
 const DEFAULT_TITLE = 'mcptest.io - MCP Playground';
 const DEFAULT_DESCRIPTION = 'A web-based testing and debugging tool for Model Context Protocol (MCP) servers.';
-const BASE_URL = 'https://mcptest.io';
-const DEFAULT_IMAGE = `${BASE_URL}/logo.png`;
+const DEFAULT_IMAGE = `${SITE_URL}/logo.png`;
 
 const setMetaTag = (property: string, content: string) => {
   let element = document.querySelector(`meta[property='${property}']`);
@@ -17,31 +18,112 @@ const setMetaTag = (property: string, content: string) => {
   element.setAttribute('content', content);
 };
 
+const setNamedMetaTag = (name: string, content: string) => {
+  let element = document.querySelector(`meta[name='${name}']`);
+  if (!element) {
+    element = document.createElement('meta');
+    element.setAttribute('name', name);
+    document.head.appendChild(element);
+  }
+  element.setAttribute('content', content);
+};
+
+const setCanonical = (href: string) => {
+  let element = document.querySelector("link[rel='canonical']");
+  if (!element) {
+    element = document.createElement('link');
+    element.setAttribute('rel', 'canonical');
+    document.head.appendChild(element);
+  }
+  element.setAttribute('href', href);
+};
+
+const setStructuredData = (data?: Record<string, unknown>) => {
+  const existing = document.getElementById('server-structured-data');
+  if (!data) {
+    existing?.remove();
+    return;
+  }
+
+  const element = existing || document.createElement('script');
+  element.id = 'server-structured-data';
+  element.setAttribute('type', 'application/ld+json');
+  element.textContent = JSON.stringify(data);
+  if (!existing) {
+    document.head.appendChild(element);
+  }
+};
+
+const applyMetadata = ({
+  title,
+  description,
+  canonicalUrl,
+  imageUrl = DEFAULT_IMAGE,
+  type = 'website',
+  structuredData,
+  robots = 'index, follow',
+}: {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  imageUrl?: string;
+  type?: string;
+  structuredData?: Record<string, unknown>;
+  robots?: string;
+}) => {
+  document.title = title;
+  setNamedMetaTag('description', description);
+  setNamedMetaTag('twitter:card', 'summary');
+  setNamedMetaTag('twitter:title', title);
+  setNamedMetaTag('twitter:description', description);
+  setNamedMetaTag('robots', robots);
+  setMetaTag('og:title', title);
+  setMetaTag('og:description', description);
+  setMetaTag('og:url', canonicalUrl);
+  setMetaTag('og:image', imageUrl);
+  setMetaTag('og:type', type);
+  setCanonical(canonicalUrl);
+  setStructuredData(structuredData);
+};
+
 export const useMetaTags = () => {
   const location = useLocation();
 
   useEffect(() => {
     const resultData = parseResultShareUrl(location.pathname, location.search);
+    const serverId = getCatalogServerIdFromPath(location.pathname);
+    const catalogServer = serverId ? getCatalogServerById(serverId) : undefined;
 
-    if (resultData) {
+    if (catalogServer) {
+      applyMetadata(getCatalogServerSeo(catalogServer));
+    } else if (serverId) {
+      applyMetadata({
+        title: 'MCP Server Not Found | mcptest.io',
+        description: 'This MCP server report is not available. Browse the catalog for tested remote MCP servers.',
+        canonicalUrl: `${SITE_URL}${location.pathname}`,
+        robots: 'noindex, follow',
+      });
+    } else if (resultData) {
       const { type, name, serverUrl } = resultData;
       const title = `MCP Test Result: ${name}`;
       const description = `Result for ${type} '${name}' from MCP server at ${serverUrl}. Click to view the full response.`;
       
-      document.title = title;
-      setMetaTag('og:title', title);
-      setMetaTag('og:description', description);
-      setMetaTag('og:url', `${BASE_URL}${location.pathname}${location.search}`);
-      setMetaTag('og:image', DEFAULT_IMAGE);
-      setMetaTag('og:type', 'article');
+      applyMetadata({
+        title,
+        description,
+        canonicalUrl: `${SITE_URL}${location.pathname}${location.search}`,
+        type: 'article',
+      });
 
     } else {
-      document.title = DEFAULT_TITLE;
-      setMetaTag('og:title', DEFAULT_TITLE);
-      setMetaTag('og:description', DEFAULT_DESCRIPTION);
-      setMetaTag('og:url', BASE_URL);
-      setMetaTag('og:image', DEFAULT_IMAGE);
-      setMetaTag('og:type', 'website');
+      const isCatalog = location.pathname === '/catalog';
+      applyMetadata({
+        title: isCatalog ? 'Remote MCP Server Catalog | mcptest.io' : DEFAULT_TITLE,
+        description: isCatalog
+          ? 'Browse remote MCP servers by capability, transport, authentication method, and live validation status.'
+          : DEFAULT_DESCRIPTION,
+        canonicalUrl: `${SITE_URL}${location.pathname === '/' ? '' : location.pathname}`,
+      });
     }
 
   }, [location]);

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,374 @@ a:hover {
   box-shadow: var(--box-shadow-xl);
 }
 
+.catalog-server-title {
+  color: var(--text-color);
+}
+
+.catalog-server-title:hover {
+  color: var(--primary-color);
+}
+
+/* Server profile / SEO report sheets */
+.server-profile {
+  width: min(1180px, 100%);
+  min-width: 0;
+  max-width: 100%;
+  margin: 0 auto;
+  padding-bottom: 2rem;
+}
+
+.server-profile-breadcrumb {
+  padding: 0.35rem 0 1rem;
+  font-size: 0.875rem;
+}
+
+.server-profile-hero {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  min-height: 260px;
+  margin-bottom: 1rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: calc(var(--border-radius) * 1.5);
+  background:
+    linear-gradient(120deg, rgba(34, 197, 94, 0.09), transparent 44%),
+    radial-gradient(circle at 82% 5%, rgba(56, 189, 248, 0.13), transparent 34%),
+    var(--card-bg);
+  box-shadow: var(--box-shadow-lg);
+}
+
+.server-profile-glow {
+  position: absolute;
+  width: 240px;
+  height: 240px;
+  top: -150px;
+  left: 20%;
+  border-radius: 50%;
+  background: var(--primary-color);
+  filter: blur(110px);
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.server-profile-identity {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 760px;
+  min-width: 0;
+}
+
+.server-profile-identity > div:last-child {
+  min-width: 0;
+}
+
+.server-profile-logo {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 84px;
+  height: 84px;
+  border: 1px solid var(--border-color);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--box-shadow-lg);
+  color: var(--primary-color);
+  font-size: 2.25rem;
+}
+
+.server-profile-logo img {
+  width: 58px;
+  height: 58px;
+  object-fit: contain;
+}
+
+.server-profile-eyebrow {
+  margin-bottom: 0.35rem;
+  color: var(--primary-color);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.server-profile-hero h1 {
+  margin-bottom: 0.6rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+}
+
+.server-profile-hero p {
+  max-width: 700px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.server-profile-actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 190px;
+}
+
+.server-profile-signal-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.server-signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 126px;
+  padding: 1.1rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--card-bg);
+  box-shadow: var(--box-shadow);
+}
+
+.server-signal-label {
+  margin-bottom: auto;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.server-signal-card strong {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0.8rem 0 0.2rem;
+  font-size: 0.93rem;
+}
+
+.server-signal-card small {
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+.server-status-dot {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 14%, transparent);
+}
+
+.server-status-online { color: var(--success-color); }
+.server-status-offline { color: var(--danger-color); }
+.server-status-unknown { color: var(--text-muted); }
+
+.server-profile-content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(300px, 0.85fr);
+  gap: 1rem;
+}
+
+.server-profile-section {
+  border: 1px solid var(--border-color);
+}
+
+.server-profile-section:hover {
+  box-shadow: var(--box-shadow-lg);
+}
+
+.server-section-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.server-section-heading h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.server-section-icon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.09);
+  color: var(--primary-color);
+}
+
+.server-spec-list {
+  margin: 0;
+}
+
+.server-spec-list > div {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.server-spec-list dt {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.server-spec-list dd {
+  min-width: 0;
+  margin: 0;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.server-endpoint-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.25rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--card-bg-secondary);
+}
+
+.server-endpoint-box > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.server-endpoint-box span {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.server-endpoint-box code {
+  overflow: hidden;
+  color: var(--text-color);
+  text-overflow: ellipsis;
+}
+
+.server-validation-state {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--card-bg-secondary);
+}
+
+.server-validation-state > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.server-validation-state span:last-child {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.server-tag {
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--card-bg-secondary);
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.72rem;
+}
+
+.server-profile-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto;
+  border-radius: 18px;
+  background: var(--card-bg-secondary);
+  color: var(--primary-color);
+  font-size: 1.75rem;
+}
+
+@media (max-width: 991.98px) {
+  .server-profile-hero {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .server-profile-actions {
+    flex-direction: row;
+  }
+
+  .server-profile-signal-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .server-profile-content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .server-profile-identity {
+    align-items: flex-start;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .server-profile-identity > div:last-child,
+  .server-profile-actions {
+    width: 100%;
+  }
+
+  .server-profile-logo {
+    width: 68px;
+    height: 68px;
+    border-radius: 18px;
+  }
+
+  .server-profile-logo img {
+    width: 46px;
+    height: 46px;
+  }
+
+  .server-profile-actions {
+    flex-direction: column;
+  }
+
+  .server-profile-signal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .server-spec-list > div {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+}
+
 .card-header {
   background-color: var(--card-bg-secondary);
   border-bottom: 1px solid var(--border-color);

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -82,6 +82,8 @@ export interface CatalogValidationResult {
  * output and any derived display metadata.
  */
 export interface CatalogServer extends Omit<CatalogServerSeed, 'transport'> {
+  /** Transport declared by the catalog source, even when a live probe is unavailable. */
+  declaredTransport: CatalogTransport;
   /** Transport support from validation, or unknown when validation is missing. */
   transport: CatalogValidationTransport;
   /** Current catalog reachability state. */

--- a/src/utils/catalogSeo.test.ts
+++ b/src/utils/catalogSeo.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { CatalogServer } from '../types/catalog';
+import {
+  formatCatalogTransport,
+  getCatalogServerIdFromPath,
+  getCatalogServerPath,
+  getCatalogServerSeo,
+} from './catalogSeo';
+
+const server: CatalogServer = {
+  id: 'example-server',
+  name: 'Example',
+  url: 'https://example.com/mcp',
+  description: 'An example remote MCP server.',
+  category: 'Developer Tools',
+  tags: ['example', 'tools'],
+  declaredTransport: 'streamable-http',
+  transport: 'unknown',
+  requiresOAuth: true,
+  status: 'unknown',
+};
+
+describe('catalog SEO helpers', () => {
+  it('builds and parses canonical server paths', () => {
+    expect(getCatalogServerPath(server.id)).toBe('/servers/example-server/');
+    expect(getCatalogServerIdFromPath('/servers/example-server')).toBe(server.id);
+    expect(getCatalogServerIdFromPath('/servers/example-server/')).toBe(server.id);
+    expect(getCatalogServerIdFromPath('/catalog/example-server')).toBeNull();
+  });
+
+  it('uses the declared transport when validation is pending', () => {
+    const seo = getCatalogServerSeo(server);
+
+    expect(formatCatalogTransport(server.declaredTransport)).toBe('Streamable HTTP');
+    expect(seo.description).toContain('Streamable HTTP');
+    expect(seo.description).toContain('OAuth 2.1');
+    expect(seo.canonicalUrl).toBe('https://mcptest.io/servers/example-server/');
+    expect(seo.structuredData.endpointUrl).toBe(server.url);
+  });
+});

--- a/src/utils/catalogSeo.ts
+++ b/src/utils/catalogSeo.ts
@@ -1,0 +1,93 @@
+import type { CatalogServer, CatalogTransport, CatalogValidationTransport } from '../types/catalog';
+
+export const SITE_URL = 'https://mcptest.io';
+
+export const getCatalogServerPath = (serverId: string): string => {
+  return `/servers/${encodeURIComponent(serverId)}/`;
+};
+
+export const getCatalogServerIdFromPath = (pathname: string): string | null => {
+  const match = pathname.match(/^\/servers\/([^/]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+};
+
+export const formatCatalogTransport = (
+  transport: CatalogValidationTransport | CatalogTransport
+): string => {
+  switch (transport) {
+    case 'streamable-http':
+      return 'Streamable HTTP';
+    case 'legacy-sse':
+      return 'Legacy HTTP+SSE';
+    case 'both':
+      return 'Streamable HTTP and legacy SSE';
+    default:
+      return 'Not yet verified';
+  }
+};
+
+export const getEffectiveCatalogTransport = (server: CatalogServer) => {
+  return server.transport === 'unknown' ? server.declaredTransport : server.transport;
+};
+
+const truncateDescription = (value: string, maxLength = 158): string => {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+};
+
+export const getCatalogServerSeo = (server: CatalogServer) => {
+  const transport = formatCatalogTransport(getEffectiveCatalogTransport(server));
+  const auth = server.requiresOAuth ? 'OAuth 2.1' : 'no authentication declared';
+  const canonicalUrl = `${SITE_URL}${getCatalogServerPath(server.id)}`;
+  const description = truncateDescription(
+    `${server.name} MCP server connection report: ${transport}, ${auth}, endpoint details, live-test status, and playground compatibility.`
+  );
+
+  return {
+    title: `${server.name} MCP Server Report | mcptest.io`,
+    description,
+    canonicalUrl,
+    imageUrl: server.logoUrl?.startsWith('http')
+      ? server.logoUrl
+      : `${SITE_URL}${server.logoUrl || '/logo.png'}`,
+    structuredData: {
+      '@context': 'https://schema.org',
+      '@type': 'WebAPI',
+      name: `${server.name} MCP Server`,
+      description: server.description,
+      url: canonicalUrl,
+      endpointUrl: server.url,
+      applicationCategory: server.category,
+      keywords: server.tags.join(', '),
+      documentation: server.homepageUrl || canonicalUrl,
+      additionalProperty: [
+        {
+          '@type': 'PropertyValue',
+          name: 'MCP transport',
+          value: transport,
+        },
+        {
+          '@type': 'PropertyValue',
+          name: 'Authentication',
+          value: server.requiresOAuth ? 'OAuth 2.1' : 'None declared',
+        },
+        {
+          '@type': 'PropertyValue',
+          name: 'Validation status',
+          value: server.status,
+        },
+      ],
+    },
+  };
+};

--- a/src/utils/catalogUtils.ts
+++ b/src/utils/catalogUtils.ts
@@ -49,6 +49,7 @@ export const getCatalogServers = (): CatalogServer[] => {
 
     return {
       ...seed,
+      declaredTransport: seed.transport,
       status: validation?.status ?? 'unknown',
       transport: isValidationTransport(validation?.transport)
         ? validation.transport
@@ -61,6 +62,10 @@ export const getCatalogServers = (): CatalogServer[] => {
       validationMessage: validation?.message,
     };
   });
+};
+
+export const getCatalogServerById = (serverId: string): CatalogServer | undefined => {
+  return getCatalogServers().find((server) => server.id === serverId);
 };
 
 export const filterCatalogServers = (


### PR DESCRIPTION
## Summary

- add dedicated `/servers/:id/` report/spec pages for every catalog server
- show declared versus live-validated transport evidence, authentication requirements, endpoint details, status, references, and Playground actions
- link catalog cards to their server reports and keep the catalog navigation active on detail pages
- generate crawler-readable HTML, canonical/Open Graph/Twitter metadata, `WebAPI` JSON-LD, `sitemap.xml`, and `robots.txt` for all 18 entries during production builds
- add focused SEO/path tests and mark unknown server profile routes `noindex`

## Verification

- `npm test` — 8 tests passed
- `npm run build` — production build passed and generated 18 profile documents plus sitemap/robots assets
- direct static preview of `/servers/context7/` returns its server-specific title, canonical URL, structured data, and readable fallback content before JavaScript
- headless Chromium visual checks passed for catalog, profile, responsive layout, and dark theme

## Notes

Vite still reports the repository's existing large-chunk and mixed static/dynamic import warnings; neither blocks the build.
