### PR TITLE
Expand and validate remote MCP catalog

### DIFF
--- a/cors-proxy-worker/README.md
+++ b/cors-proxy-worker/README.md
@@ -31,6 +31,9 @@ This Cloudflare Worker provides a CORS proxy for authenticated users of the MCP 
 The proxy expects:
 - A `target` query parameter with the URL to proxy
 - An `Authorization` header with a valid Firebase JWT token
+- Optional target credentials in ordinary headers. If the target itself needs
+  `Authorization`, send it as `X-MCP-Authorization`; the worker remaps it only
+  after authenticating the caller and never forwards the Firebase token.
 
 Example:
 ```

--- a/cors-proxy-worker/src/index.test.ts
+++ b/cors-proxy-worker/src/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getTargetRequestHeaders } from './index';
+
+describe('proxy target credential forwarding', () => {
+  it('replaces proxy authorization with the isolated target credential', () => {
+    const headers = getTargetRequestHeaders({
+      Authorization: 'Bearer firebase-jwt',
+      'X-MCP-Authorization': 'Bearer target-token',
+      'x-api-key': 'target-api-key',
+      'CF-Connecting-IP': '192.0.2.1',
+    });
+
+    expect(headers.get('authorization')).toBe('Bearer target-token');
+    expect(headers.get('x-mcp-authorization')).toBeNull();
+    expect(headers.get('x-api-key')).toBe('target-api-key');
+    expect(headers.get('cf-connecting-ip')).toBeNull();
+  });
+
+  it('never forwards Firebase authorization when no target credential exists', () => {
+    const headers = getTargetRequestHeaders({ Authorization: 'Bearer firebase-jwt' });
+
+    expect(headers.get('authorization')).toBeNull();
+  });
+});

--- a/cors-proxy-worker/src/index.test.ts
+++ b/cors-proxy-worker/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getTargetRequestHeaders } from './index';
+import { fetchTargetRequest, getTargetRequestHeaders } from './index';
 
 describe('proxy target credential forwarding', () => {
   it('replaces proxy authorization with the isolated target credential', () => {
@@ -20,5 +20,57 @@ describe('proxy target credential forwarding', () => {
     const headers = getTargetRequestHeaders({ Authorization: 'Bearer firebase-jwt' });
 
     expect(headers.get('authorization')).toBeNull();
+  });
+
+  it('preserves target credentials across same-origin redirects', async () => {
+    const requests: Request[] = [];
+    const fetch = async (request: Request) => {
+      requests.push(request);
+      if (requests.length === 1) {
+        return new Response(null, {
+          status: 307,
+          headers: { Location: '/mcp/' },
+        });
+      }
+      return new Response('connected');
+    };
+
+    const response = await fetchTargetRequest(new Request('https://example.com/mcp', {
+      headers: {
+        Authorization: 'Bearer target-token',
+        'x-api-key': 'target-api-key',
+      },
+      redirect: 'manual',
+    }), fetch);
+
+    expect(await response.text()).toBe('connected');
+    expect(requests.map(({ url }) => url)).toEqual([
+      'https://example.com/mcp',
+      'https://example.com/mcp/',
+    ]);
+    expect(requests[1].headers.get('authorization')).toBe('Bearer target-token');
+    expect(requests[1].headers.get('x-api-key')).toBe('target-api-key');
+  });
+
+  it('rejects cross-origin redirects before forwarding target credentials', async () => {
+    const requests: Request[] = [];
+    const fetch = async (request: Request) => {
+      requests.push(request);
+      return new Response(null, {
+        status: 307,
+        headers: { Location: 'https://attacker.example/mcp' },
+      });
+    };
+
+    await expect(fetchTargetRequest(new Request('https://example.com/mcp', {
+      headers: {
+        Authorization: 'Bearer target-token',
+        'x-api-key': 'target-api-key',
+      },
+      redirect: 'manual',
+    }), fetch)).rejects.toThrow('Cross-origin target redirects are not allowed');
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe('https://example.com/mcp');
   });
 });

--- a/cors-proxy-worker/src/index.ts
+++ b/cors-proxy-worker/src/index.ts
@@ -5,6 +5,9 @@ interface Env {
   FIREBASE_PROJECT_ID: string;
 }
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_TARGET_REDIRECTS = 20;
+
 export function getTargetRequestHeaders(requestHeaders: HeadersInit): Headers {
   const headers = new Headers(requestHeaders);
   const targetAuthorization = headers.get('X-MCP-Authorization');
@@ -20,6 +23,55 @@ export function getTargetRequestHeaders(requestHeaders: HeadersInit): Headers {
   headers.delete('CF-Visitor');
 
   return headers;
+}
+
+export async function fetchTargetRequest(
+  request: Request,
+  fetchImpl: (request: Request) => Promise<Response> = fetch
+): Promise<Response> {
+  let currentRequest = request;
+
+  for (let redirectCount = 0; redirectCount <= MAX_TARGET_REDIRECTS; redirectCount += 1) {
+    const response = await fetchImpl(currentRequest.clone());
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+    const location = response.headers.get('Location');
+    if (!location) return response;
+    if (redirectCount === MAX_TARGET_REDIRECTS) {
+      throw new Error('Target exceeded the maximum redirect count');
+    }
+
+    const redirectUrl = new URL(location, response.url || currentRequest.url);
+    const currentUrl = new URL(currentRequest.url);
+    if (redirectUrl.origin !== currentUrl.origin) {
+      await response.body?.cancel().catch(() => {});
+      throw new Error('Cross-origin target redirects are not allowed');
+    }
+
+    const switchToGet = response.status === 303
+      ? currentRequest.method !== 'HEAD'
+      : (response.status === 301 || response.status === 302) && currentRequest.method === 'POST';
+
+    if (switchToGet) {
+      const headers = new Headers(currentRequest.headers);
+      headers.delete('Content-Encoding');
+      headers.delete('Content-Language');
+      headers.delete('Content-Length');
+      headers.delete('Content-Location');
+      headers.delete('Content-Type');
+      currentRequest = new Request(redirectUrl, {
+        method: 'GET',
+        headers,
+        redirect: 'manual',
+      });
+    } else {
+      currentRequest = new Request(redirectUrl, currentRequest);
+    }
+
+    await response.body?.cancel().catch(() => {});
+  }
+
+  throw new Error('Target exceeded the maximum redirect count');
 }
 
 // Firebase public keys URL
@@ -111,11 +163,11 @@ export default {
         method: request.method,
         headers: headers,
         body: request.body,
-        redirect: 'follow',
+        redirect: 'manual',
       });
 
       // Make the actual request to the target server
-      const response = await fetch(newRequest);
+      const response = await fetchTargetRequest(newRequest);
 
       // Create a mutable copy of the response with CORS headers
       const mutableResponse = new Response(response.body, response);

--- a/cors-proxy-worker/src/index.ts
+++ b/cors-proxy-worker/src/index.ts
@@ -5,6 +5,23 @@ interface Env {
   FIREBASE_PROJECT_ID: string;
 }
 
+export function getTargetRequestHeaders(requestHeaders: HeadersInit): Headers {
+  const headers = new Headers(requestHeaders);
+  const targetAuthorization = headers.get('X-MCP-Authorization');
+
+  headers.delete('Authorization');
+  headers.delete('X-MCP-Authorization');
+  if (targetAuthorization) {
+    headers.set('Authorization', targetAuthorization);
+  }
+  headers.delete('CF-Connecting-IP');
+  headers.delete('CF-IPCountry');
+  headers.delete('CF-RAY');
+  headers.delete('CF-Visitor');
+
+  return headers;
+}
+
 // Firebase public keys URL
 const FIREBASE_PUBLIC_KEYS_URL = 'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 
@@ -88,14 +105,7 @@ export default {
       }
 
       // Create a new request to the target URL
-      const headers = new Headers(request.headers);
-      // Remove the Authorization header to avoid forwarding it to the target
-      headers.delete('Authorization');
-      // Remove CF-specific headers
-      headers.delete('CF-Connecting-IP');
-      headers.delete('CF-IPCountry');
-      headers.delete('CF-RAY');
-      headers.delete('CF-Visitor');
+      const headers = getTargetRequestHeaders(request.headers);
 
       const newRequest = new Request(target.toString(), {
         method: request.method,
@@ -254,17 +264,26 @@ async function getFirebasePublicKeys(): Promise<Record<string, string>> {
     throw new Error('Failed to fetch Firebase public keys');
   }
   
-  const keys = await response.json();
+  const keys: unknown = await response.json();
+  if (
+    !keys ||
+    typeof keys !== 'object' ||
+    Array.isArray(keys) ||
+    !Object.values(keys).every((value) => typeof value === 'string')
+  ) {
+    throw new Error('Firebase public-key response had an invalid shape');
+  }
+  const publicKeys = keys as Record<string, string>;
   
   // Cache the keys with expiry from cache-control header
   const cacheControl = response.headers.get('cache-control');
   const maxAgeMatch = cacheControl?.match(/max-age=(\d+)/);
   const maxAge = maxAgeMatch ? parseInt(maxAgeMatch[1]) : 3600; // Default 1 hour
   
-  publicKeysCache = keys;
+  publicKeysCache = publicKeys;
   publicKeysCacheExpiry = now + (maxAge * 1000);
   
-  return keys;
+  return publicKeys;
 }
 
 /**

--- a/scripts/generate-seo-pages.js
+++ b/scripts/generate-seo-pages.js
@@ -42,6 +42,22 @@ function isValidationTransport(transport) {
   );
 }
 
+function authenticationLabel(authType) {
+  if (authType === 'oauth') return 'OAuth 2.1';
+  if (authType === 'bearer-token') return 'Bearer token';
+  if (authType === 'api-key') return 'API key';
+  if (authType === 'none') return 'No authentication';
+  return 'Not yet verified';
+}
+
+function protocolLabel(era, version) {
+  const revision = version ? ` · ${version}` : '';
+  if (era === 'stateless') return `Stateless MCP${revision}`;
+  if (era === 'stateful') return `Stateful MCP${revision}`;
+  if (era === 'legacy') return `Legacy SSE MCP${revision}`;
+  return 'Not yet negotiated';
+}
+
 function mergeCatalogServers(seeds, validationResults) {
   const validationByServerId = new Map(
     validationResults.map((result) => [result.serverId, result])
@@ -49,19 +65,25 @@ function mergeCatalogServers(seeds, validationResults) {
 
   return seeds.map((seed) => {
     const validation = validationByServerId.get(seed.id);
+    const declaredAuthType = seed.authType || (seed.requiresOAuth ? 'oauth' : 'none');
+    const authType = declaredAuthType === 'api-key' || declaredAuthType === 'bearer-token'
+      ? declaredAuthType
+      : validation?.authType || declaredAuthType;
 
     return {
       ...seed,
       declaredTransport: seed.transport,
-      declaredRequiresOAuth: seed.requiresOAuth,
+      declaredAuthType,
       status: validation?.status ?? 'unknown',
       transport: isValidationTransport(validation?.transport)
         ? validation.transport
         : 'unknown',
-      requiresOAuth:
-        typeof validation?.requiresOAuth === 'boolean'
-          ? validation.requiresOAuth
-          : seed.requiresOAuth,
+      authType,
+      requiresOAuth: authType === 'oauth',
+      protocolEra: validation?.protocolEra || 'unknown',
+      protocolVersion: validation?.protocolVersion,
+      validatedUrl: validation?.validatedUrl,
+      authorizationServers: validation?.authorizationServers,
       checkedAt: validation?.checkedAt,
       validationMessage: validation?.message,
     };
@@ -87,13 +109,9 @@ function validationDetail(server) {
   return 'Validation pending — no automated probe result is stored yet.';
 }
 
-function authenticationLabel(requiresOAuth) {
-  return requiresOAuth ? 'OAuth 2.1' : 'None';
-}
-
 function detectedAuthenticationLabel(server) {
   if (!server.checkedAt) return 'Validation pending — not yet checked';
-  return server.requiresOAuth ? 'OAuth 2.1 detected or required' : 'No OAuth requirement detected';
+  return `${authenticationLabel(server.authType)} detected or retained from publisher evidence`;
 }
 
 function playgroundPath(server) {
@@ -101,7 +119,7 @@ function playgroundPath(server) {
     ? server.declaredTransport
     : server.transport;
   const transportMethod = transport === 'legacy-sse' ? 'sse' : 'mcp';
-  return `/server/${server.url}/${transportMethod}`;
+  return `/server/${server.validatedUrl || server.url}/${transportMethod}`;
 }
 
 function truncate(value, maxLength = 158) {
@@ -142,7 +160,16 @@ function renderServerFallback(server) {
   const sourceLink = server.sourceUrl
     ? `<a href="${escapeHtml(server.sourceUrl)}">Source repository</a>`
     : '';
-  const references = [homepageLink, sourceLink].filter(Boolean).join(' · ');
+  const registryLink = server.registryUrl
+    ? `<a href="${escapeHtml(server.registryUrl)}">Official MCP Registry record</a>`
+    : '';
+  const references = [homepageLink, sourceLink, registryLink].filter(Boolean).join(' · ');
+  const requiredHeaders = (server.requiredHeaders || []).map((header) => (
+    `      <div><dt>Required header</dt><dd><code>${escapeHtml(header.name)}</code>${header.description ? ` — ${escapeHtml(header.description)}` : ''}</dd></div>`
+  ));
+  const authorizationServers = (server.authorizationServers || []).map((issuer) => (
+    `      <div><dt>Authorization server</dt><dd><code>${escapeHtml(issuer)}</code></dd></div>`
+  ));
 
   return [
     `<article class="server-profile seo-server-fallback" data-server-id="${escapeHtml(server.id)}">`,
@@ -158,10 +185,16 @@ function renderServerFallback(server) {
     '    <h2>Connection specification</h2>',
     '    <dl class="server-spec-list">',
     `      <div><dt>Remote endpoint</dt><dd><code>${escapeHtml(server.url)}</code></dd></div>`,
+    ...(server.validatedUrl && server.validatedUrl !== server.url
+      ? [`      <div><dt>Live-validated endpoint</dt><dd><code>${escapeHtml(server.validatedUrl)}</code></dd></div>`]
+      : []),
     `      <div><dt>Declared MCP transport</dt><dd>${escapeHtml(transportLabel(server.declaredTransport))}</dd></div>`,
     `      <div><dt>Live-validated MCP transport</dt><dd>${escapeHtml(transportLabel(server.transport))} — ${escapeHtml(validationTransportNote(server))}</dd></div>`,
-    `      <div><dt>Declared authentication</dt><dd>${escapeHtml(authenticationLabel(server.declaredRequiresOAuth))}</dd></div>`,
+    `      <div><dt>Declared authentication</dt><dd>${escapeHtml(authenticationLabel(server.declaredAuthType))}</dd></div>`,
     `      <div><dt>Detected authentication</dt><dd>${escapeHtml(detectedAuthenticationLabel(server))}</dd></div>`,
+    `      <div><dt>Protocol lifecycle</dt><dd>${escapeHtml(protocolLabel(server.protocolEra, server.protocolVersion))}</dd></div>`,
+    ...requiredHeaders,
+    ...authorizationServers,
     `      <div><dt>Category</dt><dd>${escapeHtml(server.category)}</dd></div>`,
     '    </dl>',
     `    <p>${references}</p>`,
@@ -183,17 +216,17 @@ function renderServerHtml(indexHtml, server) {
   server = server.declaredTransport
     ? {
         ...server,
-        declaredRequiresOAuth:
-          typeof server.declaredRequiresOAuth === 'boolean'
-            ? server.declaredRequiresOAuth
-            : server.requiresOAuth,
+        declaredAuthType:
+          server.declaredAuthType || server.authType || (server.requiresOAuth ? 'oauth' : 'none'),
+        authType: server.authType || (server.requiresOAuth ? 'oauth' : 'none'),
+        protocolEra: server.protocolEra || 'unknown',
       }
     : mergeCatalogServers([server], [])[0];
 
   const canonicalUrl = `${SITE_URL}${serverPath(server.id)}`;
   const title = `${server.name} MCP Server Report | mcptest.io`;
   const description = truncate(
-    `${server.name} MCP server connection report: ${transportLabel(server.declaredTransport)} declared, ${server.declaredRequiresOAuth ? 'OAuth 2.1' : 'no authentication declared'}, endpoint details, live-test status, and playground compatibility.`
+    `${server.name} MCP server connection report: ${transportLabel(server.declaredTransport)}, ${protocolLabel(server.protocolEra, server.protocolVersion)}, ${authenticationLabel(server.authType)}, endpoint details, and live-test status.`
   );
   const imageUrl = server.logoUrl
     ? (server.logoUrl.startsWith('http') ? server.logoUrl : `${SITE_URL}${server.logoUrl}`)
@@ -211,8 +244,9 @@ function renderServerHtml(indexHtml, server) {
     additionalProperty: [
       { '@type': 'PropertyValue', name: 'Declared MCP transport', value: transportLabel(server.declaredTransport) },
       { '@type': 'PropertyValue', name: 'Live-validated MCP transport', value: transportLabel(server.transport) },
-      { '@type': 'PropertyValue', name: 'Declared authentication', value: authenticationLabel(server.declaredRequiresOAuth) },
+      { '@type': 'PropertyValue', name: 'Declared authentication', value: authenticationLabel(server.declaredAuthType) },
       { '@type': 'PropertyValue', name: 'Detected authentication', value: detectedAuthenticationLabel(server) },
+      { '@type': 'PropertyValue', name: 'MCP protocol lifecycle', value: protocolLabel(server.protocolEra, server.protocolVersion) },
       { '@type': 'PropertyValue', name: 'Validation status', value: validationStatusLabel(server) },
       { '@type': 'PropertyValue', name: 'Validation checked at', value: server.checkedAt || 'Not yet validated' },
       { '@type': 'PropertyValue', name: 'Validation detail', value: validationDetail(server) },

--- a/scripts/generate-seo-pages.test.js
+++ b/scripts/generate-seo-pages.test.js
@@ -16,6 +16,9 @@ function catalogServer(url, declaredTransport) {
     declaredTransport,
     transport: declaredTransport,
     requiresOAuth: false,
+    declaredAuthType: 'none',
+    authType: 'none',
+    protocolEra: 'unknown',
     status: 'online',
   };
 }

--- a/scripts/validate-catalog.js
+++ b/scripts/validate-catalog.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   Client,
+  SSEClientTransport,
   StreamableHTTPClientTransport,
   discoverOAuthProtectedResourceMetadata,
   extractWWWAuthenticateParams,
@@ -189,7 +190,7 @@ async function probeStreamableEndpoint(
       return {
         ...endpoint,
         reachable: true,
-        alive: true,
+        alive: false,
         authChallenge: true,
         protocolEra: 'unknown',
         statusCode: authResponse.status,
@@ -217,48 +218,90 @@ async function probeSseEndpoint(
   endpoint,
   { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}
 ) {
-  const result = await fetchWithTimeout(
-    endpoint.url,
-    { method: 'GET', headers: { Accept: 'text/event-stream' } },
-    fetchImpl,
-    timeoutMs
-  );
+  const responses = [];
+  let resourceMetadataUrl;
+  const observingFetch = async (input, init) => {
+    const result = await fetchWithTimeout(input, init, fetchImpl, timeoutMs);
+    if (!result.ok) {
+      const error = new Error(result.message);
+      error.code = result.errorCode === 'timeout' ? 'REQUEST_TIMEOUT' : result.errorCode;
+      throw error;
+    }
 
-  if (!result.ok) {
+    const { response } = result;
+    responses.push({
+      status: response.status,
+      contentType: response.headers.get('content-type') || '',
+    });
+    if (isAuthStatus(response.status)) {
+      resourceMetadataUrl = extractWWWAuthenticateParams(response).resourceMetadataUrl?.toString();
+    }
+    return response;
+  };
+  const client = new Client(
+    { name: CLIENT_NAME, version: '2.0.0' },
+    { versionNegotiation: { mode: 'legacy' } }
+  );
+  const transport = new SSEClientTransport(new URL(endpoint.url), {
+    fetch: observingFetch,
+    eventSourceInit: { fetch: observingFetch },
+  });
+  let connectionTimeout;
+
+  try {
+    await Promise.race([
+      client.connect(transport, { timeout: timeoutMs }),
+      new Promise((_, reject) => {
+        connectionTimeout = setTimeout(() => {
+          const error = new Error(`Legacy SSE connection timed out after ${timeoutMs}ms`);
+          error.code = 'REQUEST_TIMEOUT';
+          reject(error);
+        }, timeoutMs);
+      }),
+    ]);
+
+    const protocolVersion = client.getNegotiatedProtocolVersion();
     return {
       ...endpoint,
-      reachable: false,
+      reachable: true,
+      alive: true,
+      authChallenge: false,
+      protocolEra: 'legacy',
+      protocolVersion,
+      statusCode: responses.find(({ status }) => status >= 200 && status < 300)?.status,
+      message: `Negotiated legacy MCP${protocolVersion ? ` ${protocolVersion}` : ''} at ${endpoint.url}`,
+    };
+  } catch (error) {
+    const authResponse = responses.find(({ status }) => isAuthStatus(status));
+    const lastResponse = responses.at(-1);
+
+    if (authResponse) {
+      return {
+        ...endpoint,
+        reachable: true,
+        alive: false,
+        authChallenge: true,
+        protocolEra: 'unknown',
+        statusCode: authResponse.status,
+        resourceMetadataUrl,
+        message: `Authentication challenge at ${endpoint.url} returned HTTP ${authResponse.status}`,
+      };
+    }
+
+    return {
+      ...endpoint,
+      reachable: Boolean(lastResponse),
       alive: false,
       authChallenge: false,
       protocolEra: 'unknown',
-      errorCode: result.errorCode,
-      message: result.message,
+      statusCode: lastResponse?.status,
+      errorCode: lastResponse ? 'protocol_error' : abortErrorCode(error),
+      message: error && error.message ? error.message : String(error),
     };
+  } finally {
+    if (connectionTimeout) clearTimeout(connectionTimeout);
+    await client.close().catch(() => {});
   }
-
-  const { response } = result;
-  const resourceMetadataUrl = isAuthStatus(response.status)
-    ? extractWWWAuthenticateParams(response).resourceMetadataUrl?.toString()
-    : undefined;
-  const isEventStream = (response.headers.get('content-type') || '')
-    .toLowerCase()
-    .includes('text/event-stream');
-  const authChallenge = isAuthStatus(response.status);
-  await response.body?.cancel().catch(() => {});
-
-  return {
-    ...endpoint,
-    reachable: true,
-    alive: authChallenge || (response.ok && isEventStream),
-    authChallenge,
-    protocolEra: response.ok && isEventStream ? 'legacy' : 'unknown',
-    statusCode: response.status,
-    resourceMetadataUrl,
-    errorCode: authChallenge || (response.ok && isEventStream) ? undefined : 'protocol_error',
-    message: authChallenge
-      ? `Authentication challenge at ${endpoint.url} returned HTTP ${response.status}`
-      : `SSE probe at ${endpoint.url} returned HTTP ${response.status} (${response.headers.get('content-type') || 'no content type'})`,
-  };
 }
 
 async function probeEndpoint(endpoint, options) {
@@ -315,7 +358,7 @@ function detectedTransport(probes) {
 }
 
 function detectedStatus(probes) {
-  if (probes.some((probe) => probe.alive)) return 'online';
+  if (probes.some((probe) => probe.alive || probe.authChallenge)) return 'online';
   if (probes.some((probe) => probe.reachable)) return 'unknown';
   return 'offline';
 }
@@ -343,9 +386,14 @@ function selectProtocolProbe(probes) {
 }
 
 function resultMessage(status, transport, probes, authType) {
-  const successfulProbe = probes.find((probe) => probe.alive);
+  const successfulProbe = probes.find((probe) => probe.alive && !probe.authChallenge);
   if (successfulProbe) {
     return `${successfulProbe.message}; detected transport ${transport}; authentication ${authType}`;
+  }
+
+  const challengeProbe = probes.find((probe) => probe.authChallenge);
+  if (challengeProbe) {
+    return `${challengeProbe.message}; endpoint was reachable but did not complete an MCP probe; authentication ${authType}`;
   }
 
   const reachableProbe = probes.find((probe) => probe.reachable);
@@ -376,16 +424,17 @@ async function validateSeed(
     if (validatedTransports.has(endpoint.transport)) continue;
     const probe = await probeEndpoint(endpoint, { fetchImpl, timeoutMs });
     probes.push(probe);
-    if (probe.alive) validatedTransports.add(endpoint.transport);
+    if (probe.alive && !probe.authChallenge) validatedTransports.add(endpoint.transport);
   }
 
   const status = detectedStatus(probes);
   const transport = detectedTransport(probes);
   const protocolProbe = selectProtocolProbe(probes);
-  const successfulProbe = probes.find((probe) => probe.alive);
+  const successfulProbe = probes.find((probe) => probe.alive && !probe.authChallenge);
+  const challengeProbe = probes.find((probe) => probe.authChallenge);
   const authProbe = probes.find((probe) => probe.resourceMetadataUrl);
   const authorizationEvidence = await discoverAuthorizationEvidence(
-    successfulProbe?.url || seed.url,
+    successfulProbe?.url || challengeProbe?.url || seed.url,
     {
       protocolVersion: protocolProbe?.protocolVersion,
       resourceMetadataUrl: authProbe?.resourceMetadataUrl,
@@ -406,7 +455,9 @@ async function validateSeed(
     message: resultMessage(status, transport, probes, authType),
   };
 
-  if (successfulProbe?.url) result.validatedUrl = successfulProbe.url;
+  if (successfulProbe?.url || challengeProbe?.url) {
+    result.validatedUrl = successfulProbe?.url || challengeProbe.url;
+  }
   if (protocolProbe?.protocolVersion) result.protocolVersion = protocolProbe.protocolVersion;
   if (authorizationEvidence.authorizationServers.length > 0) {
     result.authorizationServers = authorizationEvidence.authorizationServers;

--- a/scripts/validate-catalog.js
+++ b/scripts/validate-catalog.js
@@ -2,18 +2,23 @@
 
 const fs = require('fs');
 const path = require('path');
+const {
+  Client,
+  StreamableHTTPClientTransport,
+  discoverOAuthProtectedResourceMetadata,
+  extractWWWAuthenticateParams,
+} = require('@modelcontextprotocol/client');
 
-const REQUEST_TIMEOUT_MS = 15000;
+const REQUEST_TIMEOUT_MS = 12_000;
 const CONCURRENCY = 4;
 const CLIENT_NAME = 'mcptest-catalog-validator';
-const PROTOCOL_VERSION = '2025-06-18';
 
 const catalogPath = path.join(__dirname, '..', 'src', 'data', 'serverCatalog.json');
 const outputPath = path.join(__dirname, '..', 'src', 'data', 'catalogValidation.json');
 
-function requireFetch() {
+function requireRuntime() {
   if (typeof fetch !== 'function' || typeof AbortController !== 'function') {
-    console.error('Catalog validation requires Node 18+ for global fetch and AbortController.');
+    console.error('Catalog validation requires Node 20+ for fetch and AbortController.');
     process.exitCode = 1;
     return false;
   }
@@ -21,103 +26,98 @@ function requireFetch() {
   return true;
 }
 
-function uniq(values) {
-  return [...new Set(values)];
-}
-
-function stripTrailingSlash(value) {
-  return value.replace(/\/+$/, '');
-}
-
-function withTrailingSlash(value) {
-  return `${stripTrailingSlash(value)}/`;
-}
-
 function toUrl(value) {
   try {
     return new URL(value);
-  } catch (error) {
+  } catch {
     return null;
   }
 }
 
-function endpointRoot(seedUrl) {
-  const url = toUrl(seedUrl);
-  if (!url) {
-    return null;
+function slashVariants(value) {
+  const url = toUrl(value);
+  if (!url) return [];
+
+  const withoutSlash = new URL(url);
+  withoutSlash.pathname = withoutSlash.pathname.replace(/\/+$/, '') || '/';
+  const withSlash = new URL(withoutSlash);
+  withSlash.pathname = `${withoutSlash.pathname.replace(/\/+$/, '')}/`;
+
+  return [...new Set([withoutSlash.toString(), withSlash.toString()])];
+}
+
+function siblingEndpoint(value, fromSegment, toSegment) {
+  const url = toUrl(value);
+  if (!url) return null;
+
+  const pathWithoutSlash = url.pathname.replace(/\/+$/, '');
+  if (!pathWithoutSlash.endsWith(`/${fromSegment}`)) return null;
+
+  url.pathname = `${pathWithoutSlash.slice(0, -(fromSegment.length + 1))}/${toSegment}`;
+  return url.toString();
+}
+
+/**
+ * Preserve a catalog's exact endpoint first. Only synthesize conventional
+ * /mcp and /sse candidates for origin roots or known terminal transport paths.
+ */
+function endpointVariants(seed) {
+  const seedUrl = toUrl(seed.url);
+  if (!seedUrl) return [];
+
+  const candidates = [];
+  const seen = new Set();
+  const add = (url, transport) => {
+    for (const candidateUrl of slashVariants(url)) {
+      const key = `${transport}:${candidateUrl}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push({ url: candidateUrl, transport });
+    }
+  };
+
+  add(seedUrl.toString(), seed.transport);
+
+  const normalizedPath = seedUrl.pathname.replace(/\/+$/, '');
+  if (!normalizedPath) {
+    const httpUrl = new URL(seedUrl);
+    httpUrl.pathname = '/mcp';
+    add(httpUrl.toString(), 'streamable-http');
+
+    const sseUrl = new URL(seedUrl);
+    sseUrl.pathname = '/sse';
+    add(sseUrl.toString(), 'legacy-sse');
+  } else if (normalizedPath.endsWith('/mcp')) {
+    if (seed.transport === 'legacy-sse') add(seedUrl.toString(), 'streamable-http');
+    const sseUrl = siblingEndpoint(seedUrl.toString(), 'mcp', 'sse');
+    if (sseUrl) add(sseUrl, 'legacy-sse');
+  } else if (normalizedPath.endsWith('/sse')) {
+    if (seed.transport === 'streamable-http') add(seedUrl.toString(), 'legacy-sse');
+    const httpUrl = siblingEndpoint(seedUrl.toString(), 'sse', 'mcp');
+    if (httpUrl) add(httpUrl, 'streamable-http');
+  } else {
+    add(seedUrl.toString(), seed.transport === 'legacy-sse' ? 'streamable-http' : 'legacy-sse');
   }
 
-  const pathWithoutSlash = stripTrailingSlash(url.pathname);
-  if (pathWithoutSlash.endsWith('/mcp') || pathWithoutSlash.endsWith('/sse')) {
-    url.pathname = pathWithoutSlash.replace(/\/(mcp|sse)$/, '') || '/';
-    url.search = '';
-    url.hash = '';
-    return stripTrailingSlash(url.toString());
-  }
-
-  url.search = '';
-  url.hash = '';
-  return stripTrailingSlash(url.toString());
-}
-
-function endpointVariants(seedUrl) {
-  const root = endpointRoot(seedUrl);
-  const seedWithoutSlash = stripTrailingSlash(seedUrl);
-  const endpoints = [];
-
-  if (root) {
-    endpoints.push(
-      { url: `${root}/mcp`, transport: 'streamable-http', method: 'POST' },
-      { url: `${root}/sse`, transport: 'legacy-sse', method: 'GET' }
-    );
-  }
-
-  endpoints.push(
-    { url: seedWithoutSlash, transport: 'streamable-http', method: 'POST' },
-    { url: seedWithoutSlash, transport: 'legacy-sse', method: 'GET' }
-  );
-
-  return uniq(endpoints.flatMap((endpoint) => [
-    { ...endpoint, url: stripTrailingSlash(endpoint.url) },
-    { ...endpoint, url: withTrailingSlash(endpoint.url) },
-  ]).map((endpoint) => JSON.stringify(endpoint))).map((endpoint) => JSON.parse(endpoint));
-}
-
-function originFromUrl(seedUrl) {
-  const url = toUrl(seedUrl);
-  return url ? url.origin : null;
-}
-
-function isAuthStatus(status) {
-  return status === 401 || status === 403;
-}
-
-function isAliveStatus(status) {
-  return status === 200 || isAuthStatus(status);
+  return candidates;
 }
 
 function abortErrorCode(error) {
-  if (error && error.name === 'AbortError') {
-    return 'timeout';
-  }
-
-  return 'network_error';
+  return error && (error.name === 'AbortError' || error.code === 'REQUEST_TIMEOUT')
+    ? 'timeout'
+    : 'network_error';
 }
 
-async function fetchWithTimeout(url, options = {}) {
+async function fetchWithTimeout(url, options = {}, fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS) {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const signals = [controller.signal, options.signal].filter(Boolean);
+  const signal = signals.length > 1 && typeof AbortSignal.any === 'function'
+    ? AbortSignal.any(signals)
+    : controller.signal;
 
   try {
-    const response = await fetch(url, {
-      ...options,
-      signal: controller.signal,
-    });
-
-    if (response.body && typeof response.body.cancel === 'function') {
-      response.body.cancel().catch(() => {});
-    }
-
+    const response = await fetchImpl(url, { ...options, signal });
     return { ok: true, response };
   } catch (error) {
     return {
@@ -130,121 +130,227 @@ async function fetchWithTimeout(url, options = {}) {
   }
 }
 
-async function probeEndpoint(endpoint) {
-  const headers = endpoint.method === 'POST'
-    ? {
-        'accept': 'application/json, text/event-stream',
-        'content-type': 'application/json',
-      }
-    : {
-        'accept': 'text/event-stream',
-      };
+function isAuthStatus(status) {
+  return status === 401 || status === 403;
+}
 
-  const body = endpoint.method === 'POST'
-    ? JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: PROTOCOL_VERSION,
-          capabilities: {},
-          clientInfo: {
-            name: CLIENT_NAME,
-            version: '1.0.0',
-          },
-        },
-      })
-    : undefined;
+async function probeStreamableEndpoint(
+  endpoint,
+  { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}
+) {
+  const responses = [];
+  let resourceMetadataUrl;
+  const observingFetch = async (input, init) => {
+    const response = await fetchImpl(input, init);
+    responses.push({
+      status: response.status,
+      contentType: response.headers.get('content-type') || '',
+    });
 
-  const result = await fetchWithTimeout(endpoint.url, {
-    method: endpoint.method,
-    headers,
-    body,
+    if (isAuthStatus(response.status)) {
+      resourceMetadataUrl = extractWWWAuthenticateParams(response).resourceMetadataUrl?.toString();
+    }
+
+    return response;
+  };
+  const client = new Client(
+    { name: CLIENT_NAME, version: '2.0.0' },
+    {
+      versionNegotiation: {
+        mode: 'auto',
+        probe: { timeoutMs },
+      },
+    }
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(endpoint.url), {
+    fetch: observingFetch,
   });
+
+  try {
+    await client.connect(transport, { timeout: timeoutMs });
+    const era = client.getProtocolEra();
+    const protocolVersion = client.getNegotiatedProtocolVersion();
+
+    return {
+      ...endpoint,
+      reachable: true,
+      alive: true,
+      authChallenge: false,
+      protocolEra: era === 'modern' ? 'stateless' : 'stateful',
+      protocolVersion,
+      statusCode: responses.find(({ status }) => status >= 200 && status < 300)?.status,
+      message: `Negotiated ${era === 'modern' ? 'stateless' : 'stateful'} MCP${protocolVersion ? ` ${protocolVersion}` : ''} at ${endpoint.url}`,
+    };
+  } catch (error) {
+    const authResponse = responses.find(({ status }) => isAuthStatus(status));
+    const lastResponse = responses.at(-1);
+
+    if (authResponse) {
+      return {
+        ...endpoint,
+        reachable: true,
+        alive: true,
+        authChallenge: true,
+        protocolEra: 'unknown',
+        statusCode: authResponse.status,
+        resourceMetadataUrl,
+        message: `Authentication challenge at ${endpoint.url} returned HTTP ${authResponse.status}`,
+      };
+    }
+
+    return {
+      ...endpoint,
+      reachable: Boolean(lastResponse),
+      alive: false,
+      authChallenge: false,
+      protocolEra: 'unknown',
+      statusCode: lastResponse?.status,
+      errorCode: lastResponse ? 'protocol_error' : abortErrorCode(error),
+      message: error && error.message ? error.message : String(error),
+    };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function probeSseEndpoint(
+  endpoint,
+  { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}
+) {
+  const result = await fetchWithTimeout(
+    endpoint.url,
+    { method: 'GET', headers: { Accept: 'text/event-stream' } },
+    fetchImpl,
+    timeoutMs
+  );
 
   if (!result.ok) {
     return {
       ...endpoint,
       reachable: false,
       alive: false,
-      requiresOAuth: false,
+      authChallenge: false,
+      protocolEra: 'unknown',
       errorCode: result.errorCode,
       message: result.message,
     };
   }
 
   const { response } = result;
+  const resourceMetadataUrl = isAuthStatus(response.status)
+    ? extractWWWAuthenticateParams(response).resourceMetadataUrl?.toString()
+    : undefined;
+  const isEventStream = (response.headers.get('content-type') || '')
+    .toLowerCase()
+    .includes('text/event-stream');
+  const authChallenge = isAuthStatus(response.status);
+  await response.body?.cancel().catch(() => {});
 
   return {
     ...endpoint,
     reachable: true,
-    alive: isAliveStatus(response.status),
-    requiresOAuth: isAuthStatus(response.status),
+    alive: authChallenge || (response.ok && isEventStream),
+    authChallenge,
+    protocolEra: response.ok && isEventStream ? 'legacy' : 'unknown',
     statusCode: response.status,
-    message: `${endpoint.method} ${endpoint.url} returned ${response.status}`,
+    resourceMetadataUrl,
+    errorCode: authChallenge || (response.ok && isEventStream) ? undefined : 'protocol_error',
+    message: authChallenge
+      ? `Authentication challenge at ${endpoint.url} returned HTTP ${response.status}`
+      : `SSE probe at ${endpoint.url} returned HTTP ${response.status} (${response.headers.get('content-type') || 'no content type'})`,
   };
 }
 
-async function hasOAuthMetadata(origin) {
-  if (!origin) {
-    return false;
+async function probeEndpoint(endpoint, options) {
+  return endpoint.transport === 'legacy-sse'
+    ? probeSseEndpoint(endpoint, options)
+    : probeStreamableEndpoint(endpoint, options);
+}
+
+async function discoverAuthorizationEvidence(
+  serverUrl,
+  { protocolVersion, resourceMetadataUrl, fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}
+) {
+  const metadataFetch = async (input, init) => {
+    const result = await fetchWithTimeout(input, init, fetchImpl, timeoutMs);
+    if (!result.ok) {
+      const error = new Error(result.message);
+      error.code = result.errorCode;
+      throw error;
+    }
+    return result.response;
+  };
+
+  try {
+    const metadata = await discoverOAuthProtectedResourceMetadata(
+      serverUrl,
+      { protocolVersion, resourceMetadataUrl },
+      metadataFetch
+    );
+    const authorizationServers = Array.isArray(metadata?.authorization_servers)
+      ? metadata.authorization_servers
+      : [];
+
+    return {
+      oauthMetadata: Boolean(metadata && authorizationServers.length > 0),
+      authorizationServers,
+    };
+  } catch {
+    return { oauthMetadata: false, authorizationServers: [] };
   }
-
-  const metadataUrls = [
-    `${origin}/.well-known/oauth-protected-resource`,
-    `${origin}/.well-known/oauth-authorization-server`,
-  ];
-
-  const results = await Promise.all(metadataUrls.map((url) => fetchWithTimeout(url, {
-    method: 'GET',
-    headers: {
-      'accept': 'application/json',
-    },
-  })));
-
-  return results.some((result) => result.ok && result.response.status === 200);
 }
 
 function detectedTransport(probes) {
-  const hasStreamableHttp = probes.some((probe) => probe.transport === 'streamable-http' && probe.alive);
-  const hasLegacySse = probes.some((probe) => probe.transport === 'legacy-sse' && probe.alive);
+  const hasStreamableHttp = probes.some(
+    (probe) => probe.transport === 'streamable-http' && probe.alive && !probe.authChallenge
+  );
+  const hasLegacySse = probes.some(
+    (probe) => probe.transport === 'legacy-sse' && probe.alive && !probe.authChallenge
+  );
 
-  if (hasStreamableHttp && hasLegacySse) {
-    return 'both';
-  }
-
-  if (hasStreamableHttp) {
-    return 'streamable-http';
-  }
-
-  if (hasLegacySse) {
-    return 'legacy-sse';
-  }
-
+  if (hasStreamableHttp && hasLegacySse) return 'both';
+  if (hasStreamableHttp) return 'streamable-http';
+  if (hasLegacySse) return 'legacy-sse';
   return 'unknown';
 }
 
 function detectedStatus(probes) {
-  if (probes.some((probe) => probe.alive)) {
-    return 'online';
-  }
-
-  if (probes.some((probe) => probe.reachable)) {
-    return 'unknown';
-  }
-
+  if (probes.some((probe) => probe.alive)) return 'online';
+  if (probes.some((probe) => probe.reachable)) return 'unknown';
   return 'offline';
 }
 
-function resultMessage(status, transport, probes) {
+function declaredAuthType(seed) {
+  if (seed.authType) return seed.authType;
+  return seed.requiresOAuth ? 'oauth' : 'none';
+}
+
+function detectedAuthType(seed, probes, authorizationEvidence) {
+  const declared = declaredAuthType(seed);
+  if (declared === 'api-key' || declared === 'bearer-token') return declared;
+  if (probes.some((probe) => probe.alive && !probe.authChallenge)) return declared;
+  if (authorizationEvidence.oauthMetadata) return 'oauth';
+  if (probes.some((probe) => probe.authChallenge)) {
+    return declared === 'none' ? 'bearer-token' : declared;
+  }
+  return declared;
+}
+
+function selectProtocolProbe(probes) {
+  return probes.find(
+    (probe) => probe.alive && probe.transport === 'streamable-http' && probe.protocolEra !== 'unknown'
+  ) || probes.find((probe) => probe.alive && probe.protocolEra !== 'unknown');
+}
+
+function resultMessage(status, transport, probes, authType) {
   const successfulProbe = probes.find((probe) => probe.alive);
   if (successfulProbe) {
-    return `${successfulProbe.message}; detected transport ${transport}`;
+    return `${successfulProbe.message}; detected transport ${transport}; authentication ${authType}`;
   }
 
   const reachableProbe = probes.find((probe) => probe.reachable);
   if (reachableProbe) {
-    return `${reachableProbe.message}; response was reachable but unexpected`;
+    return `${reachableProbe.message}; endpoint was reachable but did not complete an MCP probe`;
   }
 
   const failedProbe = probes[0];
@@ -254,43 +360,58 @@ function resultMessage(status, transport, probes) {
 }
 
 function errorCodeForStatus(status, probes) {
-  if (status === 'online') {
-    return undefined;
-  }
-
-  if (status === 'unknown') {
-    return 'unexpected_response';
-  }
-
-  const timedOut = probes.some((probe) => probe.errorCode === 'timeout');
-  return timedOut ? 'timeout' : 'network_error';
+  if (status === 'online') return undefined;
+  if (status === 'unknown') return 'unexpected_response';
+  return probes.some((probe) => probe.errorCode === 'timeout') ? 'timeout' : 'network_error';
 }
 
-async function validateSeed(seed) {
+async function validateSeed(
+  seed,
+  { fetchImpl = fetch, timeoutMs = REQUEST_TIMEOUT_MS } = {}
+) {
   const probes = [];
+  const validatedTransports = new Set();
 
-  for (const endpoint of endpointVariants(seed.url)) {
-    probes.push(await probeEndpoint(endpoint));
+  for (const endpoint of endpointVariants(seed)) {
+    if (validatedTransports.has(endpoint.transport)) continue;
+    const probe = await probeEndpoint(endpoint, { fetchImpl, timeoutMs });
+    probes.push(probe);
+    if (probe.alive) validatedTransports.add(endpoint.transport);
   }
 
   const status = detectedStatus(probes);
   const transport = detectedTransport(probes);
-  const oauthMetadataPresent = await hasOAuthMetadata(originFromUrl(seed.url));
-  const requiresOAuth = seed.requiresOAuth || probes.some((probe) => probe.requiresOAuth) || oauthMetadataPresent;
+  const protocolProbe = selectProtocolProbe(probes);
+  const successfulProbe = probes.find((probe) => probe.alive);
+  const authProbe = probes.find((probe) => probe.resourceMetadataUrl);
+  const authorizationEvidence = await discoverAuthorizationEvidence(
+    successfulProbe?.url || seed.url,
+    {
+      protocolVersion: protocolProbe?.protocolVersion,
+      resourceMetadataUrl: authProbe?.resourceMetadataUrl,
+      fetchImpl,
+      timeoutMs,
+    }
+  );
+  const authType = detectedAuthType(seed, probes, authorizationEvidence);
   const errorCode = errorCodeForStatus(status, probes);
-
   const result = {
     serverId: seed.id,
     status,
     transport,
-    requiresOAuth,
+    authType,
+    requiresOAuth: authType === 'oauth',
+    protocolEra: protocolProbe?.protocolEra || 'unknown',
     checkedAt: new Date().toISOString(),
-    message: resultMessage(status, transport, probes),
+    message: resultMessage(status, transport, probes, authType),
   };
 
-  if (errorCode) {
-    result.errorCode = errorCode;
+  if (successfulProbe?.url) result.validatedUrl = successfulProbe.url;
+  if (protocolProbe?.protocolVersion) result.protocolVersion = protocolProbe.protocolVersion;
+  if (authorizationEvidence.authorizationServers.length > 0) {
+    result.authorizationServers = authorizationEvidence.authorizationServers;
   }
+  if (errorCode) result.errorCode = errorCode;
 
   return result;
 }
@@ -307,11 +428,14 @@ async function mapWithConcurrency(values, concurrency, worker) {
       try {
         results[currentIndex] = await worker(values[currentIndex], currentIndex);
       } catch (error) {
+        const authType = declaredAuthType(values[currentIndex]);
         results[currentIndex] = {
           serverId: values[currentIndex].id,
           status: 'offline',
           transport: 'unknown',
-          requiresOAuth: values[currentIndex].requiresOAuth === true,
+          authType,
+          requiresOAuth: authType === 'oauth',
+          protocolEra: 'unknown',
           checkedAt: new Date().toISOString(),
           errorCode: 'validator_error',
           message: error && error.message ? error.message : String(error),
@@ -329,26 +453,20 @@ async function mapWithConcurrency(values, concurrency, worker) {
 }
 
 function writeResults(results) {
-  const dir = path.dirname(outputPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
   fs.writeFileSync(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf-8');
 }
 
 async function main() {
-  if (!requireFetch()) {
-    return;
-  }
+  if (!requireRuntime()) return;
 
   const seeds = JSON.parse(fs.readFileSync(catalogPath, 'utf-8'));
   console.log(`Validating ${seeds.length} catalog servers with concurrency ${CONCURRENCY}...`);
 
   const results = await mapWithConcurrency(seeds, CONCURRENCY, async (seed) => {
     const result = await validateSeed(seed);
-    const oauthLabel = result.requiresOAuth ? 'oauth' : 'no-oauth';
-    console.log(`${seed.id}: ${result.status}, ${result.transport}, ${oauthLabel} - ${result.message}`);
+    console.log(
+      `${seed.id}: ${result.status}, ${result.transport}, ${result.protocolEra}, ${result.authType} - ${result.message}`
+    );
     return result;
   });
 
@@ -356,7 +474,19 @@ async function main() {
   console.log(`Catalog validation results written to ${path.relative(process.cwd(), outputPath)}`);
 }
 
-main().catch((error) => {
-  console.error('Catalog validation failed:', error && error.message ? error.message : error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Catalog validation failed:', error && error.message ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  declaredAuthType,
+  detectedAuthType,
+  discoverAuthorizationEvidence,
+  endpointVariants,
+  probeSseEndpoint,
+  probeStreamableEndpoint,
+  validateSeed,
+};

--- a/scripts/validate-catalog.test.mjs
+++ b/scripts/validate-catalog.test.mjs
@@ -4,7 +4,9 @@ import validator from './validate-catalog.js';
 const {
   detectedAuthType,
   endpointVariants,
+  probeSseEndpoint,
   probeStreamableEndpoint,
+  validateSeed,
 } = validator;
 
 function jsonRpcResponse(body, result, options = {}) {
@@ -132,7 +134,7 @@ describe('catalog protocol validation', () => {
     ]);
   });
 
-  it('treats an authentication challenge as a live protected endpoint', async () => {
+  it('treats an authentication challenge as reachability evidence only', async () => {
     const fetch = async () => new Response(null, {
       status: 401,
       headers: {
@@ -146,11 +148,147 @@ describe('catalog protocol validation', () => {
     );
 
     expect(result).toMatchObject({
-      alive: true,
+      alive: false,
       reachable: true,
       authChallenge: true,
       statusCode: 401,
       resourceMetadataUrl: 'https://example.com/.well-known/oauth-protected-resource',
+    });
+  });
+
+  it('continues same-transport probing after a root authentication challenge', async () => {
+    const requestedUrls = [];
+    const fetch = async (input, init = {}) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requestedUrls.push(url.toString());
+
+      if (url.pathname === '/') {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            'WWW-Authenticate': 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+          },
+        });
+      }
+
+      if (url.pathname === '/mcp' && init.method === 'POST') {
+        const body = JSON.parse(String(init.body));
+        return jsonRpcResponse(body, {
+          supportedVersions: ['2026-07-28'],
+          capabilities: { tools: {} },
+        });
+      }
+
+      return new Response('Not found', { status: 404 });
+    };
+
+    const result = await validateSeed(
+      {
+        id: 'root-challenge',
+        url: 'https://example.com',
+        transport: 'streamable-http',
+        authType: 'none',
+      },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(requestedUrls).toContain('https://example.com/');
+    expect(requestedUrls).toContain('https://example.com/mcp');
+    expect(result).toMatchObject({
+      status: 'online',
+      transport: 'streamable-http',
+      protocolEra: 'stateless',
+      protocolVersion: '2026-07-28',
+      validatedUrl: 'https://example.com/mcp',
+    });
+    expect(result.message).toContain('Negotiated stateless MCP 2026-07-28 at https://example.com/mcp');
+    expect(result.message).not.toContain('Authentication challenge at https://example.com/');
+  });
+
+  it('requires a legacy SSE endpoint event and initialization exchange', async () => {
+    const encoder = new TextEncoder();
+    let streamController;
+    const methods = [];
+    const fetch = async (input, init = {}) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      const method = init.method || 'GET';
+
+      if (method === 'GET') {
+        const body = new ReadableStream({
+          start(controller) {
+            streamController = controller;
+            controller.enqueue(encoder.encode('event: endpoint\ndata: /messages\n\n'));
+          },
+        });
+        return new Response(body, {
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      }
+
+      expect(url.pathname).toBe('/messages');
+      const body = JSON.parse(String(init.body));
+      methods.push(body.method);
+      if (body.method === 'initialize') {
+        streamController.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'legacy-test-server', version: '1.0.0' },
+          },
+        })}\n\n`));
+      }
+      return new Response(null, { status: 202 });
+    };
+
+    const result = await probeSseEndpoint(
+      { url: 'https://example.com/sse', transport: 'legacy-sse' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      alive: true,
+      authChallenge: false,
+      protocolEra: 'legacy',
+      protocolVersion: '2025-06-18',
+    });
+    expect(methods).toEqual(['initialize', 'notifications/initialized']);
+  });
+
+  it('does not record a MIME-only event stream as legacy MCP', async () => {
+    const fetch = async () => new Response('event: ping\ndata: {}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const result = await probeSseEndpoint(
+      { url: 'https://example.com/sse', transport: 'legacy-sse' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      alive: false,
+      authChallenge: false,
+      protocolEra: 'unknown',
+      errorCode: 'protocol_error',
+    });
+  });
+
+  it('keeps legacy SSE authentication challenges as reachability evidence', async () => {
+    const fetch = async () => new Response(null, { status: 403 });
+
+    const result = await probeSseEndpoint(
+      { url: 'https://example.com/sse', transport: 'legacy-sse' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      reachable: true,
+      alive: false,
+      authChallenge: true,
+      protocolEra: 'unknown',
+      statusCode: 403,
     });
   });
 

--- a/scripts/validate-catalog.test.mjs
+++ b/scripts/validate-catalog.test.mjs
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import validator from './validate-catalog.js';
+
+const {
+  detectedAuthType,
+  endpointVariants,
+  probeStreamableEndpoint,
+} = validator;
+
+function jsonRpcResponse(body, result, options = {}) {
+  return new Response(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }), {
+    status: options.status || 200,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  });
+}
+
+describe('catalog endpoint variants', () => {
+  it('preserves an exact custom MCP endpoint without inventing child paths', () => {
+    const variants = endpointVariants({
+      url: 'https://example.com/v1/mcp/authv2',
+      transport: 'streamable-http',
+    });
+
+    expect(variants.slice(0, 2)).toEqual([
+      { url: 'https://example.com/v1/mcp/authv2', transport: 'streamable-http' },
+      { url: 'https://example.com/v1/mcp/authv2/', transport: 'streamable-http' },
+    ]);
+    expect(variants.some(({ url }) => url.includes('authv2/mcp'))).toBe(false);
+    expect(variants.some(({ url }) => url.includes('authv2/sse'))).toBe(false);
+  });
+
+  it('adds conventional transport paths for an origin root', () => {
+    const variants = endpointVariants({
+      url: 'https://example.com',
+      transport: 'streamable-http',
+    });
+
+    expect(variants).toContainEqual({
+      url: 'https://example.com/mcp',
+      transport: 'streamable-http',
+    });
+    expect(variants).toContainEqual({
+      url: 'https://example.com/sse',
+      transport: 'legacy-sse',
+    });
+  });
+
+  it('tests the exact URL with both transports when the declared transport and path differ', () => {
+    const variants = endpointVariants({
+      url: 'https://example.com/mcp',
+      transport: 'legacy-sse',
+    });
+
+    expect(variants).toContainEqual({
+      url: 'https://example.com/mcp',
+      transport: 'legacy-sse',
+    });
+    expect(variants).toContainEqual({
+      url: 'https://example.com/mcp',
+      transport: 'streamable-http',
+    });
+  });
+});
+
+describe('catalog protocol validation', () => {
+  it('negotiates a stateless 2026 Streamable HTTP server', async () => {
+    const requests = [];
+    const fetch = async (_input, init = {}) => {
+      const body = JSON.parse(String(init.body));
+      requests.push({ body, headers: new Headers(init.headers) });
+      return jsonRpcResponse(body, {
+        supportedVersions: ['2026-07-28'],
+        capabilities: { tools: {} },
+      });
+    };
+
+    const result = await probeStreamableEndpoint(
+      { url: 'https://example.com/mcp', transport: 'streamable-http' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      alive: true,
+      protocolEra: 'stateless',
+      protocolVersion: '2026-07-28',
+    });
+    expect(requests.map(({ body }) => body.method)).toEqual(['server/discover']);
+    expect(requests[0].headers.get('mcp-method')).toBe('server/discover');
+    expect(requests[0].headers.get('mcp-protocol-version')).toBe('2026-07-28');
+  });
+
+  it('falls back to stateful initialization for a 2025 server', async () => {
+    const requests = [];
+    const fetch = async (_input, init = {}) => {
+      if (init.method === 'DELETE') return new Response(null, { status: 200 });
+
+      const body = JSON.parse(String(init.body));
+      requests.push({ body, headers: new Headers(init.headers) });
+      if (body.method === 'server/discover') {
+        return new Response('Not found', { status: 404 });
+      }
+      if (!('id' in body)) return new Response(null, { status: 202 });
+
+      return jsonRpcResponse(body, {
+        protocolVersion: '2025-06-18',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'stateful-test-server', version: '1.0.0' },
+      }, {
+        headers: body.method === 'initialize'
+          ? { 'Mcp-Session-Id': 'catalog-session' }
+          : {},
+      });
+    };
+
+    const result = await probeStreamableEndpoint(
+      { url: 'https://example.com/mcp', transport: 'streamable-http' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      alive: true,
+      protocolEra: 'stateful',
+      protocolVersion: '2025-06-18',
+    });
+    expect(requests.map(({ body }) => body.method)).toEqual([
+      'server/discover',
+      'initialize',
+      'notifications/initialized',
+    ]);
+  });
+
+  it('treats an authentication challenge as a live protected endpoint', async () => {
+    const fetch = async () => new Response(null, {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+      },
+    });
+
+    const result = await probeStreamableEndpoint(
+      { url: 'https://example.com/mcp', transport: 'streamable-http' },
+      { fetchImpl: fetch, timeoutMs: 1_000 }
+    );
+
+    expect(result).toMatchObject({
+      alive: true,
+      reachable: true,
+      authChallenge: true,
+      statusCode: 401,
+      resourceMetadataUrl: 'https://example.com/.well-known/oauth-protected-resource',
+    });
+  });
+
+  it('uses an auth challenge as bearer evidence without mislabeling it OAuth', () => {
+    expect(detectedAuthType(
+      { requiresOAuth: false },
+      [{ authChallenge: true }],
+      { oauthMetadata: false }
+    )).toBe('bearer-token');
+    expect(detectedAuthType(
+      { authType: 'api-key' },
+      [{ authChallenge: true }],
+      { oauthMetadata: false }
+    )).toBe('api-key');
+    expect(detectedAuthType(
+      { authType: 'bearer-token' },
+      [{ authChallenge: true }],
+      { oauthMetadata: true }
+    )).toBe('bearer-token');
+    expect(detectedAuthType(
+      { authType: 'none' },
+      [{ alive: true, authChallenge: false }],
+      { oauthMetadata: true }
+    )).toBe('none');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -477,16 +477,20 @@ function App() {
     logEvent('catalog_test_server', {
       server_id: server.id,
       requires_oauth: server.requiresOAuth,
+      auth_type: server.authType,
+      protocol_era: server.protocolEra,
     });
 
     const newTab: ConnectionTab = {
       id: uuidv4(),
       title: server.name,
-      serverUrl: server.url,
+      serverUrl: server.validatedUrl || server.url,
       connectionStatus: 'Disconnected',
       useProxy: true,
       useOAuth: server.requiresOAuth,
-      autoConnect: true,
+      autoConnect: server.authType === 'none' || server.authType === 'oauth',
+      catalogAuthType: server.authType,
+      catalogRequiredHeaders: server.requiredHeaders,
     };
 
     setTabs(prevTabs => [...prevTabs, newTab]);

--- a/src/components/CatalogServerCard.tsx
+++ b/src/components/CatalogServerCard.tsx
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { CatalogServer, CatalogServerStatus, CatalogValidationTransport } from '../types/catalog';
 import { checkServerLiveness, type LivenessResult } from '../utils/catalogLiveness';
-import { getCatalogServerPath, getEffectiveCatalogTransport } from '../utils/catalogSeo';
+import {
+  formatCatalogAuth,
+  formatProtocolEra,
+  getCatalogServerPath,
+  getEffectiveCatalogTransport,
+} from '../utils/catalogSeo';
 
 export interface CatalogServerCardProps {
   server: CatalogServer;
@@ -68,6 +73,10 @@ const getTransportBadges = (transport: CatalogValidationTransport) => {
   }
 };
 
+const getAuthBadgeClass = (authType: CatalogServer['authType']) => {
+  return authType === 'none' ? 'bg-secondary' : 'bg-dark';
+};
+
 export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, onTest }) => {
   const [isCheckingLiveness, setIsCheckingLiveness] = useState(false);
   const [liveResult, setLiveResult] = useState<LivenessResult | null>(null);
@@ -88,7 +97,7 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
     setIsCheckingLiveness(true);
 
     try {
-      setLiveResult(await checkServerLiveness(server.url));
+      setLiveResult(await checkServerLiveness(server.validatedUrl || server.url));
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unexpected liveness check failure';
       setLiveResult({
@@ -156,10 +165,15 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
 
         <div className="d-flex flex-wrap align-items-center gap-2 mb-3">
           <span className="badge bg-secondary">{server.category}</span>
-          {server.requiresOAuth && (
-            <span className="badge bg-secondary text-white d-inline-flex align-items-center gap-1">
+          <span className={`badge ${getAuthBadgeClass(server.authType)} text-white d-inline-flex align-items-center gap-1`}>
+            {server.authType !== 'none' && (
               <i className="bi bi-shield-lock" aria-hidden="true"></i>
-              OAuth
+            )}
+            {formatCatalogAuth(server.authType)}
+          </span>
+          {server.protocolEra !== 'unknown' && (
+            <span className="badge text-bg-info" title={server.protocolVersion || undefined}>
+              {formatProtocolEra(server.protocolEra)}
             </span>
           )}
           {transportBadges.map((badge) => (

--- a/src/components/CatalogServerCard.tsx
+++ b/src/components/CatalogServerCard.tsx
@@ -172,7 +172,10 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
             {formatCatalogAuth(server.authType)}
           </span>
           {server.protocolEra !== 'unknown' && (
-            <span className="badge text-bg-info" title={server.protocolVersion || undefined}>
+            <span
+              className={`badge ${server.protocolEra === 'stateful' ? 'text-bg-primary' : 'text-bg-info'}`}
+              title={server.protocolVersion || undefined}
+            >
               {formatProtocolEra(server.protocolEra)}
             </span>
           )}

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -15,6 +15,8 @@ const OAUTH_FILTER_OPTIONS: Array<{ value: OAuthFilter; label: string }> = [
   { value: 'all', label: 'All' },
   { value: 'no-auth', label: 'No auth' },
   { value: 'oauth', label: 'OAuth' },
+  { value: 'bearer-token', label: 'Bearer' },
+  { value: 'api-key', label: 'API key' },
 ];
 
 const CatalogView: React.FC<CatalogViewProps> = ({ onTestServer }) => {
@@ -66,7 +68,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({ onTestServer }) => {
             <label className="form-label d-block" htmlFor={`${idPrefix}-oauth-all`}>
               Authentication
             </label>
-            <div className="btn-group" role="group" aria-label="Authentication filter">
+            <div className="btn-group flex-wrap" role="group" aria-label="Authentication filter">
               {OAUTH_FILTER_OPTIONS.map((option) => {
                 const optionId = `${idPrefix}-oauth-${option.value}`;
 

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import type { ProtocolEra } from '@modelcontextprotocol/client';
 import ConnectionErrorCard from './ConnectionErrorCard';
 import { TransportType } from '../types';
+import type { CatalogAuthType } from '../types/catalog';
 import { getServerUrl } from '../utils/urlUtils';
 import { useShare } from '../hooks/useShare';
 import { useAuth } from '../context/AuthContext';
@@ -39,6 +40,11 @@ interface ConnectionPanelProps {
   oauthProgress?: string;
   oauthUserInfo?: any; // User info from OAuth
   isOAuthConnection?: boolean; // Whether current connection uses OAuth
+  catalogAuthType?: CatalogAuthType;
+  credentialHeader?: string;
+  credentialValue?: string;
+  setCredentialValue?: (value: string) => void;
+  credentialInputId?: string;
 }
 
 const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
@@ -67,6 +73,11 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
   oauthProgress,
   oauthUserInfo,
   isOAuthConnection,
+  catalogAuthType,
+  credentialHeader,
+  credentialValue = '',
+  setCredentialValue,
+  credentialInputId = 'catalog-credential',
 }) => {
   const [connectionTimer, setConnectionTimer] = useState(0);
   const [placeholder] = useState(() => {
@@ -76,6 +87,7 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
   const [showUserInfoModal, setShowUserInfoModal] = useState(false);
   const { share, shareStatus, shareMessage } = useShare();
   const { currentUser } = useAuth();
+  const requiresCatalogCredential = catalogAuthType === 'api-key' || catalogAuthType === 'bearer-token';
 
   // Update timer every second while connecting
   useEffect(() => {
@@ -212,7 +224,7 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
               value={serverUrl}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setServerUrl(e.target.value)}
               onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                if (e.key === 'Enter' && !isConnecting && serverUrl && !isConnected) {
+                if (e.key === 'Enter' && !isConnecting && serverUrl && !isConnected && (!requiresCatalogCredential || credentialValue.trim())) {
                   e.preventDefault();
                   handleConnect();
                 }
@@ -235,7 +247,7 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
                  id="connectBtn"
                  className="btn btn-primary"
                  onClick={() => handleConnect()} // Call without arguments
-                 disabled={isConnecting || !serverUrl}
+                 disabled={isConnecting || !serverUrl || (requiresCatalogCredential && !credentialValue.trim())}
                >
                  {isConnecting ? `Connecting... (${connectionTimer}s)` : 'Connect'}
                </button>
@@ -286,7 +298,7 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
               )}
             </div>
           )}
-          {!isConnected && setUseOAuth && (
+          {!isConnected && !requiresCatalogCredential && setUseOAuth && (
             <div className="mt-2">
               <div className="form-check">
                 <input
@@ -300,6 +312,28 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
                 <label className="form-check-label" htmlFor="useOAuthCheck">
                   Use OAuth Authentication
                 </label>
+              </div>
+            </div>
+          )}
+          {!isConnected && requiresCatalogCredential && credentialHeader && setCredentialValue && (
+            <div className="mt-3">
+              <label className="form-label" htmlFor={credentialInputId}>
+                {catalogAuthType === 'api-key' ? 'API key' : 'Bearer token'}
+                <span className="text-muted ms-1">({credentialHeader})</span>
+              </label>
+              <input
+                id={credentialInputId}
+                className="form-control"
+                type="password"
+                value={credentialValue}
+                onChange={(event) => setCredentialValue(event.target.value)}
+                disabled={isConnecting}
+                autoComplete="new-password"
+                spellCheck={false}
+                placeholder={catalogAuthType === 'api-key' ? 'Enter API key' : 'Enter bearer token'}
+              />
+              <div className="form-text">
+                Kept only in this tab's memory. It is not saved, synced, logged, or added to the URL.
               </div>
             </div>
           )}

--- a/src/components/ServerProfileView.tsx
+++ b/src/components/ServerProfileView.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import type { CatalogServer } from '../types/catalog';
-import { formatCatalogTransport } from '../utils/catalogSeo';
+import {
+  formatCatalogAuth,
+  formatCatalogTransport,
+  formatProtocolEra,
+} from '../utils/catalogSeo';
 
 interface ServerProfileViewProps {
   server?: CatalogServer;
@@ -34,6 +38,14 @@ const validationDetail = (server: CatalogServer) => {
   if (server.validationMessage) return server.validationMessage;
   if (server.checkedAt) return 'The latest automated probe completed without additional validation detail.';
   return 'No automated probe result is stored yet. Use the Playground to run a fresh browser-side connection test.';
+};
+
+const authEvidenceNote = (server: CatalogServer) => {
+  if (server.checkedAt && server.authType !== server.declaredAuthType) {
+    return `Validation revised the declared ${formatCatalogAuth(server.declaredAuthType).toLowerCase()} method`;
+  }
+  if (server.checkedAt) return 'Merged from publisher metadata and the latest live probe';
+  return 'Declared by the current catalog listing';
 };
 
 const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestServer }) => {
@@ -117,10 +129,13 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
         </div>
         <div className="server-signal-card">
           <span className="server-signal-label">Authentication</span>
-          <strong>{server.requiresOAuth ? 'OAuth 2.1' : 'No auth declared'}</strong>
-          <small>{server.checkedAt
-            ? (server.requiresOAuth ? 'OAuth detected or required by latest evidence' : 'No OAuth requirement detected by latest validation')
-            : (server.requiresOAuth ? 'Interactive authorization declared' : 'No credentials declared by the current listing')}</small>
+          <strong>{formatCatalogAuth(server.authType)}</strong>
+          <small>{authEvidenceNote(server)}</small>
+        </div>
+        <div className="server-signal-card">
+          <span className="server-signal-label">Protocol lifecycle</span>
+          <strong>{formatProtocolEra(server.protocolEra, server.protocolVersion)}</strong>
+          <small>{server.protocolEra === 'unknown' ? 'No lifecycle negotiation recorded' : 'Negotiated by the catalog validator'}</small>
         </div>
         <div className="server-signal-card">
           <span className="server-signal-label">Category</span>
@@ -145,6 +160,12 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
                 <dt>Remote endpoint</dt>
                 <dd><code>{server.url}</code></dd>
               </div>
+              {server.validatedUrl && server.validatedUrl !== server.url && (
+                <div>
+                  <dt>Live-validated endpoint</dt>
+                  <dd><code>{server.validatedUrl}</code></dd>
+                </div>
+              )}
               <div>
                 <dt>Declared MCP transport</dt>
                 <dd>{formatCatalogTransport(server.declaredTransport)}</dd>
@@ -155,7 +176,11 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
               </div>
               <div>
                 <dt>Credential flow</dt>
-                <dd>{server.requiresOAuth ? 'OAuth 2.1 authorization code flow with PKCE' : 'No authentication advertised by the catalog entry'}</dd>
+                <dd>{formatCatalogAuth(server.authType)}</dd>
+              </div>
+              <div>
+                <dt>Protocol lifecycle</dt>
+                <dd>{formatProtocolEra(server.protocolEra, server.protocolVersion)}</dd>
               </div>
               <div>
                 <dt>Client environment</dt>
@@ -166,12 +191,12 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
             <div className="server-endpoint-box">
               <div>
                 <span>Endpoint</span>
-                <code>{server.url}</code>
+                <code>{server.validatedUrl || server.url}</code>
               </div>
               <button
                 type="button"
                 className="btn btn-sm btn-outline-secondary"
-                onClick={() => navigator.clipboard?.writeText(server.url)}
+                onClick={() => navigator.clipboard?.writeText(server.validatedUrl || server.url)}
                 aria-label={`Copy ${server.name} MCP endpoint`}
               >
                 <i className="bi bi-copy" aria-hidden="true"></i>
@@ -221,8 +246,25 @@ const ServerProfileView: React.FC<ServerProfileViewProps> = ({ server, onTestSer
           <div className="d-flex flex-wrap gap-3">
             {server.homepageUrl && <a href={server.homepageUrl} target="_blank" rel="noopener noreferrer">Product documentation <i className="bi bi-arrow-up-right"></i></a>}
             {server.sourceUrl && <a href={server.sourceUrl} target="_blank" rel="noopener noreferrer">Source repository <i className="bi bi-arrow-up-right"></i></a>}
+            {server.registryUrl && <a href={server.registryUrl} target="_blank" rel="noopener noreferrer">Official MCP Registry record <i className="bi bi-arrow-up-right"></i></a>}
             <Link to="/docs/testing-guide">MCP testing guide <i className="bi bi-arrow-right"></i></Link>
           </div>
+          {(server.requiredHeaders?.length || server.authorizationServers?.length) ? (
+            <dl className="server-spec-list mt-4 mb-0">
+              {server.requiredHeaders?.map((header) => (
+                <div key={header.name}>
+                  <dt>Required header</dt>
+                  <dd><code>{header.name}</code>{header.description ? ` — ${header.description}` : ''}</dd>
+                </div>
+              ))}
+              {server.authorizationServers?.map((issuer) => (
+                <div key={issuer}>
+                  <dt>Authorization server</dt>
+                  <dd><code>{issuer}</code></dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
         </div>
       </section>
     </article>

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ConnectionTab, LogEntry } from '../types';
 import { logEvent } from '../utils/analytics';
 
@@ -68,6 +68,28 @@ const TabContent: React.FC<TabContentProps> = ({ tab, isActive, onUpdateTab, spa
   const [toolCallHistory, setToolCallHistory] = useState<Record<string, any[]>>(() => loadData(TOOL_HISTORY_KEY, {}));
   const [resourceAccessHistory, setResourceAccessHistory] = useState<Record<string, any[]>>(() => loadData(RESOURCE_HISTORY_KEY, {}));
   const [lastResult, setLastResult] = useState<LogEntry | null>(null);
+  const [catalogCredential, setCatalogCredential] = useState('');
+  const credentialHeader = useMemo(() => {
+    if (tab.catalogAuthType !== 'api-key' && tab.catalogAuthType !== 'bearer-token') {
+      return undefined;
+    }
+
+    return tab.catalogRequiredHeaders?.find(({ required }) => required)?.name
+      || tab.catalogRequiredHeaders?.[0]?.name
+      || (tab.catalogAuthType === 'bearer-token' ? 'Authorization' : 'x-api-key');
+  }, [tab.catalogAuthType, tab.catalogRequiredHeaders]);
+  const requestHeaders = useMemo(() => {
+    const credential = catalogCredential.trim();
+    if (!credentialHeader || !credential) return undefined;
+
+    const value = tab.catalogAuthType === 'bearer-token'
+      && credentialHeader.toLowerCase() === 'authorization'
+      && !/^Bearer\s/i.test(credential)
+        ? `Bearer ${credential}`
+        : credential;
+
+    return { [credentialHeader]: value };
+  }, [catalogCredential, credentialHeader, tab.catalogAuthType]);
   
   // Execution state
   const [isExecuting, setIsExecuting] = useState(false);
@@ -117,7 +139,8 @@ const TabContent: React.FC<TabContentProps> = ({ tab, isActive, onUpdateTab, spa
       // Notify parent that OAuth flow is starting and store tab ID
       onUpdateTab(tab.id, { isAuthFlowActive: true });
       sessionStorage.setItem('oauth_tab_id', tab.id);
-    }
+    },
+    requestHeaders
   );
 
   const {
@@ -794,6 +817,11 @@ const TabContent: React.FC<TabContentProps> = ({ tab, isActive, onUpdateTab, spa
             oauthProgress={oauthProgress}
             oauthUserInfo={oauthUserInfo}
             isOAuthConnection={isOAuthConnection}
+            catalogAuthType={tab.catalogAuthType}
+            credentialHeader={credentialHeader}
+            credentialValue={catalogCredential}
+            setCredentialValue={setCatalogCredential}
+            credentialInputId={`${tab.id}-catalog-credential`}
           />
       <div className="playground-layout row flex-grow-1" style={{ paddingTop: '0' }}>
         {/* Left Panel */}

--- a/src/data/catalogValidation.json
+++ b/src/data/catalogValidation.json
@@ -6,7 +6,7 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "stateless",
-    "checkedAt": "2026-08-09T10:10:56.337Z",
+    "checkedAt": "2026-08-09T10:56:10.020Z",
     "message": "Negotiated stateless MCP 2026-07-28 at https://mcp.context7.com/mcp; detected transport streamable-http; authentication oauth",
     "validatedUrl": "https://mcp.context7.com/mcp",
     "protocolVersion": "2026-07-28",
@@ -21,7 +21,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:10.546Z",
+    "checkedAt": "2026-08-09T10:56:23.365Z",
     "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.deepwiki.com/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://mcp.deepwiki.com/mcp",
     "protocolVersion": "2025-11-25"
@@ -33,7 +33,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:10:57.834Z",
+    "checkedAt": "2026-08-09T10:56:11.540Z",
     "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.api.coingecko.com/mcp; detected transport both; authentication none",
     "validatedUrl": "https://mcp.api.coingecko.com/mcp",
     "protocolVersion": "2025-11-25"
@@ -45,8 +45,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:57.504Z",
-    "message": "Authentication challenge at https://mcp.semgrep.ai/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:11.908Z",
+    "message": "Authentication challenge at https://mcp.semgrep.ai/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.semgrep.ai/mcp",
     "authorizationServers": [
       "https://login.semgrep.dev/"
@@ -59,8 +59,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:57.522Z",
-    "message": "Authentication challenge at https://api.githubcopilot.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:11.411Z",
+    "message": "Authentication challenge at https://api.githubcopilot.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://api.githubcopilot.com/mcp",
     "authorizationServers": [
       "https://github.com/login/oauth"
@@ -73,8 +73,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:58.373Z",
-    "message": "Authentication challenge at https://mcp.linear.app/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:12.451Z",
+    "message": "Authentication challenge at https://mcp.linear.app/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.linear.app/mcp",
     "authorizationServers": [
       "https://mcp.linear.app"
@@ -87,8 +87,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:57.760Z",
-    "message": "Authentication challenge at https://mcp.notion.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:11.966Z",
+    "message": "Authentication challenge at https://mcp.notion.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.notion.com/mcp",
     "authorizationServers": [
       "https://mcp.notion.com"
@@ -101,8 +101,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:58.257Z",
-    "message": "Authentication challenge at https://mcp.sentry.dev/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:12.796Z",
+    "message": "Authentication challenge at https://mcp.sentry.dev/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.sentry.dev/mcp",
     "authorizationServers": [
       "https://mcp.sentry.dev"
@@ -115,8 +115,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:58.471Z",
-    "message": "Authentication challenge at https://mcp.atlassian.com/v1/mcp/authv2 returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:12.833Z",
+    "message": "Authentication challenge at https://mcp.atlassian.com/v1/mcp/authv2 returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.atlassian.com/v1/mcp/authv2",
     "authorizationServers": [
       "https://auth.atlassian.com/VCeDsk8ZHncYF1g234fKtc4lNipbBhu3"
@@ -129,8 +129,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:58.488Z",
-    "message": "Authentication challenge at https://mcp.paypal.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:12.981Z",
+    "message": "Authentication challenge at https://mcp.paypal.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.paypal.com/mcp",
     "authorizationServers": [
       "https://mcp.paypal.com"
@@ -143,8 +143,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:59.217Z",
-    "message": "Authentication challenge at https://mcp.stripe.com/ returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:14.122Z",
+    "message": "Authentication challenge at https://mcp.stripe.com/ returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.stripe.com/",
     "authorizationServers": [
       "https://access.stripe.com/mcp"
@@ -157,8 +157,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:00.458Z",
-    "message": "Authentication challenge at https://mcp.slack.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:15.532Z",
+    "message": "Authentication challenge at https://mcp.slack.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.slack.com/mcp",
     "authorizationServers": [
       "https://mcp.slack.com"
@@ -171,8 +171,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:58.736Z",
-    "message": "Authentication challenge at https://mcp.cloudflare.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:13.516Z",
+    "message": "Authentication challenge at https://mcp.cloudflare.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.cloudflare.com/mcp",
     "authorizationServers": [
       "https://mcp.cloudflare.com"
@@ -185,8 +185,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:10:59.691Z",
-    "message": "Authentication challenge at https://mcp.figma.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:14.904Z",
+    "message": "Authentication challenge at https://mcp.figma.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.figma.com/mcp",
     "authorizationServers": [
       "https://api.figma.com"
@@ -199,8 +199,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:00.241Z",
-    "message": "Authentication challenge at https://mcp.supabase.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:15.118Z",
+    "message": "Authentication challenge at https://mcp.supabase.com/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.supabase.com/mcp",
     "authorizationServers": [
       "https://api.supabase.com"
@@ -213,8 +213,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:00.450Z",
-    "message": "Authentication challenge at https://mcp.neon.tech/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:16.212Z",
+    "message": "Authentication challenge at https://mcp.neon.tech/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.neon.tech/mcp",
     "authorizationServers": [
       "https://mcp.neon.tech"
@@ -227,7 +227,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:01.323Z",
+    "checkedAt": "2026-08-09T10:56:16.395Z",
     "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.mdn.mozilla.net/; detected transport streamable-http; authentication none",
     "validatedUrl": "https://mcp.mdn.mozilla.net/",
     "protocolVersion": "2025-11-25"
@@ -239,7 +239,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:01.113Z",
+    "checkedAt": "2026-08-09T10:56:16.764Z",
     "message": "Negotiated stateful MCP 2025-11-25 at https://gateway.mcpservers.org/yahoo-finance/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://gateway.mcpservers.org/yahoo-finance/mcp",
     "protocolVersion": "2025-11-25"
@@ -251,8 +251,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:01.177Z",
-    "message": "Authentication challenge at https://mcp.vercel.com/ returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:17.373Z",
+    "message": "Authentication challenge at https://mcp.vercel.com/ returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://mcp.vercel.com/",
     "authorizationServers": [
       "https://vercel.com"
@@ -261,12 +261,12 @@
   {
     "serverId": "mcp-registry",
     "status": "online",
-    "transport": "both",
+    "transport": "streamable-http",
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:02.660Z",
-    "message": "Negotiated stateful MCP 2025-06-18 at https://registry.run.mcp.com.ai/mcp; detected transport both; authentication none",
+    "checkedAt": "2026-08-09T10:56:18.476Z",
+    "message": "Negotiated stateful MCP 2025-06-18 at https://registry.run.mcp.com.ai/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://registry.run.mcp.com.ai/mcp",
     "protocolVersion": "2025-06-18"
   },
@@ -277,7 +277,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateless",
-    "checkedAt": "2026-08-09T10:11:01.838Z",
+    "checkedAt": "2026-08-09T10:56:18.120Z",
     "message": "Negotiated stateless MCP 2026-07-28 at https://api.inference.sh/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://api.inference.sh/mcp",
     "protocolVersion": "2026-07-28",
@@ -292,7 +292,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:03.413Z",
+    "checkedAt": "2026-08-09T10:56:18.897Z",
     "message": "Negotiated stateful MCP 2025-06-18 at https://tandem.ac/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://tandem.ac/mcp",
     "protocolVersion": "2025-06-18"
@@ -304,8 +304,8 @@
     "authType": "oauth",
     "requiresOAuth": true,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:02.922Z",
-    "message": "Authentication challenge at https://api.agentdm.ai/mcp/v1/grid returned HTTP 401; detected transport unknown; authentication oauth",
+    "checkedAt": "2026-08-09T10:56:19.594Z",
+    "message": "Authentication challenge at https://api.agentdm.ai/mcp/v1/grid returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication oauth",
     "validatedUrl": "https://api.agentdm.ai/mcp/v1/grid",
     "authorizationServers": [
       "https://app.agentdm.ai"
@@ -318,8 +318,8 @@
     "authType": "bearer-token",
     "requiresOAuth": false,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:04.128Z",
-    "message": "Authentication challenge at https://api.adadvisor.ai/mcp returned HTTP 401; detected transport unknown; authentication bearer-token",
+    "checkedAt": "2026-08-09T10:56:20.487Z",
+    "message": "Authentication challenge at https://api.adadvisor.ai/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication bearer-token",
     "validatedUrl": "https://api.adadvisor.ai/mcp",
     "authorizationServers": [
       "https://tmvjgbjbuxnirnwjgfhc.supabase.co/auth/v1"
@@ -332,8 +332,8 @@
     "authType": "api-key",
     "requiresOAuth": false,
     "protocolEra": "unknown",
-    "checkedAt": "2026-08-09T10:11:04.015Z",
-    "message": "Authentication challenge at https://mcp-server-295985738387.europe-west1.run.app/mcp returned HTTP 401; detected transport unknown; authentication api-key",
+    "checkedAt": "2026-08-09T10:56:20.345Z",
+    "message": "Authentication challenge at https://mcp-server-295985738387.europe-west1.run.app/mcp returned HTTP 401; endpoint was reachable but did not complete an MCP probe; authentication api-key",
     "validatedUrl": "https://mcp-server-295985738387.europe-west1.run.app/mcp"
   },
   {
@@ -343,7 +343,7 @@
     "authType": "none",
     "requiresOAuth": false,
     "protocolEra": "stateful",
-    "checkedAt": "2026-08-09T10:11:07.090Z",
+    "checkedAt": "2026-08-09T10:56:23.474Z",
     "message": "Negotiated stateful MCP 2025-03-26 at https://api.agentrapay.ai/mcp; detected transport streamable-http; authentication none",
     "validatedUrl": "https://api.agentrapay.ai/mcp",
     "protocolVersion": "2025-03-26"

--- a/src/data/catalogValidation.json
+++ b/src/data/catalogValidation.json
@@ -1,1 +1,351 @@
-[]
+[
+  {
+    "serverId": "context7",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "stateless",
+    "checkedAt": "2026-08-09T10:10:56.337Z",
+    "message": "Negotiated stateless MCP 2026-07-28 at https://mcp.context7.com/mcp; detected transport streamable-http; authentication oauth",
+    "validatedUrl": "https://mcp.context7.com/mcp",
+    "protocolVersion": "2026-07-28",
+    "authorizationServers": [
+      "https://context7.com"
+    ]
+  },
+  {
+    "serverId": "deepwiki",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:10.546Z",
+    "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.deepwiki.com/mcp; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://mcp.deepwiki.com/mcp",
+    "protocolVersion": "2025-11-25"
+  },
+  {
+    "serverId": "coingecko",
+    "status": "online",
+    "transport": "both",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:10:57.834Z",
+    "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.api.coingecko.com/mcp; detected transport both; authentication none",
+    "validatedUrl": "https://mcp.api.coingecko.com/mcp",
+    "protocolVersion": "2025-11-25"
+  },
+  {
+    "serverId": "semgrep",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:57.504Z",
+    "message": "Authentication challenge at https://mcp.semgrep.ai/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.semgrep.ai/mcp",
+    "authorizationServers": [
+      "https://login.semgrep.dev/"
+    ]
+  },
+  {
+    "serverId": "github",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:57.522Z",
+    "message": "Authentication challenge at https://api.githubcopilot.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://api.githubcopilot.com/mcp",
+    "authorizationServers": [
+      "https://github.com/login/oauth"
+    ]
+  },
+  {
+    "serverId": "linear",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:58.373Z",
+    "message": "Authentication challenge at https://mcp.linear.app/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.linear.app/mcp",
+    "authorizationServers": [
+      "https://mcp.linear.app"
+    ]
+  },
+  {
+    "serverId": "notion",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:57.760Z",
+    "message": "Authentication challenge at https://mcp.notion.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.notion.com/mcp",
+    "authorizationServers": [
+      "https://mcp.notion.com"
+    ]
+  },
+  {
+    "serverId": "sentry",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:58.257Z",
+    "message": "Authentication challenge at https://mcp.sentry.dev/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.sentry.dev/mcp",
+    "authorizationServers": [
+      "https://mcp.sentry.dev"
+    ]
+  },
+  {
+    "serverId": "atlassian",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:58.471Z",
+    "message": "Authentication challenge at https://mcp.atlassian.com/v1/mcp/authv2 returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.atlassian.com/v1/mcp/authv2",
+    "authorizationServers": [
+      "https://auth.atlassian.com/VCeDsk8ZHncYF1g234fKtc4lNipbBhu3"
+    ]
+  },
+  {
+    "serverId": "paypal",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:58.488Z",
+    "message": "Authentication challenge at https://mcp.paypal.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.paypal.com/mcp",
+    "authorizationServers": [
+      "https://mcp.paypal.com"
+    ]
+  },
+  {
+    "serverId": "stripe",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:59.217Z",
+    "message": "Authentication challenge at https://mcp.stripe.com/ returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.stripe.com/",
+    "authorizationServers": [
+      "https://access.stripe.com/mcp"
+    ]
+  },
+  {
+    "serverId": "slack",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:00.458Z",
+    "message": "Authentication challenge at https://mcp.slack.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.slack.com/mcp",
+    "authorizationServers": [
+      "https://mcp.slack.com"
+    ]
+  },
+  {
+    "serverId": "cloudflare",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:58.736Z",
+    "message": "Authentication challenge at https://mcp.cloudflare.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.cloudflare.com/mcp",
+    "authorizationServers": [
+      "https://mcp.cloudflare.com"
+    ]
+  },
+  {
+    "serverId": "figma",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:10:59.691Z",
+    "message": "Authentication challenge at https://mcp.figma.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.figma.com/mcp",
+    "authorizationServers": [
+      "https://api.figma.com"
+    ]
+  },
+  {
+    "serverId": "supabase",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:00.241Z",
+    "message": "Authentication challenge at https://mcp.supabase.com/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.supabase.com/mcp",
+    "authorizationServers": [
+      "https://api.supabase.com"
+    ]
+  },
+  {
+    "serverId": "neon",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:00.450Z",
+    "message": "Authentication challenge at https://mcp.neon.tech/mcp returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.neon.tech/mcp",
+    "authorizationServers": [
+      "https://mcp.neon.tech"
+    ]
+  },
+  {
+    "serverId": "mdn",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:01.323Z",
+    "message": "Negotiated stateful MCP 2025-11-25 at https://mcp.mdn.mozilla.net/; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://mcp.mdn.mozilla.net/",
+    "protocolVersion": "2025-11-25"
+  },
+  {
+    "serverId": "yahoo-finance",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:01.113Z",
+    "message": "Negotiated stateful MCP 2025-11-25 at https://gateway.mcpservers.org/yahoo-finance/mcp; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://gateway.mcpservers.org/yahoo-finance/mcp",
+    "protocolVersion": "2025-11-25"
+  },
+  {
+    "serverId": "vercel",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:01.177Z",
+    "message": "Authentication challenge at https://mcp.vercel.com/ returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://mcp.vercel.com/",
+    "authorizationServers": [
+      "https://vercel.com"
+    ]
+  },
+  {
+    "serverId": "mcp-registry",
+    "status": "online",
+    "transport": "both",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:02.660Z",
+    "message": "Negotiated stateful MCP 2025-06-18 at https://registry.run.mcp.com.ai/mcp; detected transport both; authentication none",
+    "validatedUrl": "https://registry.run.mcp.com.ai/mcp",
+    "protocolVersion": "2025-06-18"
+  },
+  {
+    "serverId": "inference-sh",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateless",
+    "checkedAt": "2026-08-09T10:11:01.838Z",
+    "message": "Negotiated stateless MCP 2026-07-28 at https://api.inference.sh/mcp; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://api.inference.sh/mcp",
+    "protocolVersion": "2026-07-28",
+    "authorizationServers": [
+      "https://api.inference.sh"
+    ]
+  },
+  {
+    "serverId": "tandem-docs",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:03.413Z",
+    "message": "Negotiated stateful MCP 2025-06-18 at https://tandem.ac/mcp; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://tandem.ac/mcp",
+    "protocolVersion": "2025-06-18"
+  },
+  {
+    "serverId": "agentdm",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "oauth",
+    "requiresOAuth": true,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:02.922Z",
+    "message": "Authentication challenge at https://api.agentdm.ai/mcp/v1/grid returned HTTP 401; detected transport unknown; authentication oauth",
+    "validatedUrl": "https://api.agentdm.ai/mcp/v1/grid",
+    "authorizationServers": [
+      "https://app.agentdm.ai"
+    ]
+  },
+  {
+    "serverId": "adadvisor",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "bearer-token",
+    "requiresOAuth": false,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:04.128Z",
+    "message": "Authentication challenge at https://api.adadvisor.ai/mcp returned HTTP 401; detected transport unknown; authentication bearer-token",
+    "validatedUrl": "https://api.adadvisor.ai/mcp",
+    "authorizationServers": [
+      "https://tmvjgbjbuxnirnwjgfhc.supabase.co/auth/v1"
+    ]
+  },
+  {
+    "serverId": "inferventis",
+    "status": "online",
+    "transport": "unknown",
+    "authType": "api-key",
+    "requiresOAuth": false,
+    "protocolEra": "unknown",
+    "checkedAt": "2026-08-09T10:11:04.015Z",
+    "message": "Authentication challenge at https://mcp-server-295985738387.europe-west1.run.app/mcp returned HTTP 401; detected transport unknown; authentication api-key",
+    "validatedUrl": "https://mcp-server-295985738387.europe-west1.run.app/mcp"
+  },
+  {
+    "serverId": "agentra",
+    "status": "online",
+    "transport": "streamable-http",
+    "authType": "none",
+    "requiresOAuth": false,
+    "protocolEra": "stateful",
+    "checkedAt": "2026-08-09T10:11:07.090Z",
+    "message": "Negotiated stateful MCP 2025-03-26 at https://api.agentrapay.ai/mcp; detected transport streamable-http; authentication none",
+    "validatedUrl": "https://api.agentrapay.ai/mcp",
+    "protocolVersion": "2025-03-26"
+  }
+]

--- a/src/data/serverCatalog.json
+++ b/src/data/serverCatalog.json
@@ -8,6 +8,7 @@
     "tags": ["suggested", "docs", "developer-tools", "libraries", "code"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "logoUrl": "/context7-logo.png",
     "homepageUrl": "https://context7.com"
   },
@@ -20,6 +21,7 @@
     "tags": ["suggested", "docs", "github", "repositories", "no-auth"],
     "transport": "streamable-http",
     "requiresOAuth": false,
+    "authType": "none",
     "logoUrl": "/deepwiki-logo.png",
     "homepageUrl": "https://deepwiki.com"
   },
@@ -32,6 +34,7 @@
     "tags": ["suggested", "crypto", "market-data", "prices", "no-auth"],
     "transport": "streamable-http",
     "requiresOAuth": false,
+    "authType": "none",
     "logoUrl": "/coingecko-logo.png",
     "homepageUrl": "https://www.coingecko.com"
   },
@@ -41,9 +44,10 @@
     "url": "https://mcp.semgrep.ai",
     "description": "A fast, open-source, static analysis tool for finding bugs and enforcing code standards.",
     "category": "Security",
-    "tags": ["suggested", "security", "static-analysis", "code-quality", "no-auth"],
+    "tags": ["suggested", "security", "static-analysis", "code-quality", "oauth"],
     "transport": "streamable-http",
-    "requiresOAuth": false,
+    "requiresOAuth": true,
+    "authType": "oauth",
     "logoUrl": "/semgrep-logo.svg",
     "homepageUrl": "https://semgrep.dev",
     "sourceUrl": "https://github.com/semgrep/mcp"
@@ -57,6 +61,7 @@
     "tags": ["official", "github", "repositories", "issues", "pull-requests", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://github.com",
     "sourceUrl": "https://github.com/github/github-mcp-server"
   },
@@ -69,6 +74,7 @@
     "tags": ["official", "linear", "issues", "projects", "planning", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://linear.app"
   },
   {
@@ -80,6 +86,7 @@
     "tags": ["official", "notion", "docs", "databases", "workspace", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://www.notion.com",
     "sourceUrl": "https://github.com/makenotion/notion-mcp-server"
   },
@@ -92,6 +99,7 @@
     "tags": ["official", "sentry", "errors", "debugging", "observability", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://sentry.io"
   },
   {
@@ -103,6 +111,7 @@
     "tags": ["official", "atlassian", "jira", "confluence", "compass", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://www.atlassian.com"
   },
   {
@@ -114,6 +123,7 @@
     "tags": ["official", "paypal", "payments", "transactions", "commerce", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://developer.paypal.com"
   },
   {
@@ -125,6 +135,7 @@
     "tags": ["official", "stripe", "payments", "billing", "customers", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://stripe.com"
   },
   {
@@ -136,6 +147,7 @@
     "tags": ["official", "slack", "messages", "channels", "collaboration", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://slack.com"
   },
   {
@@ -147,6 +159,7 @@
     "tags": ["official", "cloudflare", "workers", "dns", "infrastructure", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://www.cloudflare.com"
   },
   {
@@ -158,6 +171,7 @@
     "tags": ["official", "figma", "design", "dev-mode", "prototyping", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://www.figma.com"
   },
   {
@@ -169,6 +183,7 @@
     "tags": ["official", "supabase", "postgres", "database", "backend", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://supabase.com"
   },
   {
@@ -180,6 +195,7 @@
     "tags": ["official", "neon", "postgres", "database", "branches", "oauth"],
     "transport": "streamable-http",
     "requiresOAuth": true,
+    "authType": "oauth",
     "homepageUrl": "https://neon.com"
   },
   {
@@ -191,6 +207,7 @@
     "tags": ["official", "mdn", "web", "javascript", "browser-compatibility", "no-auth"],
     "transport": "streamable-http",
     "requiresOAuth": false,
+    "authType": "none",
     "homepageUrl": "https://developer.mozilla.org"
   },
   {
@@ -202,6 +219,155 @@
     "tags": ["finance", "stocks", "market-data", "news", "no-auth"],
     "transport": "streamable-http",
     "requiresOAuth": false,
+    "authType": "none",
     "homepageUrl": "https://finance.yahoo.com"
+  },
+  {
+    "id": "vercel",
+    "name": "Vercel",
+    "url": "https://mcp.vercel.com",
+    "description": "Vercel's remote MCP server for inspecting and managing projects, deployments, logs, and platform resources.",
+    "category": "Cloud",
+    "tags": ["official-registry", "vercel", "deployments", "hosting", "oauth"],
+    "transport": "streamable-http",
+    "requiresOAuth": true,
+    "authType": "oauth",
+    "homepageUrl": "https://vercel.com/docs/mcp/vercel-mcp",
+    "sourceUrl": "https://github.com/vercel/vercel-mcp-overview",
+    "registryName": "com.vercel/vercel-mcp",
+    "registryVersion": "0.0.3",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3"
+  },
+  {
+    "id": "mcp-registry",
+    "name": "MCP Registry Server",
+    "url": "https://registry.run.mcp.com.ai/mcp",
+    "description": "MCP interface for searching and publishing servers through the official Model Context Protocol Registry backend.",
+    "category": "Developer Tools",
+    "tags": ["official-registry", "mcp", "registry", "discovery", "openapi", "no-auth"],
+    "transport": "streamable-http",
+    "requiresOAuth": false,
+    "authType": "none",
+    "homepageUrl": "https://run.mcp.com.ai",
+    "sourceUrl": "https://github.com/modelcontextprotocol/registry",
+    "registryName": "ai.com.mcp/registry",
+    "registryVersion": "1.0.0",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ai.com.mcp%2Fregistry/versions/1.0.0"
+  },
+  {
+    "id": "inference-sh",
+    "name": "inference.sh",
+    "url": "https://api.inference.sh/mcp",
+    "description": "Remote MCP server for running AI models, composing agents, connecting tools, and paying per inference run.",
+    "category": "AI Infrastructure",
+    "tags": ["official-registry", "inference", "models", "agents", "ai", "no-auth"],
+    "transport": "streamable-http",
+    "requiresOAuth": false,
+    "authType": "none",
+    "homepageUrl": "https://inference.sh",
+    "registryName": "ac.inference.sh/mcp",
+    "registryVersion": "2.0.1",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ac.inference.sh%2Fmcp/versions/2.0.1"
+  },
+  {
+    "id": "tandem-docs",
+    "name": "Tandem Docs",
+    "url": "https://tandem.ac/mcp",
+    "description": "Remote MCP access to Tandem documentation, installation guides, SDKs, workflows, and agent setup help.",
+    "category": "Documentation",
+    "tags": ["official-registry", "tandem", "docs", "sdk", "agents", "no-auth"],
+    "transport": "streamable-http",
+    "requiresOAuth": false,
+    "authType": "none",
+    "homepageUrl": "https://tandem.ac/docs-mcp",
+    "sourceUrl": "https://github.com/frumu-ai/tandem",
+    "registryName": "ac.tandem/docs-mcp",
+    "registryVersion": "0.3.2",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ac.tandem%2Fdocs-mcp/versions/0.3.2"
+  },
+  {
+    "id": "agentdm",
+    "name": "AgentDM",
+    "url": "https://api.agentdm.ai/mcp/v1/grid",
+    "description": "Agent-to-agent communication over MCP with messages, channels, and discoverable skills.",
+    "category": "Communication",
+    "tags": ["official-registry", "agents", "messages", "channels", "oauth"],
+    "transport": "streamable-http",
+    "requiresOAuth": true,
+    "authType": "oauth",
+    "requiredHeaders": [
+      {
+        "name": "Authorization",
+        "description": "Optional bearer API key alternative to OAuth discovery",
+        "required": false,
+        "secret": true
+      }
+    ],
+    "homepageUrl": "https://agentdm.ai",
+    "sourceUrl": "https://github.com/agentdmai/agentdm",
+    "registryName": "ai.agentdm/agentdm",
+    "registryVersion": "2.0.0",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ai.agentdm%2Fagentdm/versions/2.0.0"
+  },
+  {
+    "id": "adadvisor",
+    "name": "AdAdvisor",
+    "url": "https://api.adadvisor.ai/mcp",
+    "description": "Remote MCP server for querying Meta Ads accounts, campaigns, ad sets, ads, metrics, and settings.",
+    "category": "Marketing",
+    "tags": ["official-registry", "meta-ads", "campaigns", "analytics", "bearer-token"],
+    "transport": "streamable-http",
+    "requiresOAuth": false,
+    "authType": "bearer-token",
+    "requiredHeaders": [
+      {
+        "name": "Authorization",
+        "description": "Bearer token using an AdAdvisor adv_sk_ API key",
+        "required": true,
+        "secret": true
+      }
+    ],
+    "homepageUrl": "https://www.adadvisor.ai/docs/user-guide/getting-started-with-mcp",
+    "registryName": "ai.adadvisor/mcp-server",
+    "registryVersion": "1.0.1",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ai.adadvisor%2Fmcp-server/versions/1.0.1"
+  },
+  {
+    "id": "inferventis",
+    "name": "Inferventis",
+    "url": "https://mcp-server-295985738387.europe-west1.run.app/mcp",
+    "description": "Remote MCP server for loan and mortgage calculations, compound interest, ROI, crypto prices, and currency conversion.",
+    "category": "Finance",
+    "tags": ["official-registry", "mortgages", "calculators", "crypto", "foreign-exchange", "api-key"],
+    "transport": "streamable-http",
+    "requiresOAuth": false,
+    "authType": "api-key",
+    "requiredHeaders": [
+      {
+        "name": "x-api-key",
+        "description": "Inferventis API key obtained from the publisher",
+        "required": true,
+        "secret": true
+      }
+    ],
+    "homepageUrl": "https://inferventis.ai",
+    "sourceUrl": "https://github.com/Bankee-ai/inferventis",
+    "registryName": "ai.bankee/inferventis-mcp",
+    "registryVersion": "1.0.2",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ai.bankee%2Finferventis-mcp/versions/1.0.2"
+  },
+  {
+    "id": "agentra",
+    "name": "Agentra",
+    "url": "https://api.agentrapay.ai/mcp",
+    "description": "Legacy SSE MCP endpoint for autonomous-agent identity, know-your-agent checks, and trust scoring.",
+    "category": "Identity",
+    "tags": ["official-registry", "agents", "identity", "trust", "legacy-sse"],
+    "transport": "legacy-sse",
+    "requiresOAuth": false,
+    "authType": "none",
+    "registryName": "ai.agentrapay/agentra",
+    "registryVersion": "1.0.0",
+    "registryUrl": "https://registry.modelcontextprotocol.io/v0.1/servers/ai.agentrapay%2Fagentra/versions/1.0.0"
   }
 ]

--- a/src/hooks/useCatalog.test.ts
+++ b/src/hooks/useCatalog.test.ts
@@ -107,6 +107,13 @@ describe('catalog query params', () => {
     });
   });
 
+  it.each(['bearer-token', 'api-key'] as const)('accepts the %s auth filter', (auth) => {
+    const filters = getCatalogFiltersFromParams(new URLSearchParams(`auth=${auth}`), categories);
+
+    expect(filters.oauthFilter).toBe(auth);
+    expect(buildCatalogSearchParams('', auth, CATALOG_CATEGORY_ALL).get('auth')).toBe(auth);
+  });
+
   it('omits default values when building params', () => {
     const params = buildCatalogSearchParams('   ', 'all', CATALOG_CATEGORY_ALL);
 

--- a/src/hooks/useCatalog.ts
+++ b/src/hooks/useCatalog.ts
@@ -9,7 +9,13 @@ import {
 import { logEvent } from '../utils/analytics';
 
 const isOAuthFilter = (value: string | null): value is OAuthFilter => {
-  return value === 'all' || value === 'oauth' || value === 'no-auth';
+  return (
+    value === 'all' ||
+    value === 'oauth' ||
+    value === 'bearer-token' ||
+    value === 'api-key' ||
+    value === 'no-auth'
+  );
 };
 
 const normalizeSearchQuery = (searchQuery: string) => searchQuery.trim();
@@ -243,7 +249,7 @@ export const useCatalog = () => {
       }
 
       setOauthFilterState(nextOauthFilter);
-      logEvent('catalog_filter_oauth', { filter: nextOauthFilter });
+      logEvent('catalog_filter_auth', { filter: nextOauthFilter });
     },
     [oauthFilter]
   );

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -60,7 +60,13 @@ const saveRecentServers = (servers: (string | { url: string; useProxy?: boolean 
 };
 
 
-export const useConnection = (addLogEntry: (entryData: Omit<LogEntry, 'timestamp'>) => void, useProxy?: boolean, useOAuth?: boolean, onAuthFlowStart?: () => void) => {
+export const useConnection = (
+  addLogEntry: (entryData: Omit<LogEntry, 'timestamp'>) => void,
+  useProxy?: boolean,
+  useOAuth?: boolean,
+  onAuthFlowStart?: () => void,
+  requestHeaders?: Record<string, string>
+) => {
   const [recentServers, setRecentServers] = useState<string[]>(loadRecentServers);
   const [serverUrl, setServerUrl] = useState<string>(recentServers[0] || 'http://localhost:3033/mcp');
   const [connectionStatus, setConnectionStatus] = useState('Disconnected');
@@ -842,10 +848,15 @@ export const useConnection = (addLogEntry: (entryData: Omit<LogEntry, 'timestamp
       // Set OAuth connection flag based on whether we have an access token
       setIsOAuthConnection(!!latestAccessToken);
       if (latestAccessToken) {
-        console.log('[OAuth] Using access token for connection:', latestAccessToken.substring(0, 20) + '...');
+        console.log('[OAuth] Using access token for connection');
         addLogEntry({ type: 'info', data: `🔐 Using OAuth access token for authenticated connection` });
       }
-      return attemptParallelConnections(targetUrl, abortControllerRef.current?.signal, latestAccessToken || undefined);
+      return attemptParallelConnections(
+        targetUrl,
+        abortControllerRef.current?.signal,
+        latestAccessToken || undefined,
+        requestHeaders
+      );
     };
 
     // Helper function to attempt proxy connection
@@ -867,11 +878,18 @@ export const useConnection = (addLogEntry: (entryData: Omit<LogEntry, 'timestamp
           addLogEntry({ type: 'error', data: 'Failed to obtain authentication token for proxy' });
         }
       }
-      // For proxy connections, prefer OAuth token over Firebase token
-      const proxyAuthToken = latestAccessToken || authToken;
       // Set OAuth connection flag based on whether we have an OAuth token
       setIsOAuthConnection(!!latestAccessToken);
-      return attemptParallelConnections(connectionUrl, abortControllerRef.current?.signal, proxyAuthToken);
+      const targetHeaders = {
+        ...requestHeaders,
+        ...(latestAccessToken ? { Authorization: `Bearer ${latestAccessToken}` } : {}),
+      };
+      return attemptParallelConnections(
+        connectionUrl,
+        abortControllerRef.current?.signal,
+        authToken,
+        targetHeaders
+      );
     };
 
     try {
@@ -1043,7 +1061,7 @@ export const useConnection = (addLogEntry: (entryData: Omit<LogEntry, 'timestamp
         }
         cleanupConnection();
     }
-  }, [serverUrl, isConnecting, connectionStatus, recentServers, addLogEntry, cleanupConnection, useProxy, currentUser, isProxied, useOAuth, accessToken, getLatestAccessToken]); // Added useProxy, currentUser, isProxied, useOAuth, accessToken, and getLatestAccessToken dependencies
+  }, [serverUrl, isConnecting, connectionStatus, recentServers, addLogEntry, cleanupConnection, useProxy, currentUser, isProxied, useOAuth, accessToken, getLatestAccessToken, requestHeaders]);
 
   // Clear connection error on successful connect
   const clearConnectionError = useCallback(() => {

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -15,6 +15,12 @@ export type CatalogTransport = 'streamable-http' | 'legacy-sse';
  */
 export type CatalogValidationTransport = CatalogTransport | 'both' | 'unknown';
 
+/** MCP lifecycle style observed by validation. */
+export type CatalogProtocolEra = 'stateless' | 'stateful' | 'legacy' | 'unknown';
+
+/** Credential mechanism declared by a listing or detected during validation. */
+export type CatalogAuthType = 'none' | 'oauth' | 'bearer-token' | 'api-key' | 'unknown';
+
 /**
  * Reachability state for a catalog server after validation. The unknown state
  * is intentional because browser CORS restrictions can prevent proving whether
@@ -23,9 +29,20 @@ export type CatalogValidationTransport = CatalogTransport | 'both' | 'unknown';
 export type CatalogServerStatus = 'online' | 'offline' | 'unknown';
 
 /**
- * Three-state OAuth filter used by the searchable catalog UI.
+ * Authentication-method filter used by the searchable catalog UI.
  */
-export type OAuthFilter = 'all' | 'oauth' | 'no-auth';
+export type OAuthFilter = 'all' | 'oauth' | 'bearer-token' | 'api-key' | 'no-auth';
+
+export interface CatalogRequiredHeader {
+  /** HTTP header name expected by the remote server. */
+  name: string;
+  /** Short setup guidance that is safe to render publicly. */
+  description?: string;
+  /** Whether the header must be supplied for a successful MCP connection. */
+  required?: boolean;
+  /** Whether the value is a credential and must never be stored or rendered. */
+  secret?: boolean;
+}
 
 /**
  * Hand-curated or crawled catalog entry before validation data is merged in.
@@ -48,12 +65,22 @@ export interface CatalogServerSeed {
   transport: CatalogTransport;
   /** Whether the server requires an OAuth flow before testing. */
   requiresOAuth: boolean;
+  /** Declared authentication method; requiresOAuth remains for older seed compatibility. */
+  authType?: CatalogAuthType;
+  /** Non-secret header requirements documented by the server publisher. */
+  requiredHeaders?: CatalogRequiredHeader[];
   /** Optional logo path or URL for catalog and suggested-server surfaces. */
   logoUrl?: string;
   /** Optional project, product, or documentation homepage. */
   homepageUrl?: string;
   /** Optional source repository or package URL for the server. */
   sourceUrl?: string;
+  /** Canonical server name in the official MCP Registry. */
+  registryName?: string;
+  /** Registry version used when this listing was last curated. */
+  registryVersion?: string;
+  /** Direct official MCP Registry API record for provenance. */
+  registryUrl?: string;
 }
 
 /**
@@ -69,6 +96,16 @@ export interface CatalogValidationResult {
   transport: CatalogValidationTransport;
   /** Whether validation detected OAuth or the curated seed already required it. */
   requiresOAuth: boolean;
+  /** Authentication method inferred from metadata, challenges, and the curated seed. */
+  authType?: CatalogAuthType;
+  /** MCP lifecycle style negotiated by the probe. */
+  protocolEra?: CatalogProtocolEra;
+  /** Exact MCP protocol revision negotiated by the probe. */
+  protocolVersion?: string;
+  /** Exact endpoint URL that completed a protocol or authentication probe. */
+  validatedUrl?: string;
+  /** Authorization server issuers advertised by protected-resource metadata. */
+  authorizationServers?: string[];
   /** ISO timestamp for when validation completed. */
   checkedAt: string;
   /** Optional machine-readable failure code for diagnostics. */
@@ -86,6 +123,18 @@ export interface CatalogServer extends Omit<CatalogServerSeed, 'transport'> {
   declaredTransport: CatalogTransport;
   /** Transport support from validation, or unknown when validation is missing. */
   transport: CatalogValidationTransport;
+  /** Authentication method declared by the catalog source. */
+  declaredAuthType: CatalogAuthType;
+  /** Best-known authentication method after validation evidence is merged. */
+  authType: CatalogAuthType;
+  /** MCP lifecycle style observed by validation. */
+  protocolEra: CatalogProtocolEra;
+  /** Exact MCP revision observed by validation. */
+  protocolVersion?: string;
+  /** Exact endpoint that most recently completed a validation probe. */
+  validatedUrl?: string;
+  /** Authorization server issuers found during OAuth discovery. */
+  authorizationServers?: string[];
   /** Current catalog reachability state. */
   status: CatalogServerStatus;
   /** ISO timestamp for the latest validation result, when available. */
@@ -102,6 +151,6 @@ export interface CatalogFilters {
   query: string;
   /** Selected category, or CATALOG_CATEGORY_ALL for every category. */
   category: string;
-  /** Three-state OAuth requirement filter. */
+  /** Authentication-method filter. */
   oauth: OAuthFilter;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ToolSchema, ResourceSchema, ResourceTemplateSchema, PromptSchema } from "@modelcontextprotocol/core";
+import type { CatalogAuthType, CatalogRequiredHeader } from './catalog';
 
 // Define interfaces for state clarity
 export interface LogEntry {
@@ -84,6 +85,9 @@ export interface ConnectionTab {
   useProxy?: boolean; // Whether to use proxy for this connection
   useOAuth?: boolean; // Whether to use OAuth authentication for this connection
   autoConnect?: boolean; // Whether this tab should connect automatically once initialized
+  /** Catalog credential metadata only. Secret values stay in TabContent memory. */
+  catalogAuthType?: CatalogAuthType;
+  catalogRequiredHeaders?: CatalogRequiredHeader[];
   // Capabilities for this specific connection
   tools?: Tool[];
   resources?: Resource[];

--- a/src/utils/catalogLiveness.test.ts
+++ b/src/utils/catalogLiveness.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { attemptParallelConnections } = vi.hoisted(() => ({
+  attemptParallelConnections: vi.fn(),
+}));
+vi.mock('./transportDetection', () => ({ attemptParallelConnections }));
+
+import { checkServerLiveness, isAuthenticationFailure } from './catalogLiveness';
+
+describe('catalog browser liveness', () => {
+  beforeEach(() => attemptParallelConnections.mockReset());
+
+  it('reports a negotiated stateless server', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    attemptParallelConnections.mockResolvedValue({
+      client: { close },
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+      protocolVersion: '2026-07-28',
+      url: 'https://example.com/mcp',
+    });
+
+    await expect(checkServerLiveness('https://example.com/mcp')).resolves.toMatchObject({
+      status: 'online',
+      protocolEra: 'modern',
+      protocolVersion: '2026-07-28',
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('recognizes MCP authentication challenge errors', () => {
+    expect(isAuthenticationFailure(new Error('HTTP 401 Unauthorized'))).toBe(true);
+    expect(isAuthenticationFailure('403 Forbidden')).toBe(true);
+    expect(isAuthenticationFailure(new Error('CORS request failed'))).toBe(false);
+  });
+});

--- a/src/utils/catalogLiveness.ts
+++ b/src/utils/catalogLiveness.ts
@@ -1,109 +1,58 @@
+import type { ProtocolEra } from '@modelcontextprotocol/client';
+import type { TransportType } from '../types';
 import type { CatalogServerStatus } from '../types/catalog';
+import { attemptParallelConnections } from './transportDetection';
 
 export type LivenessResult = {
   status: CatalogServerStatus;
   authChallenge: boolean;
   detail: string;
+  transportType?: TransportType;
+  protocolEra?: ProtocolEra;
+  protocolVersion?: string;
 };
 
 const PROBE_TIMEOUT_MS = 10_000;
-const PROTOCOL_VERSION = '2025-06-18';
 
-const getMcpEndpointUrl = (serverUrl: string): string => {
-  const baseUrl = new URL(serverUrl);
-
-  if (baseUrl.searchParams.has('target')) {
-    const targetUrl = baseUrl.searchParams.get('target');
-    if (!targetUrl) {
-      throw new Error('Proxy URL missing target parameter');
-    }
-
-    const targetBaseUrl = new URL(targetUrl);
-    const targetBasePath = targetBaseUrl.pathname.replace(/\/(mcp|sse)\/?$/, '').replace(/\/$/, '');
-    targetBaseUrl.pathname = `${targetBasePath}/mcp`;
-
-    const probeUrl = new URL(baseUrl);
-    probeUrl.searchParams.set('target', targetBaseUrl.toString());
-    return probeUrl.toString();
-  }
-
-  const basePath = baseUrl.pathname.replace(/\/(mcp|sse)\/?$/, '').replace(/\/$/, '');
-  baseUrl.pathname = `${basePath}/mcp`;
-  return baseUrl.toString();
+export const isAuthenticationFailure = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b(401|403)\b|unauthori[sz]ed|forbidden|authentication required/i.test(message);
 };
 
-const createInitializeBody = () =>
-  JSON.stringify({
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'initialize',
-    params: {
-      protocolVersion: PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: {
-        name: 'mcp-sse-tester-catalog-liveness',
-        version: '1.0.0',
-      },
-    },
-  });
-
 export const checkServerLiveness = async (serverUrl: string): Promise<LivenessResult> => {
-  let endpointUrl: string;
-
-  try {
-    endpointUrl = getMcpEndpointUrl(serverUrl);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Invalid server URL';
-    return {
-      status: 'unknown',
-      authChallenge: false,
-      detail: `Unable to build MCP probe URL: ${message}.`,
-    };
-  }
-
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
 
   try {
-    const response = await fetch(endpointUrl, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-      },
-      body: createInitializeBody(),
-      signal: controller.signal,
-    });
+    const connection = await attemptParallelConnections(serverUrl, controller.signal);
+    await connection.client.close().catch(() => {});
+    const lifecycle = connection.protocolEra === 'modern' ? 'stateless' : 'stateful';
 
-    if (response.ok) {
-      return {
-        status: 'online',
-        authChallenge: false,
-        detail: `Live browser probe succeeded at ${endpointUrl} with HTTP ${response.status}.`,
-      };
-    }
-
-    if (response.status === 401 || response.status === 403) {
+    return {
+      status: 'online',
+      authChallenge: false,
+      transportType: connection.transportType,
+      protocolEra: connection.protocolEra,
+      protocolVersion: connection.protocolVersion,
+      detail: `Live browser probe negotiated ${lifecycle} MCP${connection.protocolVersion ? ` ${connection.protocolVersion}` : ''} over ${connection.transportType} at ${connection.url}.`,
+    };
+  } catch (error) {
+    if (isAuthenticationFailure(error)) {
       return {
         status: 'online',
         authChallenge: true,
-        detail: `Live browser probe reached ${endpointUrl} and received HTTP ${response.status}; authentication is required.`,
+        detail: 'The endpoint returned an authentication challenge before MCP negotiation, confirming that the protected server is reachable.',
       };
     }
 
+    const message = error instanceof Error ? error.message : String(error);
+    const timedOut = controller.signal.aborted || /abort|timeout/i.test(message);
     return {
       status: 'unknown',
       authChallenge: false,
-      detail: `Live browser probe reached ${endpointUrl} but received HTTP ${response.status}. Server liveness is unknown.`,
-    };
-  } catch (error) {
-    const isAbort = error instanceof DOMException && error.name === 'AbortError';
-    return {
-      status: 'unknown',
-      authChallenge: false,
-      detail: isAbort
-        ? `Live browser probe timed out after ${PROBE_TIMEOUT_MS / 1000} seconds. The server may be slow, unreachable, or may block CORS.`
-        : 'Live browser probe failed from this browser. The server may block CORS, be unreachable, or the request may have been blocked by the browser.',
+      detail: timedOut
+        ? `Live browser negotiation timed out after ${PROBE_TIMEOUT_MS / 1000} seconds. The server may be slow, unreachable, or may block CORS.`
+        : `Live browser negotiation failed. The server may block CORS, be unreachable, or have rejected every MCP transport candidate. ${message}`,
     };
   } finally {
     window.clearTimeout(timeoutId);

--- a/src/utils/catalogSeo.test.ts
+++ b/src/utils/catalogSeo.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { CatalogServer } from '../types/catalog';
 import {
+  formatCatalogAuth,
   formatCatalogTransport,
+  formatProtocolEra,
   getCatalogServerIdFromPath,
   getCatalogServerPath,
   getCatalogServerSeo,
@@ -17,6 +19,9 @@ const server: CatalogServer = {
   declaredTransport: 'streamable-http',
   transport: 'unknown',
   requiresOAuth: true,
+  declaredAuthType: 'oauth',
+  authType: 'oauth',
+  protocolEra: 'unknown',
   status: 'unknown',
 };
 
@@ -32,6 +37,8 @@ describe('catalog SEO helpers', () => {
     const seo = getCatalogServerSeo(server);
 
     expect(formatCatalogTransport(server.declaredTransport)).toBe('Streamable HTTP');
+    expect(formatCatalogAuth(server.authType)).toBe('OAuth 2.1');
+    expect(formatProtocolEra(server.protocolEra)).toBe('Not yet negotiated');
     expect(seo.description).toContain('Streamable HTTP');
     expect(seo.description).toContain('OAuth 2.1');
     expect(seo.canonicalUrl).toBe('https://mcptest.io/servers/example-server/');

--- a/src/utils/catalogSeo.ts
+++ b/src/utils/catalogSeo.ts
@@ -1,4 +1,10 @@
-import type { CatalogServer, CatalogTransport, CatalogValidationTransport } from '../types/catalog';
+import type {
+  CatalogAuthType,
+  CatalogProtocolEra,
+  CatalogServer,
+  CatalogTransport,
+  CatalogValidationTransport,
+} from '../types/catalog';
 
 export const SITE_URL = 'https://mcptest.io';
 
@@ -38,6 +44,36 @@ export const getEffectiveCatalogTransport = (server: CatalogServer) => {
   return server.transport === 'unknown' ? server.declaredTransport : server.transport;
 };
 
+export const formatCatalogAuth = (authType: CatalogAuthType): string => {
+  switch (authType) {
+    case 'none':
+      return 'No authentication';
+    case 'oauth':
+      return 'OAuth 2.1';
+    case 'bearer-token':
+      return 'Bearer token';
+    case 'api-key':
+      return 'API key';
+    default:
+      return 'Not yet verified';
+  }
+};
+
+export const formatProtocolEra = (era: CatalogProtocolEra, version?: string): string => {
+  const revision = version ? ` · ${version}` : '';
+
+  switch (era) {
+    case 'stateless':
+      return `Stateless MCP${revision}`;
+    case 'stateful':
+      return `Stateful MCP${revision}`;
+    case 'legacy':
+      return `Legacy SSE MCP${revision}`;
+    default:
+      return 'Not yet negotiated';
+  }
+};
+
 const truncateDescription = (value: string, maxLength = 158): string => {
   if (value.length <= maxLength) {
     return value;
@@ -48,10 +84,11 @@ const truncateDescription = (value: string, maxLength = 158): string => {
 
 export const getCatalogServerSeo = (server: CatalogServer) => {
   const transport = formatCatalogTransport(getEffectiveCatalogTransport(server));
-  const auth = server.requiresOAuth ? 'OAuth 2.1' : 'no authentication declared';
+  const auth = formatCatalogAuth(server.authType);
+  const protocol = formatProtocolEra(server.protocolEra, server.protocolVersion);
   const canonicalUrl = `${SITE_URL}${getCatalogServerPath(server.id)}`;
   const description = truncateDescription(
-    `${server.name} MCP server connection report: ${transport}, ${auth}, endpoint details, live-test status, and playground compatibility.`
+    `${server.name} MCP server connection report: ${transport}, ${protocol}, ${auth}, endpoint details, and live-test status.`
   );
 
   return {
@@ -80,7 +117,12 @@ export const getCatalogServerSeo = (server: CatalogServer) => {
         {
           '@type': 'PropertyValue',
           name: 'Authentication',
-          value: server.requiresOAuth ? 'OAuth 2.1' : 'None declared',
+          value: formatCatalogAuth(server.authType),
+        },
+        {
+          '@type': 'PropertyValue',
+          name: 'MCP protocol lifecycle',
+          value: protocol,
         },
         {
           '@type': 'PropertyValue',

--- a/src/utils/catalogUtils.test.ts
+++ b/src/utils/catalogUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { CatalogAuthType, CatalogServer } from '../types/catalog';
+import { filterCatalogServers, getCatalogServers } from './catalogUtils';
+
+const server = (id: string, authType: CatalogAuthType): CatalogServer => ({
+  id,
+  name: id,
+  url: `https://${id}.example/mcp`,
+  description: `${authType} test server`,
+  category: 'Testing',
+  tags: [authType],
+  declaredTransport: 'streamable-http',
+  transport: 'streamable-http',
+  requiresOAuth: authType === 'oauth',
+  declaredAuthType: authType,
+  authType,
+  protocolEra: 'unknown',
+  status: 'online',
+});
+
+describe('catalog authentication metadata', () => {
+  const servers = [
+    server('public', 'none'),
+    server('oauth', 'oauth'),
+    server('bearer', 'bearer-token'),
+    server('api-key', 'api-key'),
+  ];
+
+  it.each([
+    ['no-auth', 'public'],
+    ['oauth', 'oauth'],
+    ['bearer-token', 'bearer'],
+    ['api-key', 'api-key'],
+  ] as const)('filters %s servers', (authFilter, expectedId) => {
+    expect(filterCatalogServers(servers, { oauthFilter: authFilter }).map(({ id }) => id))
+      .toEqual([expectedId]);
+  });
+
+  it('merges every expanded seed into the UI-facing catalog', () => {
+    const catalog = getCatalogServers();
+
+    expect(catalog).toHaveLength(26);
+    expect(catalog.find(({ id }) => id === 'adadvisor')).toMatchObject({
+      authType: 'bearer-token',
+      declaredAuthType: 'bearer-token',
+    });
+    expect(catalog.find(({ id }) => id === 'inferventis')).toMatchObject({
+      authType: 'api-key',
+      declaredAuthType: 'api-key',
+    });
+    expect(catalog.find(({ id }) => id === 'agentra')).toMatchObject({
+      declaredTransport: 'legacy-sse',
+    });
+  });
+});

--- a/src/utils/catalogUtils.ts
+++ b/src/utils/catalogUtils.ts
@@ -3,6 +3,8 @@ import catalogValidation from '../data/catalogValidation.json';
 import {
   CATALOG_CATEGORY_ALL,
   type CatalogFilters,
+  type CatalogAuthType,
+  type CatalogProtocolEra,
   type CatalogServer,
   type CatalogServerSeed,
   type CatalogValidationResult,
@@ -29,12 +31,39 @@ const isValidationTransport = (transport: string | undefined): transport is Cata
   );
 };
 
+const isCatalogAuthType = (authType: string | undefined): authType is CatalogAuthType => {
+  return (
+    authType === 'none' ||
+    authType === 'oauth' ||
+    authType === 'bearer-token' ||
+    authType === 'api-key' ||
+    authType === 'unknown'
+  );
+};
+
+const isCatalogProtocolEra = (era: string | undefined): era is CatalogProtocolEra => {
+  return era === 'stateless' || era === 'stateful' || era === 'legacy' || era === 'unknown';
+};
+
+const getDeclaredAuthType = (seed: CatalogServerSeed): CatalogAuthType => {
+  return isCatalogAuthType(seed.authType)
+    ? seed.authType
+    : seed.requiresOAuth
+      ? 'oauth'
+      : 'none';
+};
+
 const getSearchText = (server: CatalogServer): string => {
   return [
     server.name,
     server.description,
     server.url,
     server.category,
+    server.authType,
+    server.declaredAuthType,
+    server.protocolEra,
+    server.protocolVersion,
+    server.registryName,
     ...server.tags,
   ].join(' ').toLowerCase();
 };
@@ -46,18 +75,29 @@ export const getCatalogServers = (): CatalogServer[] => {
 
   return CATALOG_SEEDS.map((seed) => {
     const validation = validationByServerId.get(seed.id);
+    const declaredAuthType = getDeclaredAuthType(seed);
+    const authType = declaredAuthType === 'api-key' || declaredAuthType === 'bearer-token'
+      ? declaredAuthType
+      : isCatalogAuthType(validation?.authType)
+        ? validation.authType
+        : declaredAuthType;
 
     return {
       ...seed,
       declaredTransport: seed.transport,
+      declaredAuthType,
+      authType,
       status: validation?.status ?? 'unknown',
       transport: isValidationTransport(validation?.transport)
         ? validation.transport
         : 'unknown',
-      requiresOAuth:
-        typeof validation?.requiresOAuth === 'boolean'
-          ? validation.requiresOAuth
-          : seed.requiresOAuth,
+      requiresOAuth: authType === 'oauth',
+      protocolEra: isCatalogProtocolEra(validation?.protocolEra)
+        ? validation.protocolEra
+        : 'unknown',
+      protocolVersion: validation?.protocolVersion,
+      validatedUrl: validation?.validatedUrl,
+      authorizationServers: validation?.authorizationServers,
       checkedAt: validation?.checkedAt,
       validationMessage: validation?.message,
     };
@@ -90,11 +130,19 @@ export const filterCatalogServers = (
     }
 
     if (oauthFilter === 'oauth') {
-      return server.requiresOAuth === true;
+      return server.authType === 'oauth';
+    }
+
+    if (oauthFilter === 'bearer-token') {
+      return server.authType === 'bearer-token';
+    }
+
+    if (oauthFilter === 'api-key') {
+      return server.authType === 'api-key';
     }
 
     if (oauthFilter === 'no-auth') {
-      return server.requiresOAuth === false;
+      return server.authType === 'none';
     }
 
     return true;

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { getRequestHeadersForCandidate, getTransportCandidates } from './transportDetection';
+
+describe('transport candidate generation', () => {
+  it('does not append paths to a custom publisher endpoint', () => {
+    const candidates = getTransportCandidates('https://mcp.atlassian.com/v1/mcp/authv2');
+
+    expect(candidates.map(({ url }) => url)).toEqual([
+      'https://mcp.atlassian.com/v1/mcp/authv2',
+      'https://mcp.atlassian.com/v1/mcp/authv2/',
+      'https://mcp.atlassian.com/v1/mcp/authv2',
+      'https://mcp.atlassian.com/v1/mcp/authv2/',
+    ]);
+    expect(candidates.some(({ url }) => url.includes('authv2/mcp'))).toBe(false);
+  });
+
+  it('preserves exact root endpoints and conventional transport paths', () => {
+    const candidates = getTransportCandidates('https://mcp.deepwiki.com');
+
+    expect(candidates).toContainEqual({
+      url: 'https://mcp.deepwiki.com/',
+      transportType: 'streamable-http',
+    });
+    expect(candidates).toContainEqual({
+      url: 'https://mcp.deepwiki.com/mcp',
+      transportType: 'streamable-http',
+    });
+    expect(candidates).toContainEqual({
+      url: 'https://mcp.deepwiki.com/sse',
+      transportType: 'legacy-sse',
+    });
+  });
+
+  it('varies the target rather than the proxy endpoint', () => {
+    const candidates = getTransportCandidates(
+      'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fcustom%2Fendpoint'
+    );
+
+    expect(candidates).toHaveLength(4);
+    expect(candidates.every(({ url }) => url.startsWith('https://proxy.mcptest.io/'))).toBe(true);
+    expect(candidates.every(({ url }) => (
+      new URL(url).searchParams.get('target')?.startsWith('https://example.com/custom/endpoint')
+    ))).toBe(true);
+  });
+
+  it('prefers a declared terminal SSE endpoint before its HTTP sibling', () => {
+    expect(getTransportCandidates('https://example.com/sse')[0]).toEqual({
+      url: 'https://example.com/sse',
+      transportType: 'legacy-sse',
+    });
+  });
+
+  it('keeps target Authorization separate from proxy authentication', () => {
+    const proxyHeaders = getRequestHeadersForCandidate(
+      'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fmcp',
+      { Authorization: 'Bearer target-secret', 'x-api-key': 'api-secret' }
+    );
+    const directHeaders = getRequestHeadersForCandidate(
+      'https://example.com/mcp',
+      { Authorization: 'Bearer target-secret' }
+    );
+
+    expect(proxyHeaders.get('authorization')).toBeNull();
+    expect(proxyHeaders.get('x-mcp-authorization')).toBe('Bearer target-secret');
+    expect(proxyHeaders.get('x-api-key')).toBe('api-secret');
+    expect(directHeaders.get('authorization')).toBe('Bearer target-secret');
+  });
+});

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -115,14 +115,35 @@ describe('transport candidate generation', () => {
     ]);
   });
 
-  it('moves to a fallback group when the preferred endpoint hangs', async () => {
+  it('moves from a hanging root group to a succeeding endpoint fallback', async () => {
     vi.useFakeTimers();
     const attemptedUrls: string[] = [];
     connectionMocks.connect = async ({ endpoint }) => {
       attemptedUrls.push(endpoint.toString());
-      if (endpoint.pathname.startsWith('/mcp')) {
+      if (endpoint.pathname === '/') {
         await new Promise(() => {});
       }
+    };
+
+    const connectionPromise = attemptParallelConnections('https://example.com');
+    await vi.advanceTimersByTimeAsync(CANDIDATE_GROUP_TIMEOUT_MS);
+
+    await expect(connectionPromise).resolves.toMatchObject({
+      url: 'https://example.com/mcp',
+      transportType: 'streamable-http',
+    });
+    expect(attemptedUrls).toEqual([
+      'https://example.com/',
+      'https://example.com/mcp',
+      'https://example.com/mcp/',
+    ]);
+  });
+
+  it('times out a group when one slash variant hangs after its peer fails', async () => {
+    vi.useFakeTimers();
+    connectionMocks.connect = async ({ endpoint }) => {
+      if (endpoint.pathname === '/mcp') throw new Error('exact endpoint failed');
+      if (endpoint.pathname === '/mcp/') await new Promise(() => {});
     };
 
     const connectionPromise = attemptParallelConnections('https://example.com/mcp');
@@ -132,12 +153,6 @@ describe('transport candidate generation', () => {
       url: 'https://example.com/sse',
       transportType: 'legacy-sse',
     });
-    expect(attemptedUrls).toEqual([
-      'https://example.com/mcp',
-      'https://example.com/mcp/',
-      'https://example.com/sse',
-      'https://example.com/sse/',
-    ]);
   });
 
   it('keeps target Authorization separate from proxy authentication', () => {

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -1,5 +1,45 @@
-import { describe, expect, it } from 'vitest';
-import { getRequestHeadersForCandidate, getTransportCandidates } from './transportDetection';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  attemptParallelConnections,
+  getRequestHeadersForCandidate,
+  getTransportCandidates,
+} from './transportDetection';
+
+const connectionMocks = vi.hoisted(() => ({
+  connect: async (_transport: { endpoint: URL }) => {},
+}));
+
+vi.mock('./mcpClient', () => {
+  const createClient = () => {
+    const client = {
+      connect: vi.fn((transport: { endpoint: URL }) => connectionMocks.connect(transport)),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    return client;
+  };
+
+  return {
+    createLegacyMcpClient: vi.fn(createClient),
+    createNegotiatingMcpClient: vi.fn(createClient),
+    getProtocolDetails: vi.fn(() => ({ era: 'stateful', version: '2025-11-25' })),
+  };
+});
+
+vi.mock('./corsAwareTransport', () => ({
+  CorsAwareStreamableHTTPTransport: class {
+    constructor(readonly endpoint: URL) {}
+  },
+}));
+
+vi.mock('./corsAwareSseTransport', () => ({
+  CorsAwareSSETransport: class {
+    constructor(readonly endpoint: URL) {}
+  },
+}));
+
+beforeEach(() => {
+  connectionMocks.connect = async () => {};
+});
 
 describe('transport candidate generation', () => {
   it('does not append paths to a custom publisher endpoint', () => {
@@ -48,6 +88,26 @@ describe('transport candidate generation', () => {
       url: 'https://example.com/sse',
       transportType: 'legacy-sse',
     });
+  });
+
+  it('does not let a faster fallback replace a successful exact endpoint', async () => {
+    const attemptedUrls: string[] = [];
+    connectionMocks.connect = async ({ endpoint }) => {
+      attemptedUrls.push(endpoint.toString());
+      const delay = endpoint.pathname.startsWith('/mcp') ? 20 : 1;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    };
+
+    const connection = await attemptParallelConnections('https://example.com/mcp');
+
+    expect(connection).toMatchObject({
+      url: 'https://example.com/mcp',
+      transportType: 'streamable-http',
+    });
+    expect(attemptedUrls).toEqual([
+      'https://example.com/mcp',
+      'https://example.com/mcp/',
+    ]);
   });
 
   it('keeps target Authorization separate from proxy authentication', () => {

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  CANDIDATE_GROUP_TIMEOUT_MS,
   attemptParallelConnections,
   getRequestHeadersForCandidate,
   getTransportCandidates,
@@ -39,6 +40,10 @@ vi.mock('./corsAwareSseTransport', () => ({
 
 beforeEach(() => {
   connectionMocks.connect = async () => {};
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('transport candidate generation', () => {
@@ -107,6 +112,31 @@ describe('transport candidate generation', () => {
     expect(attemptedUrls).toEqual([
       'https://example.com/mcp',
       'https://example.com/mcp/',
+    ]);
+  });
+
+  it('moves to a fallback group when the preferred endpoint hangs', async () => {
+    vi.useFakeTimers();
+    const attemptedUrls: string[] = [];
+    connectionMocks.connect = async ({ endpoint }) => {
+      attemptedUrls.push(endpoint.toString());
+      if (endpoint.pathname.startsWith('/mcp')) {
+        await new Promise(() => {});
+      }
+    };
+
+    const connectionPromise = attemptParallelConnections('https://example.com/mcp');
+    await vi.advanceTimersByTimeAsync(CANDIDATE_GROUP_TIMEOUT_MS);
+
+    await expect(connectionPromise).resolves.toMatchObject({
+      url: 'https://example.com/sse',
+      transportType: 'legacy-sse',
+    });
+    expect(attemptedUrls).toEqual([
+      'https://example.com/mcp',
+      'https://example.com/mcp/',
+      'https://example.com/sse',
+      'https://example.com/sse/',
     ]);
   });
 

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -8,336 +8,206 @@ import {
   getProtocolDetails,
 } from './mcpClient';
 
-export async function attemptParallelConnections(serverUrl: string, abortSignal?: AbortSignal, authToken?: string): Promise<{
-  transport: any;
+export interface TransportCandidate {
+  url: string;
+  transportType: TransportType;
+}
+
+const slashVariants = (value: URL): URL[] => {
+  const withoutSlash = new URL(value);
+  withoutSlash.pathname = withoutSlash.pathname.replace(/\/+$/, '') || '/';
+  const withSlash = new URL(withoutSlash);
+  withSlash.pathname = `${withoutSlash.pathname.replace(/\/+$/, '')}/`;
+
+  return Array.from(
+    new Map([withoutSlash, withSlash].map((url) => [url.toString(), url])).values()
+  );
+};
+
+const siblingEndpoint = (value: URL, fromSegment: string, toSegment: string): URL | null => {
+  const pathWithoutSlash = value.pathname.replace(/\/+$/, '');
+  if (!pathWithoutSlash.endsWith(`/${fromSegment}`)) return null;
+
+  const sibling = new URL(value);
+  sibling.pathname = `${pathWithoutSlash.slice(0, -(fromSegment.length + 1))}/${toSegment}`;
+  return sibling;
+};
+
+const directCandidates = (endpoint: URL): TransportCandidate[] => {
+  const candidates: TransportCandidate[] = [];
+  const seen = new Set<string>();
+  const add = (url: URL, transportType: TransportType) => {
+    for (const variant of slashVariants(url)) {
+      const candidate = { url: variant.toString(), transportType };
+      const key = `${candidate.transportType}:${candidate.url}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push(candidate);
+    }
+  };
+  const normalizedPath = endpoint.pathname.replace(/\/+$/, '');
+
+  if (normalizedPath.endsWith('/sse')) {
+    add(endpoint, 'legacy-sse');
+    const httpSibling = siblingEndpoint(endpoint, 'sse', 'mcp');
+    if (httpSibling) add(httpSibling, 'streamable-http');
+  } else if (normalizedPath.endsWith('/mcp')) {
+    add(endpoint, 'streamable-http');
+    const sseSibling = siblingEndpoint(endpoint, 'mcp', 'sse');
+    if (sseSibling) add(sseSibling, 'legacy-sse');
+  } else if (!normalizedPath) {
+    // Some publishers serve MCP directly at the origin, while others use the
+    // conventional /mcp or /sse paths. Preserve both possibilities.
+    add(endpoint, 'streamable-http');
+    const httpEndpoint = new URL(endpoint);
+    httpEndpoint.pathname = '/mcp';
+    add(httpEndpoint, 'streamable-http');
+    add(endpoint, 'legacy-sse');
+    const sseEndpoint = new URL(endpoint);
+    sseEndpoint.pathname = '/sse';
+    add(sseEndpoint, 'legacy-sse');
+  } else {
+    // A non-standard path is an endpoint, not a base URL. Never append a
+    // transport path to it; try both transports at the exact location.
+    add(endpoint, 'streamable-http');
+    add(endpoint, 'legacy-sse');
+  }
+
+  return candidates;
+};
+
+/**
+ * Builds connection candidates while preserving exact custom endpoints. For
+ * proxy URLs, only the encoded target is varied; the proxy URL itself remains
+ * untouched.
+ */
+export const getTransportCandidates = (serverUrl: string): TransportCandidate[] => {
+  const outerUrl = new URL(serverUrl);
+  const targetValue = outerUrl.searchParams.get('target');
+  if (!targetValue) return directCandidates(outerUrl);
+
+  const targetUrl = new URL(targetValue);
+  return directCandidates(targetUrl).map((candidate) => {
+    const proxyUrl = new URL(outerUrl);
+    proxyUrl.searchParams.set('target', candidate.url);
+    return { ...candidate, url: proxyUrl.toString() };
+  });
+};
+
+export const getRequestHeadersForCandidate = (
+  candidateUrl: string,
+  requestHeaders?: HeadersInit
+): Headers => {
+  const headers = new Headers(requestHeaders);
+  const candidate = new URL(candidateUrl);
+
+  if (candidate.searchParams.has('target') && headers.has('Authorization')) {
+    headers.set('X-MCP-Authorization', headers.get('Authorization') || '');
+    headers.delete('Authorization');
+  }
+
+  return headers;
+};
+
+type ConnectedCandidate = {
+  transport: CorsAwareStreamableHTTPTransport | CorsAwareSSETransport;
   transportType: TransportType;
   client: Client;
   url: string;
-  protocolEra: ProtocolEra;
-  protocolVersion?: string;
-}> {
-  const baseUrl = new URL(serverUrl);
-  
-  // Check if this is a proxy URL (contains a target parameter)
-  const isProxyUrl = baseUrl.searchParams.has('target');
-  
-  // Detect preferred transport from URL path only (not domain)
-  const originalPath = baseUrl.pathname;
-  console.log(`[DEBUG] Original path: "${originalPath}"`);
-  console.log(`[DEBUG] Is proxy URL: ${isProxyUrl}`);
-  console.log(`[DEBUG] Path analysis: endsWith('/sse')=${originalPath.endsWith('/sse')}, equals('/sse')=${originalPath === '/sse'}`);
-  
-  const preferredTransport = originalPath.endsWith('/sse') || originalPath.endsWith('/sse/') || originalPath === '/sse' ? 'sse' : 
-                            originalPath.endsWith('/mcp') || originalPath.endsWith('/mcp/') || originalPath === '/mcp' ? 'http' : null;
-  
-  console.log(`[Parallel Connection] URL contains preferred transport: ${preferredTransport || 'none detected'}`);
-  console.log('[Parallel Connection] Attempting both SSE and Streamable HTTP with/without trailing slashes...');
-  
-  // Create URLs for each transport type and slash variation
-  let httpUrlWithSlash: URL;
-  let httpUrlWithoutSlash: URL;
-  let sseUrlWithSlash: URL;
-  let sseUrlWithoutSlash: URL;
-  
-  if (isProxyUrl) {
-    // For proxy URLs, modify the target parameter instead of the proxy path
-    const targetUrl = baseUrl.searchParams.get('target');
-    if (!targetUrl) {
-      throw new Error('Proxy URL missing target parameter');
-    }
-    
-    const targetBaseUrl = new URL(targetUrl);
-    const targetBasePath = targetBaseUrl.pathname.replace(/\/(mcp|sse)\/?$/, '').replace(/\/$/, '');
-    
-    // Create modified target URLs
-    const httpTargetWithSlash = new URL(targetBaseUrl);
-    httpTargetWithSlash.pathname = targetBasePath + '/mcp/';
-    const httpTargetWithoutSlash = new URL(targetBaseUrl);
-    httpTargetWithoutSlash.pathname = targetBasePath + '/mcp';
-    const sseTargetWithSlash = new URL(targetBaseUrl);
-    sseTargetWithSlash.pathname = targetBasePath + '/sse/';
-    const sseTargetWithoutSlash = new URL(targetBaseUrl);
-    sseTargetWithoutSlash.pathname = targetBasePath + '/sse';
-    
-    // Create proxy URLs with modified targets
-    httpUrlWithSlash = new URL(baseUrl);
-    httpUrlWithSlash.searchParams.set('target', httpTargetWithSlash.toString());
-    httpUrlWithoutSlash = new URL(baseUrl);
-    httpUrlWithoutSlash.searchParams.set('target', httpTargetWithoutSlash.toString());
-    sseUrlWithSlash = new URL(baseUrl);
-    sseUrlWithSlash.searchParams.set('target', sseTargetWithSlash.toString());
-    sseUrlWithoutSlash = new URL(baseUrl);
-    sseUrlWithoutSlash.searchParams.set('target', sseTargetWithoutSlash.toString());
-  } else {
-    // For direct URLs, modify the path as before
-    const basePath = baseUrl.pathname.replace(/\/(mcp|sse)\/?$/, '').replace(/\/$/, '');
-    
-    httpUrlWithSlash = new URL(baseUrl);
-    httpUrlWithoutSlash = new URL(baseUrl);
-    sseUrlWithSlash = new URL(baseUrl);
-    sseUrlWithoutSlash = new URL(baseUrl);
-    
-    httpUrlWithSlash.pathname = basePath + '/mcp/';
-    httpUrlWithoutSlash.pathname = basePath + '/mcp';
-    sseUrlWithSlash.pathname = basePath + '/sse/';
-    sseUrlWithoutSlash.pathname = basePath + '/sse';
-  }
-  
-  console.log(`[Parallel Connection] Trying HTTP URLs: ${httpUrlWithSlash.toString()}, ${httpUrlWithoutSlash.toString()}`);
-  console.log(`[Parallel Connection] Trying SSE URLs: ${sseUrlWithSlash.toString()}, ${sseUrlWithoutSlash.toString()}`);
-  
-  // Create clients for all attempts
-  const httpClientWithSlash = createNegotiatingMcpClient('mcptest-web');
-  const httpClientWithoutSlash = createNegotiatingMcpClient('mcptest-web');
-  const sseClientWithSlash = createLegacyMcpClient('mcptest-web');
-  const sseClientWithoutSlash = createLegacyMcpClient('mcptest-web');
-  
-  // Create transport options with auth headers if token provided
-  const transportOpts = authToken ? {
-    authProvider: {
-      token: async () => authToken,
-    },
-  } : undefined;
-  
-  // Create transports for all combinations
-  const httpTransportWithSlash = new CorsAwareStreamableHTTPTransport(httpUrlWithSlash, transportOpts);
-  const httpTransportWithoutSlash = new CorsAwareStreamableHTTPTransport(httpUrlWithoutSlash, transportOpts);
-  const sseTransportWithSlash = new CorsAwareSSETransport(sseUrlWithSlash, transportOpts);
-  const sseTransportWithoutSlash = new CorsAwareSSETransport(sseUrlWithoutSlash, transportOpts);
-  
-  // Create connection promises that handle their own errors
-  const httpPromiseWithSlash = httpClientWithSlash.connect(httpTransportWithSlash)
-    .then(() => ({
-      transport: httpTransportWithSlash,
-      transportType: 'streamable-http' as TransportType,
-      client: httpClientWithSlash,
-      success: true,
-      url: httpUrlWithSlash.toString()
-    }))
-    .catch(error => ({
-      error,
-      transportType: 'streamable-http' as TransportType,
-      client: httpClientWithSlash,
-      success: false,
-      url: httpUrlWithSlash.toString()
-    }));
-  
-  const httpPromiseWithoutSlash = httpClientWithoutSlash.connect(httpTransportWithoutSlash)
-    .then(() => ({
-      transport: httpTransportWithoutSlash,
-      transportType: 'streamable-http' as TransportType,
-      client: httpClientWithoutSlash,
-      success: true,
-      url: httpUrlWithoutSlash.toString()
-    }))
-    .catch(error => ({
-      error,
-      transportType: 'streamable-http' as TransportType,
-      client: httpClientWithoutSlash,
-      success: false,
-      url: httpUrlWithoutSlash.toString()
-    }));
-  
-  const ssePromiseWithSlash = sseClientWithSlash.connect(sseTransportWithSlash)
-    .then(() => ({
-      transport: sseTransportWithSlash,
-      transportType: 'legacy-sse' as TransportType,
-      client: sseClientWithSlash,
-      success: true,
-      url: sseUrlWithSlash.toString()
-    }))
-    .catch(error => ({
-      error,
-      transportType: 'legacy-sse' as TransportType,
-      client: sseClientWithSlash,
-      success: false,
-      url: sseUrlWithSlash.toString()
-    }));
-  
-  const ssePromiseWithoutSlash = sseClientWithoutSlash.connect(sseTransportWithoutSlash)
-    .then(() => ({
-      transport: sseTransportWithoutSlash,
-      transportType: 'legacy-sse' as TransportType,
-      client: sseClientWithoutSlash,
-      success: true,
-      url: sseUrlWithoutSlash.toString()
-    }))
-    .catch(error => ({
-      error,
-      transportType: 'legacy-sse' as TransportType,
-      client: sseClientWithoutSlash,
-      success: false,
-      url: sseUrlWithoutSlash.toString()
-    }));
-  
-  // Create abort promise if signal provided
-  const abortPromise = abortSignal ? new Promise<never>((_, reject) => {
-    abortSignal.addEventListener('abort', () => {
-      reject(new Error('Connection aborted by user'));
-    });
-  }) : new Promise<never>(() => {}); // Never resolves if no abort signal
-  
-  try {
-    // Prioritize preferred transport - try it first with a short timeout
-    if (preferredTransport) {
-      console.log(`[Parallel Connection] Trying preferred transport (${preferredTransport}) first...`);
-      
-      // Try original URL first, then variations
-      const preferredPromises = preferredTransport === 'sse' ? 
-        (originalPath === '/sse' ? [ssePromiseWithoutSlash, ssePromiseWithSlash] : [ssePromiseWithSlash, ssePromiseWithoutSlash]) : 
-        (originalPath === '/mcp' ? [httpPromiseWithoutSlash, httpPromiseWithSlash] : [httpPromiseWithSlash, httpPromiseWithoutSlash]);
-      
-      // Try preferred transport with 5 second timeout
-      const preferredTimeout = new Promise<never>((_, reject) => 
-        setTimeout(() => reject(new Error('Preferred transport timeout')), 5000)
-      );
-      
-      try {
-        console.log(`[Parallel Connection] Trying ${preferredPromises.length} preferred transport attempts...`);
-        const preferredResults = await Promise.race([
-          Promise.allSettled(preferredPromises),
-          preferredTimeout
-        ]);
-        
-        if (Array.isArray(preferredResults)) {
-          // Check if any preferred transport succeeded
-          for (const result of preferredResults) {
-            if (result.status === 'fulfilled' && result.value.success) {
-              console.log(`[Parallel Connection] Preferred transport ${preferredTransport} succeeded!`);
-              const successfulResult = result.value;
-              
-              // Close all other connections
-              const allClients = [
-                httpClientWithSlash,
-                httpClientWithoutSlash,
-                sseClientWithSlash,
-                sseClientWithoutSlash
-              ];
-              
-              try {
-                await Promise.allSettled(
-                  allClients
-                    .filter(client => client !== successfulResult.client)
-                    .map(client => client.close())
-                );
-              } catch (error) {
-                console.log('[Parallel Connection] Error closing unused connections:', error);
-              }
-              
-              const protocol = getProtocolDetails(successfulResult.client);
-              return {
-                transport: successfulResult.transport,
-                transportType: successfulResult.transportType,
-                client: successfulResult.client,
-                url: successfulResult.url,
-                protocolEra: protocol.era,
-                protocolVersion: protocol.version,
-              };
-            }
-          }
+};
+
+const firstSuccessful = <T,>(promises: Promise<T>[]): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const errors: Error[] = [];
+    let remaining = promises.length;
+
+    for (const promise of promises) {
+      promise.then(resolve).catch((error) => {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+        remaining -= 1;
+        if (remaining === 0) {
+          reject(new Error(
+            `All connections failed: ${errors.map(({ message }) => message).join(', ')}`
+          ));
         }
-      } catch (error) {
-        console.log(`[Parallel Connection] Preferred transport ${preferredTransport} failed or timed out:`, error.message);
-        console.log(`[Parallel Connection] Falling back to all methods...`);
-      }
+      });
     }
-    
-    // Fall back to all connection attempts
-    const allPromises = [
-      httpPromiseWithSlash,
-      httpPromiseWithoutSlash, 
-      ssePromiseWithSlash,
-      ssePromiseWithoutSlash
-    ];
-    
-    const promises = abortSignal ? [
-      Promise.allSettled(allPromises),
-      abortPromise
-    ] : [Promise.allSettled(allPromises)];
-    
-    const raceResult = await Promise.race(promises);
-    
-    // If we get here and raceResult is an array, it means allSettled completed
-    if (Array.isArray(raceResult)) {
-      const results = raceResult;
-      
-      // Find the first successful connection
-      let successfulResult = null;
-      let errors: Error[] = [];
-      
-      for (const result of results) {
-        if (result.status === 'fulfilled' && result.value.success) {
-          successfulResult = result.value;
-          break;
-        } else if (result.status === 'fulfilled' && !result.value.success) {
-          errors.push(result.value.error);
-        } else if (result.status === 'rejected') {
-          errors.push(result.reason);
-        }
-      }
-      
-      if (successfulResult) {
-        console.log(`[Parallel Connection] ${successfulResult.transportType} connected successfully to ${successfulResult.url}!`);
-        
-        // Close all other connections
-        const allClients = [
-          httpClientWithSlash,
-          httpClientWithoutSlash,
-          sseClientWithSlash,
-          sseClientWithoutSlash
-        ];
-        
-        try {
-          await Promise.allSettled(
-            allClients
-              .filter(client => client !== successfulResult.client)
-              .map(client => client.close())
-          );
-        } catch (error) {
-          console.log('[Parallel Connection] Error closing unused connections:', error);
-        }
-        
-        const protocol = getProtocolDetails(successfulResult.client);
-        return {
-          transport: successfulResult.transport,
-          transportType: successfulResult.transportType,
-          client: successfulResult.client,
-          url: successfulResult.url,
-          protocolEra: protocol.era,
-          protocolVersion: protocol.version,
-        };
-      } else {
-        // All connections failed
-        const errorMessage = errors.length > 0 
-          ? `All connections failed: ${errors.map(e => e.message).join(', ')}`
-          : 'All connections failed with unknown errors';
-        throw new Error(errorMessage);
-      }
-    }
-    
-    // If we reach here, it means abort was triggered
+  });
+};
+
+export async function attemptParallelConnections(
+  serverUrl: string,
+  abortSignal?: AbortSignal,
+  authToken?: string,
+  requestHeaders?: HeadersInit
+): Promise<ConnectedCandidate & { protocolEra: ProtocolEra; protocolVersion?: string }> {
+  const candidates = getTransportCandidates(serverUrl);
+  const clients: Client[] = [];
+  const transportOptionsFor = (candidateUrl: string) => {
+    const headers = getRequestHeadersForCandidate(candidateUrl, requestHeaders);
+
+    return {
+      ...(authToken ? { authProvider: { token: async () => authToken } } : {}),
+      ...(Array.from(headers.keys()).length > 0 ? { headers } : {}),
+    };
+  };
+
+  if (abortSignal?.aborted) {
     throw new Error('Connection aborted by user');
-    
+  }
+
+  console.log('[Parallel Connection] Trying publisher endpoint candidates:', candidates);
+
+  const attempts = candidates.map(async (candidate): Promise<ConnectedCandidate> => {
+    const client = candidate.transportType === 'legacy-sse'
+      ? createLegacyMcpClient('mcptest-web')
+      : createNegotiatingMcpClient('mcptest-web');
+    clients.push(client);
+    const endpoint = new URL(candidate.url);
+    const transportOpts = transportOptionsFor(candidate.url);
+    const transport = candidate.transportType === 'legacy-sse'
+      ? new CorsAwareSSETransport(endpoint, transportOpts)
+      : new CorsAwareStreamableHTTPTransport(endpoint, transportOpts);
+
+    await client.connect(transport);
+    return { ...candidate, client, transport };
+  });
+
+  let removeAbortListener = () => {};
+  const abortPromise = new Promise<never>((_, reject) => {
+    if (!abortSignal) return;
+    const abort = () => reject(new Error('Connection aborted by user'));
+    abortSignal.addEventListener('abort', abort, { once: true });
+    removeAbortListener = () => abortSignal.removeEventListener('abort', abort);
+  });
+
+  try {
+    const successful = await Promise.race([
+      firstSuccessful(attempts),
+      abortPromise,
+    ]);
+    await Promise.allSettled(
+      clients.filter((client) => client !== successful.client).map((client) => client.close())
+    );
+    const protocol = getProtocolDetails(successful.client);
+
+    console.log(
+      `[Parallel Connection] ${successful.transportType} connected to ${successful.url}`
+    );
+    return {
+      ...successful,
+      protocolEra: protocol.era,
+      protocolVersion: protocol.version,
+    };
   } catch (error) {
-    // Clean up all connections on error
-    const allClients = [
-      httpClientWithSlash,
-      httpClientWithoutSlash,
-      sseClientWithSlash,
-      sseClientWithoutSlash
-    ];
-    
-    try {
-      await Promise.allSettled(allClients.map(client => client.close()));
-    } catch (cleanupError) {
-      console.log('[Parallel Connection] Error during cleanup:', cleanupError);
-    }
+    await Promise.allSettled(clients.map((client) => client.close()));
     throw error;
+  } finally {
+    removeAbortListener();
   }
 }
 
-// Keep the original function for backwards compatibility
+// Kept for callers that still use transport detection only for presentation.
 export async function detectTransport(serverUrl: string): Promise<TransportType> {
-  // This is now just used for display purposes - the actual connection uses parallel attempts
-  return 'legacy-sse';
+  return getTransportCandidates(serverUrl)[0]?.transportType || 'legacy-sse';
 }

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -13,6 +13,8 @@ export interface TransportCandidate {
   transportType: TransportType;
 }
 
+export const CANDIDATE_GROUP_TIMEOUT_MS = 5_000;
+
 const slashVariants = (value: URL): URL[] => {
   const withoutSlash = new URL(value);
   withoutSlash.pathname = withoutSlash.pathname.replace(/\/+$/, '') || '/';
@@ -221,17 +223,32 @@ export async function attemptParallelConnections(
       }
 
       let successful: ConnectedCandidate;
+      const firstGroupClientIndex = clients.length;
+      let groupTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      const groupTimeout = new Promise<never>((_, reject) => {
+        groupTimeoutId = setTimeout(() => {
+          reject(new Error(
+            `Connection candidates timed out after ${CANDIDATE_GROUP_TIMEOUT_MS / 1000} seconds`
+          ));
+        }, CANDIDATE_GROUP_TIMEOUT_MS);
+      });
       try {
         successful = await Promise.race([
           firstSuccessful(candidateGroup.map(attemptConnection)),
           abortPromise,
+          groupTimeout,
         ]);
       } catch (error) {
         if (abortSignal?.aborted) {
           throw new Error('Connection aborted by user');
         }
         failures.push(error instanceof Error ? error : new Error(String(error)));
+        await Promise.allSettled(
+          clients.slice(firstGroupClientIndex).map((client) => client.close())
+        );
         continue;
+      } finally {
+        if (groupTimeoutId) clearTimeout(groupTimeoutId);
       }
 
       await Promise.allSettled(

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -135,6 +135,35 @@ const firstSuccessful = <T,>(promises: Promise<T>[]): Promise<T> => {
   });
 };
 
+const candidateGroupKey = (candidate: TransportCandidate): string => {
+  const outerUrl = new URL(candidate.url);
+  const targetValue = outerUrl.searchParams.get('target');
+  const endpoint = targetValue ? new URL(targetValue) : outerUrl;
+  endpoint.pathname = endpoint.pathname.replace(/\/+$/, '') || '/';
+
+  return `${candidate.transportType}:${endpoint.toString()}`;
+};
+
+const groupCandidatesByPriority = (
+  candidates: TransportCandidate[]
+): TransportCandidate[][] => {
+  const groups: TransportCandidate[][] = [];
+
+  for (const candidate of candidates) {
+    const currentGroup = groups[groups.length - 1];
+    if (
+      !currentGroup
+      || candidateGroupKey(currentGroup[0]) !== candidateGroupKey(candidate)
+    ) {
+      groups.push([candidate]);
+    } else {
+      currentGroup.push(candidate);
+    }
+  }
+
+  return groups;
+};
+
 export async function attemptParallelConnections(
   serverUrl: string,
   abortSignal?: AbortSignal,
@@ -158,7 +187,9 @@ export async function attemptParallelConnections(
 
   console.log('[Parallel Connection] Trying publisher endpoint candidates:', candidates);
 
-  const attempts = candidates.map(async (candidate): Promise<ConnectedCandidate> => {
+  const attemptConnection = async (
+    candidate: TransportCandidate
+  ): Promise<ConnectedCandidate> => {
     const client = candidate.transportType === 'legacy-sse'
       ? createLegacyMcpClient('mcptest-web')
       : createNegotiatingMcpClient('mcptest-web');
@@ -171,7 +202,7 @@ export async function attemptParallelConnections(
 
     await client.connect(transport);
     return { ...candidate, client, transport };
-  });
+  };
 
   let removeAbortListener = () => {};
   const abortPromise = new Promise<never>((_, reject) => {
@@ -182,23 +213,47 @@ export async function attemptParallelConnections(
   });
 
   try {
-    const successful = await Promise.race([
-      firstSuccessful(attempts),
-      abortPromise,
-    ]);
-    await Promise.allSettled(
-      clients.filter((client) => client !== successful.client).map((client) => client.close())
-    );
-    const protocol = getProtocolDetails(successful.client);
+    const failures: Error[] = [];
 
-    console.log(
-      `[Parallel Connection] ${successful.transportType} connected to ${successful.url}`
+    for (const candidateGroup of groupCandidatesByPriority(candidates)) {
+      if (abortSignal?.aborted) {
+        throw new Error('Connection aborted by user');
+      }
+
+      let successful: ConnectedCandidate;
+      try {
+        successful = await Promise.race([
+          firstSuccessful(candidateGroup.map(attemptConnection)),
+          abortPromise,
+        ]);
+      } catch (error) {
+        if (abortSignal?.aborted) {
+          throw new Error('Connection aborted by user');
+        }
+        failures.push(error instanceof Error ? error : new Error(String(error)));
+        continue;
+      }
+
+      await Promise.allSettled(
+        clients.filter((client) => client !== successful.client).map((client) => client.close())
+      );
+      const protocol = getProtocolDetails(successful.client);
+
+      console.log(
+        `[Parallel Connection] ${successful.transportType} connected to ${successful.url}`
+      );
+      return {
+        ...successful,
+        protocolEra: protocol.era,
+        protocolVersion: protocol.version,
+      };
+    }
+
+    throw new Error(
+      `All connections failed: ${failures.map(({ message }) => (
+        message.replace(/^All connections failed: /, '')
+      )).join(', ')}`
     );
-    return {
-      ...successful,
-      protocolEra: protocol.era,
-      protocolVersion: protocol.version,
-    };
   } catch (error) {
     await Promise.allSettled(clients.map((client) => client.close()));
     throw error;


### PR DESCRIPTION
## Summary
- expand the catalog from 18 to 26 remote MCP servers with official Registry provenance and public, OAuth, bearer-token, API-key, Streamable HTTP, and legacy SSE declarations
- replace the old fixed initialize probe with SDK-backed 2026 stateless negotiation, stateful fallback, legacy SSE checks, protected-resource discovery, exact endpoint preservation, and stored protocol/auth evidence
- fix browser connection candidates for custom endpoints and root endpoints, and reuse real MCP negotiation for live checks
- add in-memory-only API-key and bearer-token entry in the Playground, including isolated target authorization through the authenticated CORS proxy
- enrich catalog filters, cards, server reports, structured data, and generated SEO pages with authentication, protocol, validated endpoint, and Registry evidence

## Live validation
- 26/26 catalog endpoints recorded online on 2026-08-09
- stateless MCP 2026-07-28 negotiated: Context7, inference.sh
- stateful MCP negotiated across 2025-03-26, 2025-06-18, and 2025-11-25 servers
- protected endpoints classified from 401/403 plus OAuth protected-resource metadata without treating a challenge as transport proof
- Agentra registry SSE declaration was tested at its exact custom URL and live validation found stateful Streamable HTTP

## Verification
- `npm test` — 40 tests passed
- `npx vite build` — passed
- `npm run generate-seo` — 26 server pages, 33 sitemap URLs
- `npx tsc -p cors-proxy-worker/tsconfig.json` — passed
- `npm run validate-catalog` — 26/26 online
