### PR TITLE
Separate evaluator proxy and target credentials

### DIFF
--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -16,6 +16,7 @@ import {
   evaluateServer,
   fetchForEvaluation,
   getEvaluationProxyHeaders,
+  getEvaluationTransportProbeUrl,
 } from './evaluation';
 import { getRequestHeadersForCandidate } from './transportDetection';
 
@@ -68,6 +69,15 @@ describe('evaluation proxy authentication', () => {
     expect(proxyHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
   });
 
+  it('rewrites the target inside an existing proxy URL for transport probes', () => {
+    const probeUrl = getEvaluationTransportProbeUrl(
+      'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+      'sse'
+    );
+
+    expect(new URL(probeUrl).searchParams.get('target')).toBe('https://mcp.example/sse');
+  });
+
   it('uses Firebase for the proxy hop and OAuth only for the MCP target', async () => {
     const client = {
       listTools: vi.fn().mockResolvedValue({ tools: [] }),
@@ -103,6 +113,44 @@ describe('evaluation proxy authentication', () => {
     expect(outgoingTargetHeaders.get('x-mcp-authorization')).toBe(
       'Bearer oauth-access-token'
     );
+    const proxyFetch = vi.mocked(fetch).mock.calls.find(([input]) => (
+      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/sse'
+    ));
+    expect(proxyFetch).toBeDefined();
+    const probeHeaders = new Headers(proxyFetch?.[1]?.headers);
+    expect(probeHeaders.get('authorization')).toBe('Bearer firebase-jwt');
+    expect(probeHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not nest an already-proxied connection probe without OAuth', async () => {
+    const client = {
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      listResources: vi.fn().mockResolvedValue({ resources: [] }),
+      listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+      setLoggingLevel: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockResolvedValueOnce({
+        client,
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+        transportType: 'streamable-http',
+      });
+
+    await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    const proxyFetch = vi.mocked(fetch).mock.calls.find(([input]) => (
+      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/sse'
+    ));
+    expect(proxyFetch).toBeDefined();
+    expect(
+      new URL(String(proxyFetch?.[0])).searchParams.get('target')
+    ).not.toContain('proxy.mcptest.test');
+    const probeHeaders = new Headers(proxyFetch?.[1]?.headers);
+    expect(probeHeaders.get('authorization')).toBe('Bearer firebase-jwt');
+    expect(probeHeaders.get('x-mcp-authorization')).toBeNull();
     expect(client.close).toHaveBeenCalledOnce();
   });
 });

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const connectionMocks = vi.hoisted(() => ({
+  attempt: vi.fn(),
+}));
+
+vi.mock('./transportDetection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./transportDetection')>();
+  return {
+    ...actual,
+    attemptParallelConnections: connectionMocks.attempt,
+  };
+});
+
+import {
+  evaluateServer,
+  fetchForEvaluation,
+  getEvaluationProxyHeaders,
+} from './evaluation';
+import { getRequestHeadersForCandidate } from './transportDetection';
+
+describe('evaluation proxy authentication', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_PROXY_URL', 'https://proxy.mcptest.test/');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('Not found', { status: 404 })));
+    connectionMocks.attempt.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps Firebase and target OAuth credentials in separate headers', () => {
+    const headers = getEvaluationProxyHeaders(
+      { 'Content-Type': 'application/json' },
+      'firebase-jwt',
+      'oauth-access-token'
+    );
+
+    expect(headers.get('authorization')).toBe('Bearer firebase-jwt');
+    expect(headers.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
+    expect(headers.get('x-oauth-token')).toBeNull();
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('uses the isolated target header when direct evaluation fetch falls back', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockResolvedValueOnce(new Response('proxied'));
+
+    const response = await fetchForEvaluation(
+      'https://mcp.example/mcp',
+      'firebase-jwt',
+      { headers: { Accept: 'application/json' } },
+      'oauth-access-token'
+    );
+
+    expect(await response.text()).toBe('proxied');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [proxyTarget, proxyInit] = fetchMock.mock.calls[1];
+    expect(new URL(String(proxyTarget)).searchParams.get('target')).toBe(
+      'https://mcp.example/mcp'
+    );
+    const proxyHeaders = new Headers(proxyInit?.headers);
+    expect(proxyHeaders.get('authorization')).toBe('Bearer firebase-jwt');
+    expect(proxyHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
+  });
+
+  it('uses Firebase for the proxy hop and OAuth only for the MCP target', async () => {
+    const client = {
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      listResources: vi.fn().mockResolvedValue({ resources: [] }),
+      listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+      setLoggingLevel: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockResolvedValueOnce({
+        client,
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+        transportType: 'streamable-http',
+      });
+
+    await evaluateServer(
+      'https://mcp.example/mcp',
+      'firebase-jwt',
+      vi.fn(),
+      'oauth-access-token'
+    );
+
+    expect(connectionMocks.attempt).toHaveBeenCalledTimes(2);
+    const [proxyUrl, , proxyAuthToken, targetHeaders] = connectionMocks.attempt.mock.calls[1];
+    expect(proxyUrl).toBe(
+      'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp'
+    );
+    expect(proxyAuthToken).toBe('firebase-jwt');
+
+    const outgoingTargetHeaders = getRequestHeadersForCandidate(proxyUrl, targetHeaders);
+    expect(outgoingTargetHeaders.get('authorization')).toBeNull();
+    expect(outgoingTargetHeaders.get('x-mcp-authorization')).toBe(
+      'Bearer oauth-access-token'
+    );
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -123,7 +123,7 @@ describe('evaluation proxy authentication', () => {
     expect(client.close).toHaveBeenCalledOnce();
   });
 
-  it('does not nest an already-proxied connection probe without OAuth', async () => {
+  it('does not nest an already-proxied HTTP probe without OAuth', async () => {
     const client = {
       listTools: vi.fn().mockResolvedValue({ tools: [] }),
       listResources: vi.fn().mockResolvedValue({ resources: [] }),
@@ -135,14 +135,14 @@ describe('evaluation proxy authentication', () => {
       .mockRejectedValueOnce(new Error('Direct CORS failure'))
       .mockResolvedValueOnce({
         client,
-        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
-        transportType: 'streamable-http',
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fsse',
+        transportType: 'legacy-sse',
       });
 
-    await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+    await evaluateServer('https://mcp.example/sse', 'firebase-jwt', vi.fn());
 
     const proxyFetch = vi.mocked(fetch).mock.calls.find(([input]) => (
-      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/sse'
+      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/mcp'
     ));
     expect(proxyFetch).toBeDefined();
     expect(

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -4,6 +4,38 @@ import { attemptParallelConnections } from './transportDetection';
 
 const getProxyUrl = (): string | undefined => import.meta.env.VITE_PROXY_URL;
 
+const isConfiguredProxyTarget = (value: string, proxyUrl: string): boolean => {
+  const candidate = new URL(value);
+  const configuredProxy = new URL(proxyUrl);
+
+  return candidate.origin === configuredProxy.origin
+    && candidate.pathname === configuredProxy.pathname
+    && candidate.searchParams.has('target');
+};
+
+export function getEvaluationTransportProbeUrl(
+  connectionUrl: string,
+  targetTransport: 'mcp' | 'sse'
+): string {
+  const outerUrl = new URL(connectionUrl);
+  const proxyUrl = getProxyUrl();
+  const proxyTarget = outerUrl.searchParams.get('target');
+  const isProxied = Boolean(
+    proxyUrl
+    && proxyTarget
+    && isConfiguredProxyTarget(connectionUrl, proxyUrl)
+  );
+  const targetUrl = isProxied
+    ? new URL(proxyTarget as string)
+    : outerUrl;
+
+  targetUrl.pathname = targetUrl.pathname.replace(/\/(?:mcp|sse)\/?$/, `/${targetTransport}`);
+
+  if (!isProxied) return targetUrl.toString();
+  outerUrl.searchParams.set('target', targetUrl.toString());
+  return outerUrl.toString();
+}
+
 interface DetailItem {
   text: string;
   context?: string;
@@ -45,8 +77,16 @@ export async function fetchForEvaluation(
   options: RequestInit = {},
   oauthToken?: string | null
 ): Promise<Response> {
+  const proxyUrl = getProxyUrl();
+  if (proxyUrl && isConfiguredProxyTarget(url, proxyUrl)) {
+    return fetch(url, {
+      ...options,
+      headers: getEvaluationProxyHeaders(options.headers, firebaseToken, oauthToken),
+    });
+  }
+
   const headers = new Headers(options.headers);
-  
+
   // Try direct fetch first if we have an OAuth token
   if (oauthToken) {
     headers.set('Authorization', `Bearer ${oauthToken}`);
@@ -56,9 +96,8 @@ export async function fetchForEvaluation(
       console.log('[Evaluation] Direct fetch failed, falling back to proxy');
     }
   }
-  
+
   // Fallback to proxy if direct fetch fails or no OAuth token
-  const proxyUrl = getProxyUrl();
   if (!proxyUrl) {
     throw new Error('Direct connection failed and no proxy configured');
   }
@@ -671,7 +710,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
       
       // Also check for SSE support even when using HTTP streaming
       try {
-        const sseCheckUrl = connectionUrl.replace(/\/mcp\/?$/, '/sse');
+        const sseCheckUrl = getEvaluationTransportProbeUrl(connectionUrl, 'sse');
         const sseResponse = await fetchForEvaluation(sseCheckUrl, token, {
           method: 'GET',
           headers: { 'Accept': 'text/event-stream' }
@@ -709,7 +748,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
       
       // Also check if HTTP streaming is supported
       try {
-        const httpCheckUrl = connectionUrl.replace(/\/sse\/?$/, '/mcp');
+        const httpCheckUrl = getEvaluationTransportProbeUrl(connectionUrl, 'mcp');
         const httpResponse = await fetchForEvaluation(httpCheckUrl, token, {
           method: 'POST',
           headers: { 

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -1,7 +1,8 @@
 // src/utils/evaluation.ts
 import { Client } from "@modelcontextprotocol/client";
 import { attemptParallelConnections } from './transportDetection';
-const PROXY_URL = import.meta.env.VITE_PROXY_URL;
+
+const getProxyUrl = (): string | undefined => import.meta.env.VITE_PROXY_URL;
 
 interface DetailItem {
   text: string;
@@ -23,7 +24,27 @@ interface EvaluationReport {
   sections: Record<string, EvaluationSection>;
 }
 
-async function proxiedFetch(url: string, token: string, options: RequestInit = {}, oauthToken?: string | null): Promise<Response> {
+export function getEvaluationProxyHeaders(
+  requestHeaders: HeadersInit | undefined,
+  firebaseToken: string,
+  oauthToken?: string | null
+): Headers {
+  const headers = new Headers(requestHeaders);
+  headers.set('Authorization', `Bearer ${firebaseToken}`);
+
+  if (oauthToken) {
+    headers.set('X-MCP-Authorization', `Bearer ${oauthToken}`);
+  }
+
+  return headers;
+}
+
+export async function fetchForEvaluation(
+  url: string,
+  firebaseToken: string,
+  options: RequestInit = {},
+  oauthToken?: string | null
+): Promise<Response> {
   const headers = new Headers(options.headers);
   
   // Try direct fetch first if we have an OAuth token
@@ -37,18 +58,14 @@ async function proxiedFetch(url: string, token: string, options: RequestInit = {
   }
   
   // Fallback to proxy if direct fetch fails or no OAuth token
-  if (!PROXY_URL) {
+  const proxyUrl = getProxyUrl();
+  if (!proxyUrl) {
     throw new Error('Direct connection failed and no proxy configured');
   }
   
-  const target = `${PROXY_URL}?target=${encodeURIComponent(url)}`;
-  const proxyHeaders = new Headers(options.headers);
-  proxyHeaders.set('Authorization', `Bearer ${token}`);
-  
-  // If we have an OAuth token for the server, add it to the request
-  if (oauthToken) {
-    proxyHeaders.set('X-OAuth-Token', oauthToken);
-  }
+  const target = new URL(proxyUrl);
+  target.searchParams.set('target', url);
+  const proxyHeaders = getEvaluationProxyHeaders(options.headers, firebaseToken, oauthToken);
   
   return fetch(target, { ...options, headers: proxyHeaders });
 }
@@ -96,18 +113,27 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
       onProgress(`Connected successfully using ${connectionResult.transportType} transport (direct ${authType})`);
     } catch (directError: any) {
       // Direct connection failed, only try proxy if configured
-      if (PROXY_URL) {
+      const proxyUrl = getProxyUrl();
+      if (proxyUrl) {
         onProgress('Direct connection failed, attempting proxy connection...');
-        const proxyUrl = `${PROXY_URL}?target=${encodeURIComponent(serverUrl)}`;
-        
-        // Use OAuth token if available, otherwise use Firebase token for proxy auth
-        const proxyAuthToken = accessToken || token;
-        const connectionResult = await attemptParallelConnections(proxyUrl, abortController.signal, proxyAuthToken);
+        const proxyConnectionUrl = new URL(proxyUrl);
+        proxyConnectionUrl.searchParams.set('target', serverUrl);
+        const targetHeaders = accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined;
+        const connectionResult = await attemptParallelConnections(
+          proxyConnectionUrl.toString(),
+          abortController.signal,
+          token,
+          targetHeaders
+        );
         mcpClient = connectionResult.client;
         connectionUrl = connectionResult.url;
         transportType = connectionResult.transportType;
         usedProxy = true;
-        const authType = accessToken ? 'with OAuth' : 'with Firebase token';
+        const authType = accessToken
+          ? 'with Firebase proxy auth and OAuth target auth'
+          : 'with Firebase proxy auth';
         onProgress(`Connected successfully using ${connectionResult.transportType} transport (proxy ${authType})`);
       } else {
         throw directError;
@@ -120,7 +146,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
     if (!accessToken) {
       onProgress('Checking if server requires OAuth authentication...');
       try {
-        const testResponse = await proxiedFetch(`${serverUrl}/mcp/v1/initialize`, token, {
+        const testResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -196,7 +222,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
     // Fallback to direct HTTP check if client connection failed
     try {
       // Check if server responds to basic MCP request
-      response = await proxiedFetch(`${serverUrl}/mcp/v1/initialize`, token, {
+      response = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -646,7 +672,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
       // Also check for SSE support even when using HTTP streaming
       try {
         const sseCheckUrl = connectionUrl.replace(/\/mcp\/?$/, '/sse');
-        const sseResponse = await proxiedFetch(sseCheckUrl, token, {
+        const sseResponse = await fetchForEvaluation(sseCheckUrl, token, {
           method: 'GET',
           headers: { 'Accept': 'text/event-stream' }
         }, accessToken);
@@ -684,7 +710,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
       // Also check if HTTP streaming is supported
       try {
         const httpCheckUrl = connectionUrl.replace(/\/sse\/?$/, '/mcp');
-        const httpResponse = await proxiedFetch(httpCheckUrl, token, {
+        const httpResponse = await fetchForEvaluation(httpCheckUrl, token, {
           method: 'POST',
           headers: { 
             'Content-Type': 'application/json',
@@ -729,7 +755,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
     // Fallback to manual transport checks if no MCP client
     try {
       // Check for HTTP streaming support (preferred over SSE)
-    const streamResponse = await proxiedFetch(`${serverUrl}/mcp/v1/stream`, token, {
+    const streamResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/stream`, token, {
       method: 'POST',
       headers: { 
         'Content-Type': 'application/json',
@@ -764,7 +790,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
     
     // Always check for SSE support (legacy)
     try {
-      const sseResponse = await proxiedFetch(`${serverUrl}/sse`, token, {
+      const sseResponse = await fetchForEvaluation(`${serverUrl}/sse`, token, {
         method: 'GET',
         headers: { 'Accept': 'text/event-stream' }
       }, accessToken);
@@ -849,7 +875,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
   
   try {
     // Check for OAuth discovery endpoint
-    const oauthDiscoveryResponse = await proxiedFetch(`${serverUrl}/.well-known/oauth-authorization-server`, token, {}, accessToken);
+    const oauthDiscoveryResponse = await fetchForEvaluation(`${serverUrl}/.well-known/oauth-authorization-server`, token, {}, accessToken);
     
     if (oauthDiscoveryResponse.ok) {
       // OAuth is supported, include security section
@@ -934,7 +960,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
     const siteUrl = window.location.origin;
     
     // CORS preflight check
-    const corsResponse = await proxiedFetch(`${serverUrl}/mcp/v1/initialize`, token, {
+    const corsResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
       method: 'OPTIONS',
       headers: {
         'Origin': siteUrl,
@@ -1082,7 +1108,7 @@ export async function evaluateServer(serverUrl: string, token: string, onProgres
 
   try {
     const startTime = Date.now();
-    const perfResponse = await proxiedFetch(`${serverUrl}/mcp/v1/initialize`, token, {
+    const perfResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- always authenticate the CORS proxy with the Firebase ID token
- forward OAuth credentials only through the isolated target authorization header
- use safe URL query composition for proxy targets
- add evaluator-to-transport and HTTP fallback regression coverage

## Verification
- npm test (52 tests)
- npx tsc --noEmit
- npx tsc -p cors-proxy-worker/tsconfig.json
- npm run build
- git diff --check