### PR TITLE
Document stateless and stateful MCP workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,142 +1,99 @@
-# MCP HTTP Stream Transport Tester
+# mcptest.io
 
-A web-based testing tool for Model Context Protocol (MCP) servers using the HTTP Stream Transport protocol.
+`mcptest.io` is a browser-based inspector, playground, evaluator, and public catalog for remote Model Context Protocol (MCP) servers. It speaks the current stateless MCP protocol and remains compatible with stateful and legacy servers already in production.
 
-## Features
+## What it supports
 
-- Connect to MCP servers using the HTTP Stream Transport protocol
-- Session management with Mcp-Session-Id header
-- Stream resumability with Last-Event-ID tracking
-- List available tools on the server
-- Execute tools with dynamic parameter forms
-- View real-time responses in both batch and streaming modes
-- Proper JSON-RPC 2.0 message formatting
+- **MCP 2026-07-28 (stateless):** probes with `server/discover`, sends self-describing requests, and adds the required `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` routing headers.
+- **MCP 2025 and earlier (stateful):** automatically falls back to `initialize` / `notifications/initialized`, retains `Mcp-Session-Id`, and supports JSON or SSE responses over Streamable HTTP.
+- **Legacy HTTP+SSE:** detects the original two-endpoint transport as a final compatibility fallback.
+- **Capabilities:** discovers and exercises tools, resources, and prompts with raw JSON-RPC logs and schema-driven tool forms.
+- **Authentication:** supports OAuth 2.1 with PKCE, bearer tokens, and API keys. Target credentials remain separate from Firebase credentials when the optional CORS proxy is used.
+- **Server catalog:** ships a validated catalog of public remote servers, authentication and protocol badges, and indexable server report pages included in the sitemap.
+- **Evaluation:** creates shareable server reports and reusable tool-call dashboards.
 
-## Installation
+The exact URL entered by a user or supplied by the catalog is tried first. Conventional `/mcp` and `/sse` paths are compatibility fallbacks; they do not replace an explicit custom endpoint.
 
-1. Clone this repository
-2. Install dependencies with `npm install`
-3. Configure environment variables (see Configuration section below)
-4. Start the development server with `npm run dev`
-5. Open your browser to `http://localhost:5173`
+## Protocol negotiation
 
-## Configuration
+The client uses automatic version negotiation from the official TypeScript SDK:
 
-### Firebase Authentication (Optional)
+1. It sends a bounded `server/discover` probe.
+2. A 2026 server returns its supported versions and capabilities. The connection remains stateless: there is no initialization handshake or transport session ID.
+3. A 2025-only server triggers a transparent fallback to the stateful `initialize` handshake.
+4. If Streamable HTTP is unavailable, the client can try the deprecated HTTP+SSE transport.
 
-The application supports optional Firebase authentication for Google sign-in. To enable it:
+An authentication response is not treated as evidence that a server is legacy. The UI surfaces the auth requirement so the user can provide OAuth, bearer-token, or API-key credentials and retry the same endpoint.
 
-1. Create a `.env` file in the root directory (copy from `.env.example`)
-2. Set `VITE_FIREBASE_AUTH_ENABLED=true`
-3. Add your Firebase configuration values:
-   ```
-   VITE_FIREBASE_API_KEY=your-api-key
-   VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
-   VITE_FIREBASE_PROJECT_ID=your-project-id
-   VITE_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
-   VITE_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
-   VITE_FIREBASE_APP_ID=your-app-id
-   VITE_FIREBASE_MEASUREMENT_ID=your-measurement-id
-   ```
+See the in-app guides for the complete wire behavior:
 
-**Note**: If Firebase authentication is enabled but not properly configured, you will see authentication errors. Make sure to use valid Firebase project credentials from your Firebase console.
+- `/docs/what-is-mcp`
+- `/docs/remote-vs-local`
+- `/docs/testing-guide`
+- `/docs/troubleshooting`
 
-### OAuth 2.1 Support
+## Local development
 
-The application includes OAuth 2.1 authorization code flow with PKCE for secure authentication with MCP servers.
+Requirements: Node.js 22 or newer and npm.
 
-#### OAuth Features
+```bash
+git clone https://github.com/integry/mcptest.git
+cd mcptest
+cp .env.example .env
+npm ci
+npm run dev
+```
 
-- OAuth 2.1 compliant authorization code flow
-- PKCE (Proof Key for Code Exchange) for enhanced security
-- Automatic token management
-- Local OAuth server configuration
+Vite serves the app at `http://localhost:5173` by default.
 
-## HTTP Stream Transport Protocol
+### Environment variables
 
-The HTTP Stream Transport is the recommended transport mechanism for web-based MCP applications, implementing the Streamable HTTP transport protocol from the MCP specification.
+The app works without Firebase when `VITE_FIREBASE_AUTH_ENABLED=false`. To enable sign-in and persisted user data, configure the documented `VITE_FIREBASE_*` values in `.env`.
 
-### Key Features
+Set `VITE_CLOUDFLARE_WORKER_URL` for persisted dashboards and reports. Set `VITE_PROXY_URL` to an approved deployment of `cors-proxy-worker` when browser CORS prevents a direct connection. The proxy requires Firebase authentication and forwards MCP target credentials through its isolated target-auth channel.
 
-- **Single Endpoint**: Uses a single HTTP endpoint (`/mcp`) for all MCP communication
-- **Multiple Response Modes**: Support for both batch (JSON) and streaming (SSE) responses
-- **Session Management**: Built-in session tracking and management via the `Mcp-Session-Id` header
-- **Resumability**: Support for resuming broken SSE connections using the `Last-Event-ID` header
-- **Authentication**: Comprehensive authentication support
-- **CORS**: Flexible CORS configuration for web applications
+Do not commit `.env` or real server credentials.
 
-### HTTP Methods
+## Verification
 
-- **POST**: For sending client requests, notifications, and responses
-- **GET**: For establishing SSE streams for receiving server messages
-- **DELETE**: For terminating sessions
+```bash
+npm test
+npx tsc --noEmit
+npm run validate-catalog
+npm run build
+npm audit --audit-level=low
+```
 
-## Usage
+`npm run build` creates the Vite production bundle, generates one static HTML report document per catalog server, and refreshes `sitemap.xml` and `robots.txt`.
 
-1. Enter the base URL of your MCP server (e.g., `http://localhost:8080`)
-2. Click "Connect" to initialize a session with the `/mcp` endpoint
-3. Click "List Available Tools" to retrieve the tools from the server
-4. Select a tool from the list to view its parameters
-5. Fill in the required parameters
-6. Click "Execute Tool" to run the selected tool
-7. View the responses in the right panel
+The two Worker package trees are checked separately:
 
-## MCP API Endpoints
+```bash
+cd cors-proxy-worker
+npm ci
+npx tsc --noEmit
+npx wrangler deploy --dry-run
 
-The MCP Tester implements the Model Context Protocol specification with HTTP Stream Transport and expects the following endpoint on the MCP server:
+cd ../cloudflare-worker
+npm ci
+npx wrangler deploy --dry-run
+```
 
-- `/mcp` - Single endpoint for all MCP communication (initialization, tool listing, tool execution, and SSE)
+## Catalog maintenance
 
-## JSON-RPC Methods
+Catalog entries live in `src/data/mcpServers.ts`. Run `npm run validate-catalog` after changing one. Validation uses actual MCP negotiation and records the observed endpoint, transport, protocol era, version, reachability, and authentication requirement in `src/data/catalogValidation.json`.
 
-The tester uses the following JSON-RPC 2.0 methods:
+A protected endpoint that returns a valid authentication challenge can be catalog-valid and reachable without being transport-verified anonymously. Keep that distinction explicit in catalog metadata and UI copy.
 
-- `initialize` - Initialize a session with the server
-- `list_tools` - Retrieve available tools from the server
-- `execute_tool` - Execute a tool with parameters
+## Core JSON-RPC methods
 
-## Event Types
+- `server/discover` — advertises versions and capabilities for the stateless 2026 era.
+- `tools/list` and `tools/call` — discover and invoke tools.
+- `resources/list` and `resources/read` — discover and read resources.
+- `prompts/list` and `prompts/get` — discover and render prompts.
+- `initialize` and `notifications/initialized` — stateful compatibility handshake for 2025-era servers.
 
-The tester listens for the following SSE event types:
-
-- `message` (default) - General messages
-- `tool_response` - Tool execution responses
-- `tool_error` - Tool execution errors
-- `tool_list` - Tool discovery responses
-
-## Session Management
-
-The tester implements session management using the `Mcp-Session-Id` header:
-
-1. The server generates a session ID during initialization
-2. The tester includes this session ID in all subsequent requests
-3. The tester can terminate the session with a DELETE request
-
-## Stream Resumability
-
-The tester supports resuming broken SSE connections:
-
-1. Each SSE event includes a unique ID
-2. The tester tracks the last received event ID
-3. When reconnecting, the tester includes the `Last-Event-ID` header
-4. The server can replay missed messages since that event ID
-
-## Error Handling
-
-The tester handles various error scenarios:
-
-- Connection errors with automatic reconnection
-- HTTP errors with appropriate error messages
-- JSON-RPC errors with detailed information
-- Streaming errors with graceful fallback
-
-## Development
-
-To modify the tester:
-
-1. Edit `index.html` for UI changes
-2. Edit `script.js` for client-side logic
-4. Edit `styles.css` for styling
+The authoritative references are the [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28/), the [current specification](https://modelcontextprotocol.io/specification/2026-07-28), and the official TypeScript SDK's [protocol-version guide](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/protocol-versions.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-sse-tester",
   "version": "1.0.0",
-  "description": "Web-based MCP SSE server testing tool",
+  "description": "Browser-based tester and catalog for remote MCP servers",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/src/components/OAuthConfig.tsx
+++ b/src/components/OAuthConfig.tsx
@@ -45,7 +45,7 @@ const OAuthConfig: React.FC<OAuthConfigProps> = ({ serverUrl, onConfigured, onCa
       
       1. Register your application with the OAuth provider
       2. Configure the following settings:
-         - Application Name: MCP SSE Tester (or your preferred name)
+         - Application Name: mcptest.io (or your preferred name)
          - Application Type: Public (SPA/Native)
          - Redirect URI: ${window.location.origin}/oauth/callback
          - Grant Type: Authorization Code with PKCE

--- a/src/components/docs/RemoteVsLocal.tsx
+++ b/src/components/docs/RemoteVsLocal.tsx
@@ -9,231 +9,186 @@ const RemoteVsLocal: React.FC = () => {
           <h1 className="mb-4">Remote vs. Local MCP Servers</h1>
 
           <p className="lead">
-            MCP defines two standard transports: stdio, where the client launches the server as a local
-            subprocess, and Streamable HTTP, where the server runs as an independent web service. Which
-            one you implement shapes everything downstream — deployment, session handling, authentication,
-            and security. This page explains both, with an emphasis on what it takes to build a correct
-            remote server.
+            MCP&apos;s standard transports are stdio for a server launched on the user&apos;s machine and
+            Streamable HTTP for an independently deployed service. Remote MCP now spans two lifecycle
+            eras: sessionless requests in <code>2026-07-28</code> and the stateful handshake used by
+            every earlier stable revision. A compatible client and a production server need to be
+            explicit about which behavior they are using.
           </p>
 
           <h2 className="mt-5">Local servers: stdio</h2>
           <p>
-            With the stdio transport, the client starts the server process itself and writes JSON-RPC
-            messages to the server's standard input; the server replies on standard output. Messages are
-            newline-delimited, must not contain embedded newlines, and nothing that is not a valid MCP
-            message may be written to stdout — a stray <code>console.log</code> corrupts the stream,
-            which is the single most common stdio bug. Logging belongs on stderr, which the client may
-            capture or ignore.
+            With stdio, the client launches the server as a subprocess and exchanges newline-delimited
+            JSON-RPC through standard input and output. Nothing except valid MCP messages may be written
+            to stdout; diagnostic logging belongs on stderr. This transport is a strong fit for local
+            files, developer tools, or anything that should have no network-facing endpoint.
           </p>
           <p>
-            Stdio is the right choice when the server needs access to the user's machine (files, local
-            tooling, dev environments) or when you want zero network surface. It requires no
-            authentication — the process inherits the user's permissions — and has minimal latency. Its
-            limits are structural: one client per process, the user must have the runtime installed,
-            and there is nothing to share between users or devices. Credentials, when needed, come from
-            the environment rather than from an OAuth flow.
+            Process lifetime supplies a natural isolation boundary. Credentials usually arrive through
+            the environment, and each client gets its own process. The trade-offs are installation and
+            runtime requirements on the user&apos;s machine, one process per client, and no shared hosted
+            endpoint. Stdio can carry either protocol era when the SDK supports it; “local” does not by
+            itself mean “legacy.”
           </p>
 
           <h2 className="mt-5">Remote servers: Streamable HTTP</h2>
           <p>
-            A remote server exposes a single HTTP endpoint — the <strong>MCP endpoint</strong>, for
-            example <code>https://example.com/mcp</code> — that supports both POST and GET. One server
-            process serves many concurrent clients, which is what enables hosted, multi-tenant MCP
-            services that work from any client, including browser-based ones like this playground.
-            Streamable HTTP was introduced in protocol version <code>2025-03-26</code>, replacing the
-            original HTTP+SSE transport (see the compatibility note below).
+            A remote server exposes one exact MCP endpoint, such as{' '}
+            <code>https://example.com/mcp</code>. The endpoint accepts JSON-RPC requests over HTTP POST
+            and can answer with <code>application/json</code> or a per-request{' '}
+            <code>text/event-stream</code> response. One deployment can serve many clients and can sit
+            behind standard gateways, authentication services, and load balancers.
           </p>
 
-          <h3 className="mt-4">Request flow</h3>
+          <h3 className="mt-4">2026 stateless flow</h3>
           <p>
-            Every JSON-RPC message from the client is a new HTTP POST to the MCP endpoint, and the
-            client must send an <code>Accept</code> header listing
-            both <code>application/json</code> and <code>text/event-stream</code>. How the server
-            answers depends on the message:
+            In <code>2026-07-28</code>, every request stands alone. There is no{' '}
+            <code>initialize</code> / <code>notifications/initialized</code> handshake and no{' '}
+            <code>Mcp-Session-Id</code>. A server must implement <code>server/discover</code>, while a
+            client may call it to learn the supported versions and capabilities before normal work.
+            The official SDK&apos;s automatic mode uses that call as an era probe.
           </p>
           <p>
-            For a JSON-RPC <em>request</em>, the server chooses between two response modes. It can
-            return <code>Content-Type: application/json</code> with the single JSON-RPC response — the
-            simple case — or it can return <code>Content-Type: text/event-stream</code> and open an SSE
-            stream. The streaming mode is what allows a server to send progress notifications, log
-            messages, or even its own requests back to the client while a long tool call runs, before
-            finally delivering the JSON-RPC response on the same stream. Clients must support both
-            modes; servers should close the stream once the response has been sent.
+            Every request includes its protocol version and client capabilities in{' '}
+            <code>params._meta</code>. Streamable HTTP also requires{' '}
+            <code>MCP-Protocol-Version</code> and <code>Mcp-Method</code> headers; named operations such
+            as <code>tools/call</code>, <code>resources/read</code>, and <code>prompts/get</code> also
+            require <code>Mcp-Name</code>. The header version must match the body metadata. This design
+            lets a gateway route, authorize, and meter a call before parsing the JSON body, and lets any
+            healthy server instance handle any request.
           </p>
           <p>
-            For a JSON-RPC <em>notification</em> or <em>response</em> (such
-            as <code>notifications/initialized</code>), the server returns <code>202 Accepted</code>{' '}
-            with no body.
-          </p>
-          <p>
-            Separately, the client may issue a GET to the MCP endpoint to open a long-lived SSE stream
-            for unsolicited server-to-client messages — resource change notifications, server-initiated
-            requests, and so on. Supporting this GET stream is optional: a server that does not offer
-            one must respond <code>405 Method Not Allowed</code>, and clients must tolerate that.
+            A POST request may still receive an SSE response while work runs. For continuing change
+            notifications, 2026 uses the <code>subscriptions/listen</code> request instead of the old
+            standalone GET stream. Closing a per-request SSE response cancels that request. Interactive
+            tool flows use multi-round-trip <code>input_required</code> results and retries instead of
+            server-initiated requests on a permanently open connection.
           </p>
 
-          <h3 className="mt-4">Sessions</h3>
+          <h3 className="mt-4">2025 stateful flow</h3>
           <p>
-            HTTP is stateless, so the transport defines an explicit session mechanism. A server that
-            wants stateful sessions returns an <code>Mcp-Session-Id</code> header on the response to
-            the <code>initialize</code> request. From then on the client must include that header on
-            every request. The rest of the contract is precise, and worth testing directly:
+            Revisions through <code>2025-11-25</code> start with an <code>initialize</code> POST. The
+            server returns the selected protocol version, capabilities, and server identity; the client
+            acknowledges with <code>notifications/initialized</code>. A server that wants transport
+            state also returns <code>Mcp-Session-Id</code>. The client must then include that opaque ID
+            and the negotiated <code>MCP-Protocol-Version</code> on later requests.
           </p>
           <ul>
-            <li>Requests missing a required session ID (other than initialization) get <code>400 Bad Request</code>.</li>
-            <li>The server may expire a session at any time; requests with a stale ID get <code>404 Not Found</code>, and the client must react by starting a fresh session with a new <code>initialize</code> request.</li>
-            <li>A client that is done with a session should send HTTP DELETE to the MCP endpoint with the session header; servers may refuse with <code>405</code> if they don't support explicit termination.</li>
+            <li>A missing required session ID normally produces <code>400 Bad Request</code>.</li>
+            <li>An expired or unknown session ID produces <code>404 Not Found</code>; the client creates a fresh connection rather than retrying the stale session.</li>
+            <li>A client may send DELETE with the session header to terminate it; a server that does not support explicit termination may answer <code>405 Method Not Allowed</code>.</li>
+            <li>A separate GET may open a server-to-client SSE stream. Returning <code>405</code> is valid when that optional stream is unsupported.</li>
           </ul>
           <p>
-            Session IDs must be cryptographically secure and unguessable (a UUID from a secure random
-            generator, for instance), and must contain only visible ASCII characters. Do not use
-            sequential or predictable IDs — the session ID is a bearer credential for the session.
+            Session IDs must be secure, unpredictable, and kept out of URLs and logs. Stateful servers
+            deployed across instances need shared session storage or correct affinity; otherwise users
+            see intermittent 404 responses as calls land on different instances.
           </p>
 
-          <h3 className="mt-4">The protocol version header</h3>
+          <h3 className="mt-4">Streaming and compatibility</h3>
           <p>
-            After initialization, the client must include <code>MCP-Protocol-Version:
-            &lt;negotiated-version&gt;</code> (for example <code>2025-11-25</code>) on every HTTP
-            request. If the header is missing, servers should assume <code>2025-03-26</code> for
-            backwards compatibility; if it names an invalid or unsupported version, the server must
-            respond <code>400 Bad Request</code>.
+            For 2025 Streamable HTTP, clients send an <code>Accept</code> header offering both{' '}
+            <code>application/json</code> and <code>text/event-stream</code>. A JSON-RPC request can
+            receive one JSON response or an SSE stream that eventually contains it. Notifications and
+            client responses normally receive <code>202 Accepted</code> with no body. SSE event IDs and
+            <code>Last-Event-ID</code> support resumption where the server offers it.
           </p>
-
-          <h3 className="mt-4">Resumability</h3>
           <p>
-            SSE connections drop — networks fail, proxies time out, and since protocol
-            version <code>2025-11-25</code> servers may deliberately close a connection to avoid holding
-            it open. To avoid losing messages, servers can attach an <code>id</code> to each SSE event.
-            A client that reconnects sends the standard <code>Last-Event-ID</code> header on a GET, and
-            the server replays the messages that were sent after that event on the disconnected stream.
-            Disconnection is explicitly <em>not</em> cancellation: a client that wants to abort a
-            request sends a <code>notifications/cancelled</code> message rather than just hanging up.
-          </p>
-
-          <h3 className="mt-4">Backwards compatibility: the deprecated HTTP+SSE transport</h3>
-          <p>
-            Protocol version <code>2024-11-05</code> used a two-endpoint design: the client opened an
-            SSE stream via GET, received an <code>endpoint</code> event naming a separate POST URL, and
-            sent all messages there. You will still encounter servers built this way. Clients detect
-            the old transport by first POSTing an <code>initialize</code> request to the URL: if it
-            fails with 4xx, they fall back to a GET expecting the <code>endpoint</code> event. This
-            playground performs the same fallback automatically, so both generations of servers can be
-            tested.
+            The original <code>2024-11-05</code> HTTP+SSE transport uses two endpoints: a client opens
+            a GET stream, receives an <code>endpoint</code> event, and sends messages to the advertised
+            POST URL. It is deprecated, but mcptest.io keeps it as a final fallback for deployed servers.
+            An explicit URL is always tested before conventional path guesses such as <code>/mcp</code>
+            or <code>/sse</code>.
           </p>
 
           <h2 className="mt-5">Authorization</h2>
           <p>
-            Authorization is optional in MCP, but any remote server exposing non-public data needs it.
-            The specification standardizes on OAuth 2.1: the MCP server acts as
-            a <strong>resource server</strong> that accepts Bearer tokens, and an authorization server —
-            which may be the same deployment or a third-party identity provider — issues them. The flow
-            a compliant client walks through is fully discoverable, with no manual configuration:
-          </p>
-          <ol>
-            <li>The client makes an unauthenticated request and receives <code>401 Unauthorized</code>. The <code>WWW-Authenticate</code> header can point at the server's <strong>protected resource metadata</strong> (RFC 9728); otherwise the client falls back to the well-known URI, e.g. <code>/.well-known/oauth-protected-resource</code>.</li>
-            <li>That metadata names one or more authorization servers. The client fetches the authorization server's own metadata via OAuth 2.0 Authorization Server Metadata (RFC 8414) or OpenID Connect Discovery.</li>
-            <li>The client identifies itself — via a pre-registered client ID, an OAuth Client ID Metadata Document (an HTTPS URL serving the client's metadata, new in <code>2025-11-25</code>), or Dynamic Client Registration (RFC 7591).</li>
-            <li>The client runs the authorization code flow with PKCE (the <code>S256</code> method is mandatory), including the RFC 8707 <code>resource</code> parameter that binds the requested token to this specific MCP server's canonical URI.</li>
-            <li>Every subsequent request carries <code>Authorization: Bearer &lt;token&gt;</code> — on every request, never in the query string.</li>
-          </ol>
-          <p>
-            On the server side, the non-negotiable rules are: serve protected resource metadata; validate
-            that each token was issued <em>for you</em> (audience validation), not merely that it is
-            valid; return <code>401</code> for missing or invalid tokens and <code>403</code> with
-            an <code>insufficient_scope</code> challenge when a token lacks the scopes an operation
-            needs; and never pass a token you received from a client through to an upstream API. Token
-            passthrough is explicitly forbidden by the specification because it creates confused-deputy
-            vulnerabilities.
+            Remote MCP authorization uses the OAuth 2.1 resource-server model. A protected MCP endpoint
+            returns <code>401 Unauthorized</code> and points the client to protected-resource metadata.
+            That metadata names the authorization server; the client discovers its metadata, identifies
+            itself, and runs authorization code with PKCE and an RFC 8707 <code>resource</code> value
+            bound to the MCP server.
           </p>
           <p>
-            This playground implements the full client side of this flow — discovery, registration,
-            PKCE, token refresh — which makes it a practical way to verify your authorization
-            implementation end to end. See the <Link to="/docs/testing-guide">testing guide</Link> for
-            the workflow.
+            Servers must validate issuer, audience, expiry, and scopes rather than accepting any token
+            that happens to be structurally valid. The 2026 revision requires authorization-response
+            issuer validation when an <code>iss</code> value is returned, binds client credentials to
+            their issuer, and deprecates Dynamic Client Registration in favor of Client ID Metadata
+            Documents. Bearer tokens belong in the <code>Authorization</code> header, never a query
+            string, and an MCP server must not pass a client token through to an unrelated upstream API.
+          </p>
+          <p>
+            mcptest.io supports discovered OAuth with PKCE as well as explicit bearer tokens and API
+            keys for servers that use provider-specific authentication. When its optional CORS proxy is
+            enabled, Firebase authenticates the proxy hop and the target credential is carried through
+            a separate internal header; the two trust boundaries are not conflated.
           </p>
 
-          <h2 className="mt-5">Security requirements</h2>
+          <h2 className="mt-5">CORS and origin security</h2>
           <p>
-            The transport specification imposes hard requirements on remote servers beyond
-            authorization. Servers <strong>must</strong> validate the <code>Origin</code> header on all
-            incoming connections and answer <code>403 Forbidden</code> when it is present and invalid;
-            this is the defense against DNS-rebinding attacks, where a malicious web page tricks a
-            browser into speaking to a server it shouldn't reach. Servers intended to run locally
-            should bind to <code>127.0.0.1</code> rather than <code>0.0.0.0</code>. Production
-            deployments must use HTTPS everywhere, keep tokens and session IDs out of logs and URLs,
-            and apply rate limiting — an MCP endpoint that executes tools is a more attractive target
-            than a typical JSON API.
+            A browser client needs the server to allow <code>Content-Type</code>, <code>Accept</code>,{' '}
+            <code>Authorization</code>, <code>x-api-key</code>, <code>MCP-Protocol-Version</code>,{' '}
+            <code>Mcp-Method</code>, and <code>Mcp-Name</code>. A 2025 stateful endpoint must additionally
+            allow <code>Mcp-Session-Id</code> and <code>Last-Event-ID</code>, and expose{' '}
+            <code>Mcp-Session-Id</code> so browser code can read it. Only allow the headers and origins
+            your deployment actually uses.
           </p>
           <p>
-            One practical consequence of MCP's browser reachability: if you want browser-based clients
-            (including this one) to connect directly, your server must also send CORS headers, and it
-            must expose the <code>Mcp-Session-Id</code> header to scripts
-            via <code>Access-Control-Expose-Headers</code>. CORS is not part of the MCP specification —
-            it is a browser requirement — but omitting it is one of the most common reasons a remote
-            server "works in curl but not in the browser". The{' '}
-            <Link to="/docs/troubleshooting">troubleshooting guide</Link> covers this in detail.
+            CORS is a browser control, not MCP authorization. Remote servers must still validate the
+            incoming <code>Origin</code> and reject disallowed origins. Local HTTP servers should bind to
+            loopback rather than all interfaces. Production endpoints need HTTPS, rate limits, careful
+            credential redaction, request-size limits, and tool-level authorization.
           </p>
 
-          <h2 className="mt-5">Choosing a transport</h2>
-          <p>
-            The decision usually makes itself. If the server's job is to act on the user's own machine,
-            use stdio. If the server fronts a shared service, an API, or data that lives on the
-            network — or if you want users to connect without installing anything — build a remote
-            server on Streamable HTTP. Many production systems do both: a thin stdio server for local
-            development and a hosted Streamable HTTP deployment for everyone else, sharing the same tool
-            implementations behind the transport layer.
-          </p>
+          <h2 className="mt-5">Choosing and testing a deployment</h2>
           <div className="table-responsive">
             <table className="table">
               <thead>
                 <tr>
                   <th>Aspect</th>
-                  <th>stdio (local)</th>
-                  <th>Streamable HTTP (remote)</th>
+                  <th>stdio</th>
+                  <th>HTTP 2026</th>
+                  <th>HTTP 2025</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <td>Process model</td>
-                  <td>Subprocess per client</td>
-                  <td>One service, many clients</td>
+                  <td>Usually one subprocess per client</td>
+                  <td>Shared service; any request can reach any instance</td>
+                  <td>Shared service; sessions may require storage or affinity</td>
                 </tr>
                 <tr>
-                  <td>Message framing</td>
-                  <td>Newline-delimited JSON-RPC on stdin/stdout</td>
-                  <td>JSON-RPC over HTTP POST, responses as JSON or SSE</td>
+                  <td>Lifecycle</td>
+                  <td>Depends on negotiated era</td>
+                  <td>Self-describing requests; optional discovery</td>
+                  <td>Initialize once; retain negotiated state</td>
                 </tr>
                 <tr>
-                  <td>Sessions</td>
-                  <td>Implicit in the process lifetime</td>
-                  <td><code>Mcp-Session-Id</code> header, explicit lifecycle</td>
+                  <td>Credentials</td>
+                  <td>Usually environment or host-managed</td>
+                  <td colSpan={2}>OAuth bearer token, API key, or public endpoint</td>
                 </tr>
                 <tr>
-                  <td>Authentication</td>
-                  <td>Environment credentials</td>
-                  <td>OAuth 2.1 Bearer tokens</td>
-                </tr>
-                <tr>
-                  <td>Server-initiated messages</td>
-                  <td>Written to stdout at any time</td>
-                  <td>SSE streams (per-request or via GET)</td>
-                </tr>
-                <tr>
-                  <td>Main security concerns</td>
-                  <td>Runs with the user's full permissions</td>
-                  <td>Origin validation, token audience, CORS, rate limiting</td>
+                  <td>Best fit</td>
+                  <td>Local files and developer tooling</td>
+                  <td>New scalable hosted services</td>
+                  <td>Compatibility with deployed clients and servers</td>
                 </tr>
               </tbody>
             </table>
           </div>
-
           <p className="mt-4">
-            For the normative details, see the specification's{' '}
-            <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports" target="_blank" rel="noopener noreferrer">transports</a>{' '}
-            and{' '}
-            <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization" target="_blank" rel="noopener noreferrer">authorization</a>{' '}
-            chapters. To validate a server against everything described here, continue to the{' '}
-            <Link to="/docs/testing-guide">testing guide</Link>.
+            New hosted servers should implement the stateless 2026 lifecycle. Supporting the stateful
+            era as well broadens compatibility, but its session contract must remain isolated from the
+            2026 path. Continue with the <Link to="/docs/testing-guide">testing guide</Link> to test
+            both, or use <Link to="/docs/troubleshooting">troubleshooting</Link> when negotiation fails.
+          </p>
+          <p>
+            Normative references: the{' '}
+            <a href="https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http" target="_blank" rel="noopener noreferrer">2026 Streamable HTTP transport</a>,{' '}
+            <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports" target="_blank" rel="noopener noreferrer">2025 transport</a>, and{' '}
+            <a href="https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization" target="_blank" rel="noopener noreferrer">current authorization specification</a>.
           </p>
         </div>
       </div>

--- a/src/components/docs/TestingGuide.tsx
+++ b/src/components/docs/TestingGuide.tsx
@@ -9,104 +9,122 @@ const TestingGuide: React.FC = () => {
           <h1 className="mb-4">Testing Remote MCP Servers</h1>
 
           <p className="lead">
-            A remote MCP server is only correct if a real client can walk the full protocol against it:
-            negotiate a session, discover capabilities, execute tools, and fail cleanly when given bad
-            input. This guide describes that verification process — first interactively with the
-            playground on this site, then from the command line for scripting and CI.
+            A useful MCP test proves more than reachability. It identifies the protocol era, validates
+            HTTP and JSON-RPC behavior, exercises every advertised capability, checks authentication,
+            and confirms failures are safe and actionable. This guide covers stateless 2026 servers and
+            the stateful 2025 servers still widely deployed.
           </p>
 
-          <h2 className="mt-5">What you are actually verifying</h2>
+          <h2 className="mt-5">Start with the exact endpoint</h2>
           <p>
-            Testing an MCP server is not just "does it respond". A server that answers requests can
-            still break clients by mishandling sessions, advertising capabilities it doesn't implement,
-            returning malformed tool results, or omitting the HTTP behaviors the transport specification
-            requires. A useful test pass covers four layers: the <strong>transport contract</strong>{' '}
-            (HTTP methods, headers, status codes, streaming), the <strong>protocol lifecycle</strong>{' '}
-            (initialization, version negotiation, session management), the <strong>capabilities</strong>{' '}
-            themselves (tools, resources, prompts and their schemas), and <strong>failure behavior</strong>{' '}
-            (invalid input, expired sessions, missing auth). The sections below work through each.
+            Use the complete published MCP URL, including its path, for example{' '}
+            <code>https://your-server.example.com/custom/mcp</code>. mcptest.io tries that exact URL
+            first, then conventional path fallbacks only when needed. A valid auth challenge means the
+            service is reachable but does not, by itself, prove that anonymous MCP negotiation passed.
           </p>
 
-          <h2 className="mt-5">Interactive testing with the playground</h2>
+          <h2 className="mt-5">Interactive testing in the playground</h2>
           <p>
-            Enter your server's MCP endpoint URL (for
-            example <code>https://your-server.example.com/mcp</code>) in the playground and connect.
-            The playground is a spec-compliant Streamable HTTP client running in your browser: it sends
-            the <code>initialize</code> request with the proper <code>Accept</code> headers, completes
-            the handshake with <code>notifications/initialized</code>, captures
-            the <code>Mcp-Session-Id</code> header if your server issues one, and attaches the
-            negotiated <code>MCP-Protocol-Version</code> to every subsequent request. If the endpoint
-            turns out to be a legacy HTTP+SSE server (protocol <code>2024-11-05</code>), it falls back
-            to that transport automatically. Every request and response is shown in the message log, so
-            you can inspect the exact JSON-RPC traffic rather than guessing at what happened.
+            Enter the endpoint and connect. The playground first probes with{' '}
+            <code>server/discover</code>. If the server offers <code>2026-07-28</code>, the client uses
+            stateless, self-describing requests. If the endpoint is 2025-only, it falls back to{' '}
+            <code>initialize</code>, sends <code>notifications/initialized</code>, and preserves a
+            server-issued <code>Mcp-Session-Id</code>. The deprecated HTTP+SSE transport is the last
+            fallback. Authentication responses are surfaced instead of being misclassified as an old
+            protocol.
           </p>
           <p>
-            The first thing to check after connecting is the initialization result: does the server
-            report the protocol version you expect, and does its advertised capability set match what
-            it actually implements? Capability mismatches — advertising <code>resources</code> but
-            returning "method not found" for <code>resources/list</code> — are among the most common
-            interoperability bugs, because most SDK quickstarts enable capabilities wholesale.
+            Check the connection log before testing features. For a stateless server, confirm the
+            negotiated version and that discovery capabilities match reality. For a stateful server,
+            confirm the initialization result, selected version, capabilities, and any session header.
+            The same client API then lists and invokes capabilities in either era.
           </p>
+
+          <h3 className="mt-4">Capabilities</h3>
+          <ul>
+            <li><strong>Tools:</strong> inspect every input schema, call each tool with representative valid input, and compare structured output with its declared schema.</li>
+            <li><strong>Negative tool calls:</strong> try missing required fields, wrong types, bounds, unexpected properties, unusual Unicode, and large inputs. Recoverable tool failures should normally return a tool result with <code>isError: true</code>, not crash the transport.</li>
+            <li><strong>Resources:</strong> list and read several URIs; verify MIME types, text versus base64 content, templates, pagination, and authorization boundaries.</li>
+            <li><strong>Prompts:</strong> list templates, exercise required and optional arguments, and verify the returned messages and roles.</li>
+            <li><strong>2026 caches:</strong> where list results provide <code>ttlMs</code> and <code>cacheScope</code>, verify they reflect the data&apos;s real freshness and privacy boundary.</li>
+            <li><strong>2026 multi-round trips:</strong> exercise calls that return <code>input_required</code>, then verify the retried request carries the expected <code>inputResponses</code> and request state.</li>
+          </ul>
+
+          <h3 className="mt-4">Authentication</h3>
           <p>
-            <strong>Tools.</strong> List the server's tools and review each declared input schema —
-            names, types, required fields, descriptions. The playground renders a form from the schema,
-            which is itself a useful test: if the form looks wrong, an LLM will misuse the tool the same
-            way. Call each tool with representative valid input and confirm the result content is
-            well-formed; if the tool declares an output schema, check the structured result validates
-            against it. Then deliberately send wrong input — missing required fields, wrong types,
-            out-of-range values. Since spec <code>2025-06-18</code> era guidance, input validation
-            failures should come back as <em>tool execution errors</em> (a result
-            with <code>isError: true</code> and a message the model can read and correct from), not as
-            JSON-RPC protocol errors, and definitely not as unhandled exceptions that kill the session.
-          </p>
-          <p>
-            <strong>Resources and prompts.</strong> List resources and read a few, verifying URIs, MIME
-            types, and content encoding (text vs. base64 blobs). If the server exposes resource
-            templates, expand them with edge-case parameters — special characters, very long values.
-            For prompts, fetch each with valid and missing arguments and confirm the returned messages
-            are coherent. If the server declares subscription support, subscribe to a resource and
-            verify a change actually produces a notification; this exercises the server's GET-based SSE
-            stream, which otherwise goes untested.
-          </p>
-          <p>
-            <strong>Streaming.</strong> If your server streams responses (SSE mode) for long-running
-            tools, watch the message log during a slow call: progress notifications should arrive while
-            the call runs, and the final JSON-RPC response should terminate the stream. Test what
-            happens when you cancel mid-call and when the connection drops — a resumable server replays
-            missed events when the client reconnects with <code>Last-Event-ID</code>.
-          </p>
-          <p>
-            <strong>Authorization.</strong> Connecting to a protected server exercises the entire OAuth
-            2.1 flow described in{' '}
-            <Link to="/docs/remote-vs-local">Remote vs. Local MCP Servers</Link>: the playground reacts
-            to your <code>401</code>, discovers the protected resource metadata and authorization
-            server, registers or identifies itself, and runs the authorization code flow with PKCE in a
-            popup. This end-to-end path is hard to test any other way short of writing a client, and it
-            fails loudly at whichever step your server gets wrong — missing metadata, bad issuer URLs,
-            PKCE not supported, or tokens rejected after issuance. Also verify the negative cases: the
-            server must reject requests with no token and with a token issued for a different resource.
-          </p>
-          <p>
-            Once a server checks out, you can save tool calls to a dashboard to re-run them later as a
-            regression check, and share links to specific results with your team.
+            For OAuth servers, start without credentials. A correct <code>401</code> should lead to
+            protected-resource metadata, authorization-server metadata, client identification, and an
+            authorization-code flow with PKCE. After sign-in, verify that the token is accepted only by
+            its intended MCP resource and that insufficient scopes produce a useful{' '}
+            <code>403</code> challenge. For provider-specific servers, select bearer token or API key
+            and verify both valid and invalid credentials.
           </p>
 
           <div className="alert alert-info mt-4" role="alert">
-            <strong>Browser clients need CORS.</strong> Because the playground runs in your browser,
-            your server must send CORS headers: allow the origin, allow
-            the <code>Content-Type</code>, <code>Accept</code>, <code>Authorization</code>,{' '}
-            <code>Mcp-Session-Id</code> and <code>MCP-Protocol-Version</code> request headers, and
-            expose <code>Mcp-Session-Id</code> via <code>Access-Control-Expose-Headers</code> —
-            otherwise the client cannot read the session ID and every request after initialization
-            fails. See <Link to="/docs/troubleshooting">troubleshooting</Link> for a working
-            configuration.
+            <strong>Browser clients need CORS.</strong> Allow <code>Content-Type</code>,{' '}
+            <code>Accept</code>, <code>Authorization</code>, <code>x-api-key</code>,{' '}
+            <code>MCP-Protocol-Version</code>, <code>Mcp-Method</code>, and <code>Mcp-Name</code>. For
+            stateful 2025 support, also allow <code>Mcp-Session-Id</code> and{' '}
+            <code>Last-Event-ID</code>, and expose <code>Mcp-Session-Id</code> in responses.
           </div>
 
-          <h2 className="mt-5">Testing from the command line</h2>
+          <h2 className="mt-5">Command-line check: stateless 2026</h2>
           <p>
-            For scripted checks and CI, curl against the MCP endpoint directly. Initialization is a
-            plain POST — note the dual <code>Accept</code> header the transport requires, and
-            the <code>-i</code> flag so you can see whether the server issues a session ID:
+            A 2026 server must implement <code>server/discover</code>. The client call is optional, but
+            it is the clearest compatibility probe. Include the version and method headers plus the
+            required per-request metadata:
+          </p>
+          <pre className="bg-light p-3 rounded"><code>{`curl -i https://your-server.example.com/mcp \\
+  -H "Content-Type: application/json" \\
+  -H "Accept: application/json, text/event-stream" \\
+  -H "MCP-Protocol-Version: 2026-07-28" \\
+  -H "Mcp-Method: server/discover" \\
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "discover-1",
+    "method": "server/discover",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {
+          "name": "curl-check",
+          "version": "1.0.0"
+        },
+        "io.modelcontextprotocol/clientCapabilities": {}
+      }
+    }
+  }'`}</code></pre>
+          <p>
+            A successful result advertises supported versions and capabilities. There is no initialized
+            notification and no session header to retain. Test an ordinary request independently:
+          </p>
+          <pre className="bg-light p-3 rounded"><code>{`curl -i https://your-server.example.com/mcp \\
+  -H "Content-Type: application/json" \\
+  -H "Accept: application/json, text/event-stream" \\
+  -H "MCP-Protocol-Version: 2026-07-28" \\
+  -H "Mcp-Method: tools/list" \\
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list",
+    "params": {
+      "_meta": {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {}
+      }
+    }
+  }'`}</code></pre>
+          <p>
+            For <code>tools/call</code>, add <code>Mcp-Name: &lt;tool-name&gt;</code>. Do the same with the
+            resource URI for <code>resources/read</code> and prompt name for <code>prompts/get</code>.
+            Confirm a missing method header, a missing required name header, or a mismatch between the
+            header and body metadata is rejected rather than silently routed.
+          </p>
+
+          <h2 className="mt-5">Command-line check: stateful 2025</h2>
+          <p>
+            A 2025-only server begins with initialization. Keep <code>-i</code> so the response headers
+            reveal whether it issued a session ID:
           </p>
           <pre className="bg-light p-3 rounded"><code>{`curl -i https://your-server.example.com/mcp \\
   -H "Content-Type: application/json" \\
@@ -118,62 +136,50 @@ const TestingGuide: React.FC = () => {
     "params": {
       "protocolVersion": "2025-11-25",
       "capabilities": {},
-      "clientInfo": { "name": "curl", "version": "1.0" }
+      "clientInfo": { "name": "curl-check", "version": "1.0.0" }
     }
   }'`}</code></pre>
           <p>
-            A compliant server answers with the <code>InitializeResult</code> — either as
-            plain JSON or as an SSE stream containing it — and, if stateful,
-            an <code>Mcp-Session-Id</code> response header. Complete the handshake and then exercise
-            the API, carrying the session ID and protocol version on every request:
+            Complete the handshake and carry the negotiated version and session ID on later requests:
           </p>
-          <pre className="bg-light p-3 rounded"><code>{`# The initialized notification must return 202 Accepted
+          <pre className="bg-light p-3 rounded"><code>{`# Use the Mcp-Session-Id returned above when the server issued one.
 curl -i https://your-server.example.com/mcp \\
   -H "Content-Type: application/json" \\
   -H "Accept: application/json, text/event-stream" \\
-  -H "Mcp-Session-Id: $SESSION_ID" \\
   -H "MCP-Protocol-Version: 2025-11-25" \\
+  -H "Mcp-Session-Id: $SESSION_ID" \\
   -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
 
-# List and call tools
-curl https://your-server.example.com/mcp \\
+curl -i https://your-server.example.com/mcp \\
   -H "Content-Type: application/json" \\
   -H "Accept: application/json, text/event-stream" \\
-  -H "Mcp-Session-Id: $SESSION_ID" \\
   -H "MCP-Protocol-Version: 2025-11-25" \\
+  -H "Mcp-Session-Id: $SESSION_ID" \\
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'`}</code></pre>
           <p>
-            From here, a conformance pass is a handful of assertions you can script:
+            Omit the session header entirely when the server did not issue one; do not send a literal
+            empty value. On a stateful implementation, verify missing IDs return 400, unknown or expired
+            IDs return 404, optional GET and DELETE return either their documented behavior or 405, and
+            concurrent sessions never leak data into one another.
           </p>
+
+          <h2 className="mt-5">Failure and production checks</h2>
           <ul>
-            <li>A request without the session ID (when one was issued) returns <code>400</code>; an unknown or expired session ID returns <code>404</code>.</li>
-            <li>A GET to the endpoint either opens an SSE stream or returns exactly <code>405</code>.</li>
-            <li>An unsupported <code>MCP-Protocol-Version</code> header value returns <code>400</code>.</li>
-            <li>A request with an invalid <code>Origin</code> header returns <code>403</code>.</li>
-            <li>On a protected server, a request without a token returns <code>401</code>, and the protected resource metadata is reachable (via the <code>WWW-Authenticate</code> header or <code>/.well-known/oauth-protected-resource</code>).</li>
-            <li>Malformed JSON and unknown methods produce proper JSON-RPC error responses (<code>-32700</code> parse error, <code>-32601</code> method not found) rather than empty bodies or 500s.</li>
+            <li>Malformed JSON returns JSON-RPC <code>-32700</code>; an unknown method returns <code>-32601</code> instead of an empty body or generic 500.</li>
+            <li>An unsupported version produces a protocol-specific error; 2026 header/body mismatches produce <code>400</code>.</li>
+            <li>An invalid <code>Origin</code> is rejected, while approved browser origins pass preflight with the exact headers they need.</li>
+            <li>Tokens are audience- and scope-checked, secrets are absent from logs and URLs, and rate limits apply at both endpoint and tool level.</li>
+            <li>Concurrent calls, cancellation, proxy timeouts, SSE buffering, deploys, and instance scaling do not corrupt state or duplicate side effects.</li>
+            <li>List ordering and cache hints remain deterministic; schema changes trigger the appropriate refresh behavior.</li>
           </ul>
 
-          <h2 className="mt-5">Beyond correctness</h2>
-          <p>
-            Once the protocol behavior is right, test the things that only show up under real
-            conditions. Run concurrent sessions and confirm state does not leak between them — session
-            isolation bugs are invisible in single-client testing. Feed tools adversarial input (path
-            traversal attempts, injection payloads, megabyte-sized strings, unusual Unicode) and verify
-            they refuse rather than crash. Measure time-to-first-byte on streamed responses, since
-            agents block on it. And check behavior at the edges of infrastructure: many streaming bugs
-            are caused not by the server but by a reverse proxy buffering SSE — worth testing through
-            your production ingress, not just against localhost.
-          </p>
-
           <p className="mt-4">
-            Useful companions to this playground:{' '}
-            <a href="https://github.com/modelcontextprotocol/inspector" target="_blank" rel="noopener noreferrer">MCP Inspector</a>{' '}
-            (the official local debugging UI, which also covers stdio servers), the{' '}
-            <a href="https://modelcontextprotocol.io/legacy/tools/debugging" target="_blank" rel="noopener noreferrer">official debugging guide</a>, and the{' '}
-            <a href="https://github.com/modelcontextprotocol/servers" target="_blank" rel="noopener noreferrer">reference server implementations</a>{' '}
-            to compare behavior against. When a test fails and the cause isn't obvious, the{' '}
-            <Link to="/docs/troubleshooting">troubleshooting guide</Link> maps symptoms to causes.
+            The official <a href="https://github.com/modelcontextprotocol/inspector" target="_blank" rel="noopener noreferrer">MCP Inspector</a>{' '}
+            is a useful second client, especially for stdio. For wire-level expectations use the{' '}
+            <a href="https://modelcontextprotocol.io/specification/2026-07-28" target="_blank" rel="noopener noreferrer">current specification</a>{' '}
+            and the TypeScript SDK&apos;s{' '}
+            <a href="https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/protocol-versions.md" target="_blank" rel="noopener noreferrer">protocol-version guide</a>.
+            When a check fails, continue to <Link to="/docs/troubleshooting">troubleshooting</Link>.
           </p>
         </div>
       </div>

--- a/src/components/docs/Troubleshooting.tsx
+++ b/src/components/docs/Troubleshooting.tsx
@@ -9,201 +9,186 @@ const Troubleshooting: React.FC = () => {
           <h1 className="mb-4">Troubleshooting Remote MCP Servers</h1>
 
           <p className="lead">
-            Most remote MCP failures fall into a small number of categories: CORS, HTTP status
-            mishandling, session lifecycle bugs, streaming infrastructure, and OAuth. This guide is
-            organized by symptom. Throughout, the fastest diagnostic tool is your browser's network tab
-            (or <code>curl -i</code>): look at the actual status code and headers before theorizing.
+            Start with the actual HTTP exchange: endpoint, status, response headers, protocol era, and
+            JSON-RPC body. Most failures then collapse into one of six buckets—wrong URL, 2026 routing
+            metadata, 2025 session state, CORS, streaming infrastructure, or authorization.
           </p>
 
-          <h2 className="mt-5">The connection fails immediately</h2>
+          <h2 className="mt-5">The endpoint cannot be reached</h2>
           <p>
-            If the client cannot reach the server at all, work outward from the URL. The endpoint must
-            be the full MCP endpoint path — servers built with the official SDKs typically serve
-            at <code>/mcp</code>, and POSTing to the bare domain returns <code>404</code>. Verify with
-            curl that the endpoint answers an <code>initialize</code> POST (see the{' '}
-            <Link to="/docs/testing-guide">testing guide</Link> for the exact request). If curl works
-            but the browser doesn't, it is almost always CORS — see the next section. If neither works,
-            check TLS (browser clients require valid HTTPS certificates; self-signed certs fail
-            silently in fetch), DNS, and whether the process is actually listening on the port your
-            ingress forwards to.
+            Test the full published endpoint, not only the origin. A server may be mounted at{' '}
+            <code>/mcp</code>, a tenant path, or a completely custom route. mcptest.io preserves an
+            explicit path and tests it first; conventional <code>/mcp</code> and <code>/sse</code> paths
+            are fallbacks. A bare origin returning 404 therefore says little about a custom endpoint.
           </p>
           <p>
-            A <code>404</code> from a server you know is running can also mean the server is a legacy
-            HTTP+SSE implementation (protocol <code>2024-11-05</code>). Spec-compliant clients,
-            including this playground, react to a failed <code>initialize</code> POST by attempting a
-            GET and looking for an <code>endpoint</code> SSE event. If your server is legacy and
-            clients still can't connect, confirm the GET actually returns that event as its first
-            message.
+            Use <code>curl -i</code> with the stateless discovery or stateful initialization request from
+            the <Link to="/docs/testing-guide">testing guide</Link>. If neither reaches the application,
+            check DNS, TLS, ingress path rewrites, request-size limits, and whether the process is bound
+            to the forwarded port. A <code>401</code> or <code>403</code> proves the endpoint is reachable;
+            it is an authentication outcome, not evidence that the server is stateful or broken.
           </p>
 
-          <h2 className="mt-5">Works in curl, fails in the browser: CORS</h2>
+          <h2 className="mt-5">2026 discovery or requests fail</h2>
           <p>
-            Browsers enforce the same-origin policy; curl does not. When a browser-based client (like
-            this playground) calls your server, the browser first sends a
-            preflight <code>OPTIONS</code> request, and it will only expose response headers that your
-            server explicitly allows. The failure modes are distinctive: the network tab shows the
-            request blocked or the preflight failing, and the console logs a CORS policy error while
-            the server logs show nothing wrong.
+            A <code>2026-07-28</code> server must implement <code>server/discover</code>, although clients
+            do not have to call it before other operations. Each request must carry{' '}
+            <code>io.modelcontextprotocol/protocolVersion</code> and{' '}
+            <code>io.modelcontextprotocol/clientCapabilities</code> in <code>params._meta</code>. On HTTP,
+            it also needs <code>MCP-Protocol-Version</code> and <code>Mcp-Method</code>; named calls need
+            <code>Mcp-Name</code>. The header version and body version must match.
           </p>
           <p>
-            Three things must all be configured. The server must allow the client's origin; it must
-            allow the request headers MCP uses; and — the one everyone misses — it must{' '}
-            <em>expose</em> <code>Mcp-Session-Id</code> so the client can read it from the
-            initialization response. If that header is not exposed, connection appears to succeed but
-            every subsequent request fails with <code>400</code>, because the client never saw the
-            session ID. An Express example:
+            If discovery succeeds but the next request gets 400, compare those fields character for
+            character and inspect gateway logs. Proxies often drop unfamiliar headers unless they are
+            explicitly allowed. If a gateway routes on <code>Mcp-Method</code> or <code>Mcp-Name</code>,
+            verify it forwards the same request unchanged. Do not add <code>Mcp-Session-Id</code> or send
+            an initialization notification on the 2026 path; both belong to the older lifecycle.
+          </p>
+
+          <h2 className="mt-5">2025 initialization or sessions fail</h2>
+          <p>
+            Revisions through <code>2025-11-25</code> begin with <code>initialize</code>, followed by{' '}
+            <code>notifications/initialized</code>. If the response includes{' '}
+            <code>Mcp-Session-Id</code>, preserve it exactly and attach it to the notification and every
+            later request. The common symptoms are:
+          </p>
+          <ul>
+            <li><strong>400 after initialization:</strong> the client lost the session ID, CORS hid it, or the server issued it too late.</li>
+            <li><strong>Intermittent 404:</strong> session state is in one instance&apos;s memory and requests are reaching another, or the server expired the session.</li>
+            <li><strong>Tabs affect one another:</strong> the server is keying state on IP or a global variable rather than the opaque session ID.</li>
+            <li><strong>DELETE or GET returns 405:</strong> this can be valid because explicit termination and the standalone SSE stream are optional.</li>
+          </ul>
+          <p>
+            A client should establish a new session after an expired-ID 404. A server should use secure,
+            unpredictable IDs and either shared storage or deliberate affinity when it scales out.
+          </p>
+
+          <h2 className="mt-5">Works in curl, fails in a browser</h2>
+          <p>
+            That pattern is usually CORS. The browser&apos;s preflight must allow the app&apos;s origin and every
+            non-simple header the chosen protocol and authentication mode use. For an Express server
+            supporting both eras:
           </p>
           <pre className="bg-light p-3 rounded"><code>{`import cors from 'cors';
 
 app.use(cors({
   origin: ['https://mcptest.io', 'http://localhost:5173'],
   allowedHeaders: [
-    'Content-Type', 'Accept', 'Authorization',
-    'Mcp-Session-Id', 'MCP-Protocol-Version', 'Last-Event-ID'
+    'Content-Type',
+    'Accept',
+    'Authorization',
+    'x-api-key',
+    'MCP-Protocol-Version',
+    'Mcp-Method',
+    'Mcp-Name',
+    'Mcp-Session-Id',
+    'Last-Event-ID'
   ],
   exposedHeaders: ['Mcp-Session-Id']
 }));`}</code></pre>
           <p>
-            Remember that CORS is a browser mechanism layered on top of MCP, not a substitute for the
-            transport's own security rules: your server must still validate
-            the <code>Origin</code> header and return <code>403</code> for origins it does not trust,
-            which is the specification's defense against DNS rebinding.
+            Exposing <code>Mcp-Session-Id</code> matters only to stateful 2025 responses, but omitting it
+            makes initialization appear successful while every later call fails. CORS does not replace
+            authorization or MCP&apos;s origin checks. Keep the production origin list narrow and reject
+            untrusted <code>Origin</code> values.
+          </p>
+          <p>
+            If you use mcptest.io&apos;s optional proxy, sign-in authenticates the proxy itself. OAuth bearer
+            tokens or API keys authenticate only the target MCP server. A 401 from the proxy and a 401
+            from the target have different remedies; inspect the response and message log before
+            refreshing target credentials.
           </p>
 
-          <h2 className="mt-5">Decoding HTTP status codes</h2>
-          <p>
-            The Streamable HTTP transport assigns specific meanings to status codes, so an error status
-            from a compliant server is a strong hint:
-          </p>
+          <h2 className="mt-5">HTTP status decoder</h2>
           <div className="table-responsive">
             <table className="table">
               <thead>
                 <tr>
-                  <th style={{ whiteSpace: 'nowrap' }}>Status</th>
-                  <th>Meaning in MCP terms</th>
+                  <th>Status</th>
+                  <th>Likely meaning</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <td><code>400</code></td>
-                  <td>Malformed request — most often a missing <code>Mcp-Session-Id</code> header on a stateful server, or an invalid/unsupported <code>MCP-Protocol-Version</code> header.</td>
+                  <td>Malformed transport request: 2026 metadata/header mismatch, missing routing header, invalid version header, or a missing required 2025 session ID.</td>
                 </tr>
                 <tr>
                   <td><code>401</code></td>
-                  <td>Authorization required or the token is invalid/expired. The <code>WWW-Authenticate</code> header should point at the protected resource metadata; a client is expected to start (or redo) the OAuth flow.</td>
+                  <td>Authentication is required or the token is invalid or expired. Inspect <code>WWW-Authenticate</code> and protected-resource metadata.</td>
                 </tr>
                 <tr>
                   <td><code>403</code></td>
-                  <td>The <code>Origin</code> header failed validation, or the token lacks required scopes (<code>error="insufficient_scope"</code> in <code>WWW-Authenticate</code>).</td>
+                  <td>Origin rejected, token lacks scope, API key lacks permission, or a policy blocks this method or named capability.</td>
                 </tr>
                 <tr>
                   <td><code>404</code></td>
-                  <td>On a request carrying a session ID: the session has expired or been terminated. The correct client reaction is to re-initialize, not retry.</td>
+                  <td>Wrong route, or—when a 2025 session header is present—an expired or unknown session.</td>
                 </tr>
                 <tr>
                   <td><code>405</code></td>
-                  <td>Normal for GET if the server offers no standalone SSE stream, and for DELETE if it doesn't support client-initiated session termination. Only a bug if POST itself returns it — then you're hitting the wrong path.</td>
+                  <td>Wrong endpoint for POST. In the 2025 era it can be a valid answer to optional GET or DELETE.</td>
                 </tr>
                 <tr>
                   <td><code>406</code></td>
-                  <td>The <code>Accept</code> header is wrong. Clients must offer both <code>application/json</code> and <code>text/event-stream</code> on POST.</td>
+                  <td>The requested response media types are unsupported; 2025 Streamable HTTP clients offer JSON and SSE on POST.</td>
                 </tr>
                 <tr>
                   <td><code>202</code></td>
-                  <td>Not an error — the required response to notifications and client responses, with an empty body. Treating it as a failure (or returning a body with it) is a client/server bug respectively.</td>
+                  <td>Normal empty acceptance for a 2025 notification or client response, not a failure.</td>
                 </tr>
               </tbody>
             </table>
           </div>
 
-          <h2 className="mt-5">Session problems</h2>
+          <h2 className="mt-5">SSE responses hang or arrive all at once</h2>
           <p>
-            The session contract trips up hand-rolled servers. Symptoms and causes: every request after
-            initialization returns <code>400</code> — the client isn't sending the session header back,
-            usually because CORS hides it (see above) or because the server expects it on
-            the <code>initialized</code> notification but assigned it too late. Requests randomly start
-            failing with <code>404</code> mid-session — the server expired the session (restart,
-            deployment, in-memory session store behind a load balancer without sticky routing); the
-            client must transparently re-initialize. Two browser tabs interfere with each other — the
-            server is keying sessions on something other than the session ID, such as the client IP.
-            When running multiple server instances, session state must live somewhere shared (or use
-            sticky sessions), or every scaled-out deployment becomes an intermittent <code>404</code>{' '}
-            generator.
+            Reverse proxies and compression middleware commonly buffer SSE. Disable buffering on the
+            route, avoid compressing event streams, and review idle timeouts from the application
+            through the public ingress. Send correctly framed events and flush them after each message.
+          </p>
+          <p>
+            Interpret disconnects by protocol era. In 2026, closing a per-request SSE response cancels
+            that request, and continuing notifications use <code>subscriptions/listen</code>. In 2025,
+            a dropped stream is not automatically cancellation; resumable servers may accept{' '}
+            <code>Last-Event-ID</code>, and explicit <code>notifications/cancelled</code> carries client
+            cancellation. Applying one era&apos;s rule to the other can create duplicate work or jobs that
+            never stop.
           </p>
 
-          <h2 className="mt-5">Streaming and SSE issues</h2>
+          <h2 className="mt-5">OAuth discovery or token exchange fails</h2>
           <p>
-            When tool calls hang, progress notifications never arrive, or responses appear only when
-            the connection closes, suspect the infrastructure between client and server before the
-            server itself. Reverse proxies buffer by default: for nginx you
-            need <code>proxy_buffering off</code> (or the server can send
-            an <code>X-Accel-Buffering: no</code> header), and compression middleware must not gzip
-            SSE responses — buffering plus compression means events sit in a buffer until the stream
-            ends. Idle timeouts on proxies and load balancers will also sever long-lived streams;
-            either raise them, send periodic keep-alive comments, or implement resumability so clients
-            recover. Note that since protocol <code>2025-11-25</code>, servers may intentionally close
-            SSE connections and expect clients to poll by reconnecting — a disconnect is not an error,
-            and clients should reconnect with <code>Last-Event-ID</code> rather than surfacing a
-            failure. Conversely, a client that disappears is not a cancellation: honor
-            explicit <code>notifications/cancelled</code> messages instead of tying work to connection
-            lifetime.
+            After a 401, verify that <code>WWW-Authenticate</code> or the well-known URI leads to
+            protected-resource metadata and that its authorization-server URLs are correct. Browser
+            clients must also be able to read these metadata documents through CORS. Confirm the
+            authorization server advertises PKCE <code>S256</code>, the redirect URI matches exactly,
+            and the client sends the RFC 8707 <code>resource</code> value for the canonical MCP URI.
+          </p>
+          <p>
+            If login succeeds but the MCP endpoint rejects the token, compare issuer, audience,
+            resource URI, expiry, and scopes. The 2026 authorization flow also validates the returned
+            authorization issuer and must not reuse client credentials across issuers. Prefer Client ID
+            Metadata Documents for new clients; Dynamic Client Registration is deprecated in 2026.
           </p>
 
-          <h2 className="mt-5">OAuth and authorization failures</h2>
+          <h2 className="mt-5">JSON-RPC and capability errors</h2>
           <p>
-            Because the MCP authorization flow is discovery-driven, most failures happen before any
-            login screen appears. If a client reports it cannot find authorization details after
-            a <code>401</code>, check that your protected resource metadata is actually reachable:
-            either the <code>WWW-Authenticate</code> header carries a valid <code>resource_metadata</code>{' '}
-            URL, or the well-known document exists
-            (<code>/.well-known/oauth-protected-resource</code>, optionally suffixed with the MCP
-            endpoint path) and lists your authorization server in <code>authorization_servers</code>.
-            The metadata endpoints themselves must be CORS-readable for browser clients — a common gap,
-            since they are often served by an auth library that doesn't share the MCP endpoint's CORS
-            configuration.
-          </p>
-          <p>
-            If discovery succeeds but the flow fails, the classic OAuth errors apply, each with an MCP
-            twist. <code>invalid_client</code> or a rejected registration usually means the
-            authorization server supports neither Dynamic Client Registration nor Client ID Metadata
-            Documents, leaving clients no way to identify themselves without
-            pre-registration. <code>redirect_uri_mismatch</code> means the client's callback URL isn't
-            registered. A client refusing to proceed because PKCE support is not advertised means your
-            authorization server metadata omits <code>code_challenge_methods_supported</code> — clients
-            are required to abort in that case. And if the flow completes but the MCP server still
-            rejects the token, check audience validation from both directions: the client must send
-            the RFC 8707 <code>resource</code> parameter naming your server's canonical URI, and your
-            server must be validating tokens against that same identifier. Mismatched canonical URIs
-            (trailing slashes, http vs. https, missing path) are a frequent silent culprit.
-          </p>
-
-          <h2 className="mt-5">Protocol-level errors</h2>
-          <p>
-            JSON-RPC error codes surface application-level problems: <code>-32700</code> means the
-            server couldn't parse your JSON, <code>-32601</code> means the method doesn't exist (often
-            a capability the server advertises but never implemented — compare
-            the <code>initialize</code> result against reality), and <code>-32602</code> flags invalid
-            parameters. One subtlety worth fixing on the server side: a tool that receives bad
-            arguments should generally return a successful JSON-RPC response whose result
-            has <code>isError: true</code> and a descriptive message, rather than a protocol error —
-            execution errors are visible to the model, which lets it correct its own tool call, while
-            protocol errors are not. Version mismatches show up as failed initialization: a compliant
-            server counters with the newest version it supports when it doesn't support the client's,
-            and only fails if there is genuinely no overlap, while missing <code>MCP-Protocol-Version</code>{' '}
-            headers on later requests make servers assume <code>2025-03-26</code> — which can
-            mysteriously disable newer features.
+            <code>-32700</code> means invalid JSON, <code>-32601</code> means the method is absent, and{' '}
+            <code>-32602</code> means invalid parameters. If a server advertises tools, resources, or
+            prompts but their list methods return method-not-found, fix the advertised capabilities.
+            Tool input and execution failures that a model can correct should normally be returned as a
+            tool result with <code>isError: true</code>; reserve protocol errors for protocol failures.
           </p>
 
           <h2 className="mt-5">Still stuck?</h2>
           <p>
-            Reproduce the failure in the playground with the message log open — the raw request and
-            response usually identify the failing layer immediately. For protocol questions, the{' '}
-            <a href="https://modelcontextprotocol.io/specification/2025-11-25" target="_blank" rel="noopener noreferrer">specification</a>{' '}
-            is precise and readable, and the{' '}
-            <a href="https://github.com/orgs/modelcontextprotocol/discussions" target="_blank" rel="noopener noreferrer">community discussions</a>{' '}
-            cover most edge cases that aren't. When filing a bug against a server or SDK, include the
-            exact JSON-RPC messages, HTTP status codes and headers, and the protocol version negotiated
-            at initialization — with those three things, most MCP issues are diagnosable on sight.
+            Capture the exact endpoint, negotiated era and version, JSON-RPC request and response, HTTP
+            status, and headers—with secrets removed. Those five details are usually enough to isolate
+            the failing layer. Compare the exchange with the{' '}
+            <a href="https://modelcontextprotocol.io/specification/2026-07-28" target="_blank" rel="noopener noreferrer">current specification</a>,{' '}
+            the <a href="https://modelcontextprotocol.io/specification/2025-11-25" target="_blank" rel="noopener noreferrer">2025 compatibility specification</a>, and the official SDK&apos;s{' '}
+            <a href="https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/protocol-versions.md" target="_blank" rel="noopener noreferrer">negotiation guide</a>.
           </p>
         </div>
       </div>

--- a/src/components/docs/WhatIsMcp.tsx
+++ b/src/components/docs/WhatIsMcp.tsx
@@ -20,7 +20,7 @@ const WhatIsMcp: React.FC = () => {
             Foundation project. It defines three roles: the <strong>host</strong> is the AI application
             a person uses, a <strong>client</strong> speaks MCP on the host&apos;s behalf, and a{' '}
             <strong>server</strong> provides capabilities backed by a database, SaaS API, local system,
-            or business process. All three exchange <a href="https://www.jsonrpc.org/specification" target="_blank" rel="noopener noreferrer">JSON-RPC 2.0</a>{' '}
+            or business process. Clients and servers exchange <a href="https://www.jsonrpc.org/specification" target="_blank" rel="noopener noreferrer">JSON-RPC 2.0</a>{' '}
             messages over a transport such as local stdio or remote Streamable HTTP.
           </p>
 

--- a/src/components/docs/WhatIsMcp.tsx
+++ b/src/components/docs/WhatIsMcp.tsx
@@ -9,168 +9,183 @@ const WhatIsMcp: React.FC = () => {
           <h1 className="mb-4">What is the Model Context Protocol?</h1>
 
           <p className="lead">
-            The Model Context Protocol (MCP) is an open protocol that standardizes how applications
-            provide context and capabilities to large language models. An MCP server exposes tools,
-            data, and prompt templates through a well-defined JSON-RPC interface, and any MCP-compatible
-            client — Claude, IDEs, agent frameworks, or a testing tool like this one — can connect to it
-            and use those capabilities without custom integration work.
+            The Model Context Protocol (MCP) is an open protocol for connecting AI applications to
+            tools and context. A service describes its capabilities once through a standard JSON-RPC
+            interface; MCP clients can then discover and use them without a bespoke integration for
+            every client-server pair.
           </p>
 
           <p>
-            MCP was introduced by Anthropic in November 2024 and has since moved to an open governance
-            model with contributions from across the industry. It solves the "N×M integration problem":
-            instead of every AI application building bespoke connectors for every data source or API,
-            a service implements one MCP server and every MCP client can use it. The protocol is
-            transport-agnostic, but in practice two transports matter: <strong>stdio</strong> for servers
-            that run locally as a subprocess, and <strong>Streamable HTTP</strong> for servers reachable
-            over the network — so-called <em>remote MCP servers</em>, which are the focus of this site.
+            MCP was introduced by Anthropic in November 2024 and is now an openly governed Linux
+            Foundation project. It defines three roles: the <strong>host</strong> is the AI application
+            a person uses, a <strong>client</strong> speaks MCP on the host&apos;s behalf, and a{' '}
+            <strong>server</strong> provides capabilities backed by a database, SaaS API, local system,
+            or business process. All three exchange <a href="https://www.jsonrpc.org/specification" target="_blank" rel="noopener noreferrer">JSON-RPC 2.0</a>{' '}
+            messages over a transport such as local stdio or remote Streamable HTTP.
           </p>
 
-          <h2 className="mt-5">Architecture</h2>
+          <h2 className="mt-5">What a server exposes</h2>
           <p>
-            MCP defines three roles. A <strong>host</strong> is the AI application the user interacts
-            with — a chat interface, an IDE, an agent runtime. The host creates one or
-            more <strong>clients</strong>, each of which maintains a stateful, one-to-one connection to
-            a single <strong>server</strong>. The server is the process that actually provides context
-            and functionality, whether that is a wrapper around a database, a SaaS API, a file system,
-            or custom business logic.
+            <strong>Tools</strong> are functions an AI model can invoke: search a database, create a
+            ticket, or send a message. Each tool has a name, description, JSON Schema input, and
+            optional structured output schema. Clients use <code>tools/list</code> and{' '}
+            <code>tools/call</code> to discover and invoke them.
           </p>
           <p>
-            All communication between client and server uses <a href="https://www.jsonrpc.org/specification" target="_blank" rel="noopener noreferrer">JSON-RPC 2.0</a> messages:
-            requests that expect a response, responses, and one-way notifications. The protocol is
-            bidirectional — servers can also send requests to clients (for example, to ask the client's
-            model to generate text), which is what distinguishes MCP from a plain REST API.
-          </p>
-
-          <h2 className="mt-5">What a server can expose</h2>
-          <p>
-            A server advertises its capabilities during initialization and then serves them through a
-            small set of standardized methods. The three server-side primitives are:
+            <strong>Resources</strong> are data addressed by URIs. They may be listed with{' '}
+            <code>resources/list</code>, parameterized through URI templates, and read with{' '}
+            <code>resources/read</code>. <strong>Prompts</strong> are reusable message templates,
+            discovered with <code>prompts/list</code> and rendered with <code>prompts/get</code>.
           </p>
           <p>
-            <strong>Tools</strong> are functions the language model can invoke — searching a database,
-            creating a ticket, sending a message. Each tool declares a name, a description, and a JSON
-            Schema for its inputs (and optionally for structured outputs). Clients discover tools
-            with <code>tools/list</code> and invoke them with <code>tools/call</code>. Tools are the
-            primitive that turns a model from a text generator into an agent that acts, which makes
-            testing them thoroughly — including their error behavior — the core of MCP server testing.
-          </p>
-          <p>
-            <strong>Resources</strong> are pieces of data identified by URIs — file contents, database
-            records, API responses — that the host application can read and attach to the model's
-            context. Resources can be static, listed via <code>resources/list</code>, or parameterized
-            through URI templates. Servers can also let clients subscribe to change notifications for
-            individual resources.
-          </p>
-          <p>
-            <strong>Prompts</strong> are reusable, parameterized message templates, discovered
-            via <code>prompts/list</code> and instantiated with <code>prompts/get</code>. They are
-            typically surfaced in the host UI as slash commands or quick actions.
-          </p>
-          <p>
-            Clients can offer capabilities in the other direction as well: <strong>sampling</strong> lets
-            a server request an LLM completion from the client, <strong>elicitation</strong> lets a
-            server ask the user for additional input mid-operation, and <strong>roots</strong> let the
-            client tell the server which directories or locations it should operate on.
+            The 2026 protocol also supports in-band multi-round-trip requests. A tool, resource, or
+            prompt operation can return <code>resultType: &quot;input_required&quot;</code>; the client
+            obtains the requested user or model input and retries the original call with{' '}
+            <code>inputResponses</code>. This replaces the held-open server-to-client requests used by
+            older sampling, elicitation, and roots flows. Roots, sampling, and logging are deprecated
+            in the 2026 core, although compatibility implementations may continue to serve them.
           </p>
 
-          <h2 className="mt-5">The connection lifecycle</h2>
+          <h2 className="mt-5">Two protocol eras</h2>
           <p>
-            Every MCP session follows the same lifecycle regardless of transport. The client opens the
-            connection and sends an <code>initialize</code> request declaring the protocol version it
-            supports, its capabilities, and its identity:
-          </p>
-          <pre className="bg-light p-3 rounded"><code>{`{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "initialize",
-  "params": {
-    "protocolVersion": "2025-11-25",
-    "capabilities": { "elicitation": {} },
-    "clientInfo": { "name": "mcptest.io", "version": "1.0.0" }
-  }
-}`}</code></pre>
-          <p>
-            The server responds with the protocol version it will use for the session, its own
-            capabilities (for example <code>tools</code>, <code>resources</code>, <code>prompts</code>,
-            and whether it emits list-change notifications), and its server info. The client then sends
-            a <code>notifications/initialized</code> notification, after which normal operation begins.
-            Version and capability negotiation happen here and only here: both sides must agree on a
-            single protocol version, and neither side may use a capability the other did not declare.
-            A surprising number of real-world interoperability bugs are simply servers that advertise
-            capabilities they don't implement, or that reject protocol versions they should negotiate
-            down from — which is why the <Link to="/docs/testing-guide">testing guide</Link> starts with
-            the handshake.
-          </p>
-
-          <h2 className="mt-5">Transports</h2>
-          <p>
-            The specification defines two standard transports. With <strong>stdio</strong>, the client
-            launches the server as a local subprocess and exchanges newline-delimited JSON-RPC messages
-            over standard input and output. With <strong>Streamable HTTP</strong>, the server runs as an
-            independent HTTP service exposing a single MCP endpoint that accepts POST and GET requests,
-            optionally streaming responses via Server-Sent Events. Streamable HTTP replaced the original
-            HTTP+SSE transport in 2025 and is what makes remote, multi-tenant MCP deployments practical.
-            The trade-offs and the full mechanics — sessions, streaming, resumability, authorization —
-            are covered in <Link to="/docs/remote-vs-local">Remote vs. Local MCP Servers</Link>.
-          </p>
-
-          <h2 className="mt-5">Protocol versions</h2>
-          <p>
-            MCP versions are date strings (<code>YYYY-MM-DD</code>) that change only when a revision
-            contains backwards-incompatible changes. Knowing the version history matters when testing,
-            because servers and clients in the wild span all of these revisions:
+            MCP now has two lifecycle families. A production client should understand both because
+            many deployed servers still implement a 2025 revision.
           </p>
           <div className="table-responsive">
             <table className="table">
               <thead>
                 <tr>
+                  <th>Behavior</th>
+                  <th>2026-07-28 stateless</th>
+                  <th>2025 and earlier stateful</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Start</td>
+                  <td>Optional client probe to required server method <code>server/discover</code></td>
+                  <td><code>initialize</code>, then <code>notifications/initialized</code></td>
+                </tr>
+                <tr>
+                  <td>Request context</td>
+                  <td>Protocol version and client capabilities in every request&apos;s <code>_meta</code></td>
+                  <td>Negotiated once during initialization</td>
+                </tr>
+                <tr>
+                  <td>Transport session</td>
+                  <td>None; <code>Mcp-Session-Id</code> was removed</td>
+                  <td>Optional server-issued <code>Mcp-Session-Id</code></td>
+                </tr>
+                <tr>
+                  <td>Server changes</td>
+                  <td><code>subscriptions/listen</code></td>
+                  <td>Standalone GET SSE stream and notifications</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h3 className="mt-4">Stateless requests in 2026</h3>
+          <p>
+            There is no <code>initialize</code> handshake in <code>2026-07-28</code>. Every request is
+            self-describing. The protocol version and client capabilities are required in{' '}
+            <code>params._meta</code>, while client identity is recommended. On Streamable HTTP, the
+            body metadata is mirrored by routing headers so a gateway can classify a request without
+            parsing JSON:
+          </p>
+          <pre className="bg-light p-3 rounded"><code>{`POST /mcp
+MCP-Protocol-Version: 2026-07-28
+Mcp-Method: tools/call
+Mcp-Name: search
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "search",
+    "arguments": { "query": "stateless MCP" },
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "mcptest.io",
+        "version": "2.0.0"
+      },
+      "io.modelcontextprotocol/clientCapabilities": {}
+    }
+  }
+}`}</code></pre>
+          <p>
+            <code>Mcp-Method</code> is required on every HTTP request. <code>Mcp-Name</code> is also
+            required for <code>tools/call</code>, <code>resources/read</code>, and{' '}
+            <code>prompts/get</code>. The <code>MCP-Protocol-Version</code> header must match the version
+            in <code>_meta</code>. With no hidden transport session, requests can reach any healthy
+            instance behind a normal load balancer. Applications can still keep business state by
+            returning an explicit handle and accepting it as a later tool argument.
+          </p>
+
+          <h3 className="mt-4">Stateful compatibility through 2025</h3>
+          <p>
+            Revisions through <code>2025-11-25</code> begin with <code>initialize</code>. The client and
+            server negotiate one version and capability set, the client sends{' '}
+            <code>notifications/initialized</code>, and a stateful server may issue an opaque{' '}
+            <code>Mcp-Session-Id</code> that the client must return on later requests. This remains a
+            valid and important compatibility path; it is not how a 2026-only request should be served.
+          </p>
+          <p>
+            mcptest.io uses automatic SDK negotiation. It probes with <code>server/discover</code> and
+            adopts stateless behavior when the server offers <code>2026-07-28</code>. A 2025-only
+            response falls back to the byte-compatible initialization flow. Authentication failures
+            remain authentication failures rather than being mistaken for lifecycle evidence.
+          </p>
+
+          <h2 className="mt-5">Protocol versions</h2>
+          <div className="table-responsive">
+            <table className="table">
+              <thead>
+                <tr>
                   <th style={{ whiteSpace: 'nowrap' }}>Version</th>
-                  <th>Highlights</th>
+                  <th>Important changes</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <td><code>2024-11-05</code></td>
-                  <td>First stable release. Tools, resources, prompts, sampling; stdio and the original HTTP+SSE transport.</td>
+                  <td>First stable release; stdio and the original two-endpoint HTTP+SSE transport.</td>
                 </tr>
                 <tr>
                   <td><code>2025-03-26</code></td>
-                  <td>Replaced HTTP+SSE with Streamable HTTP; introduced the OAuth-based authorization framework; tool annotations and audio content.</td>
+                  <td>Introduced Streamable HTTP and the OAuth-based authorization framework.</td>
                 </tr>
                 <tr>
                   <td><code>2025-06-18</code></td>
-                  <td>Reworked authorization around OAuth 2.1 resource servers (RFC 9728 protected resource metadata, RFC 8707 resource indicators); structured tool output; elicitation; required <code>MCP-Protocol-Version</code> header on HTTP; removed JSON-RPC batching.</td>
+                  <td>OAuth 2.1 resource-server model, structured tool output, elicitation, protocol-version header, and no JSON-RPC batching.</td>
                 </tr>
                 <tr>
                   <td><code>2025-11-25</code></td>
-                  <td>Current version. OpenID Connect Discovery support, OAuth Client ID Metadata Documents, incremental scope consent, URL-mode elicitation, icons metadata, tool calling in sampling, experimental long-running tasks, and SSE polling refinements.</td>
+                  <td>OIDC discovery, Client ID Metadata Documents, URL elicitation, icons, experimental tasks, and SSE polling refinements.</td>
+                </tr>
+                <tr>
+                  <td><code>2026-07-28</code></td>
+                  <td>Current version: stateless core, discovery, header routing, cacheable lists, multi-round-trip input, subscriptions, extensions, and authorization hardening.</td>
                 </tr>
               </tbody>
             </table>
           </div>
-          <p>
-            Clients and servers may support several versions at once and negotiate the one to use during
-            initialization. On HTTP transports, the negotiated version must also be echoed on every
-            subsequent request in the <code>MCP-Protocol-Version</code> header.
-          </p>
 
           <h2 className="mt-5">Where to go next</h2>
           <p>
-            If you are building or evaluating a remote MCP server, read{' '}
-            <Link to="/docs/remote-vs-local">Remote vs. Local MCP Servers</Link> for the transport,
-            session, and authorization mechanics, then use the{' '}
-            <Link to="/docs/testing-guide">testing guide</Link> to validate your implementation against
-            a real client — this site's playground speaks Streamable HTTP directly from your browser.
-            When something breaks, the <Link to="/docs/troubleshooting">troubleshooting guide</Link>{' '}
-            maps the most common failure symptoms to their causes.
+            Read <Link to="/docs/remote-vs-local">Remote vs. Local MCP Servers</Link> for the
+            transport mechanics, then use the <Link to="/docs/testing-guide">testing guide</Link> to
+            verify both lifecycle eras. The <Link to="/docs/troubleshooting">troubleshooting guide</Link>{' '}
+            maps common CORS, session, routing-header, streaming, and authorization failures to fixes.
           </p>
           <p>
-            The authoritative protocol reference is the official specification at{' '}
-            <a href="https://modelcontextprotocol.io/specification/2025-11-25" target="_blank" rel="noopener noreferrer">modelcontextprotocol.io</a>.
-            Official SDKs for TypeScript, Python, and other languages, plus a large catalog of open-source
-            server implementations, live in the{' '}
-            <a href="https://github.com/modelcontextprotocol" target="_blank" rel="noopener noreferrer">modelcontextprotocol GitHub organization</a>.
+            The authoritative references are the{' '}
+            <a href="https://modelcontextprotocol.io/specification/2026-07-28" target="_blank" rel="noopener noreferrer">2026-07-28 specification</a>,
+            the official <a href="https://blog.modelcontextprotocol.io/posts/2026-07-28/" target="_blank" rel="noopener noreferrer">release overview</a>,
+            and the TypeScript SDK&apos;s{' '}
+            <a href="https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/protocol-versions.md" target="_blank" rel="noopener noreferrer">dual-era negotiation guide</a>.
           </p>
         </div>
       </div>

--- a/src/utils/oauthDiscovery.ts
+++ b/src/utils/oauthDiscovery.ts
@@ -293,7 +293,7 @@ export async function getOrRegisterOAuthClient(
     
     // Prepare registration request
     const registrationRequest: DynamicClientRegistrationRequest = {
-      client_name: 'MCP SSE Tester',
+      client_name: 'mcptest.io',
       redirect_uris: [`${window.location.origin}/oauth/callback`],
       grant_types: ['authorization_code'],
       response_types: ['code'],


### PR DESCRIPTION
## Summary
- replace the stateful-only README with a current product and development guide
- document MCP 2026-07-28 stateless discovery, per-request metadata, and routing headers
- retain full MCP 2025 initialization, session, SSE, and legacy HTTP+SSE guidance
- add dual-era curl checks, CORS configuration, authentication boundaries, and troubleshooting
- refresh the old MCP SSE Tester product name in OAuth-facing copy

## Verification
- npm test -- --run (56 tests)
- npx tsc --noEmit
- npm run build (26 SEO server profiles generated)
- git diff --check

## Sources
- official MCP 2026-07-28 release and specification
- official TypeScript SDK protocol-version and migration guides