### PR TITLE
Refresh the MCP technical interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1663,7 +1663,7 @@ function App() {
   }
 
   return (
-    <div className="container-fluid vh-100 d-flex flex-column p-0">
+    <div className="app-shell container-fluid vh-100 d-flex flex-column p-0">
 
       {/* Mobile Sidebar Overlay */}
       <div 
@@ -1697,12 +1697,11 @@ function App() {
         />
       </div>
 
-      {/* UPDATE Header props */}
       <Header theme={theme} onToggleTheme={toggleTheme} />
 
-      <main className="flex-grow-1 d-flex overflow-hidden" role="main"> {/* Main content area */}
+      <main className="app-workspace flex-grow-1 d-flex overflow-hidden" role="main">
         {/* Desktop Side Navigation */}
-        <div className="desktop-sidebar col-auto bg-light border-end p-2 d-flex flex-column" style={{ width: '250px', height: '100%' }}>
+        <div className="desktop-sidebar col-auto p-2 d-flex flex-column">
           <SideNav
             activeView={activeView}
             spaces={spaces}

--- a/src/components/CatalogServerCard.tsx
+++ b/src/components/CatalogServerCard.tsx
@@ -111,15 +111,14 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
   };
 
   return (
-    <div className="card h-100">
+    <div className="card h-100 catalog-server-card">
       <div className="card-body d-flex flex-column">
         <div className="d-flex align-items-start gap-3 mb-3">
           {server.logoUrl && (
             <img
               src={server.logoUrl}
               alt={`${server.name} logo`}
-              className="rounded flex-shrink-0"
-              style={{ width: '48px', height: '48px', objectFit: 'contain' }}
+              className="catalog-server-logo flex-shrink-0"
             />
           )}
           <div className="flex-grow-1" style={{ minWidth: 0 }}>
@@ -131,8 +130,7 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
               </h5>
               <div className="d-flex align-items-center gap-2 flex-shrink-0">
                 <span
-                  className={`rounded-circle flex-shrink-0 ${statusDetails.className}`}
-                  style={{ width: '12px', height: '12px' }}
+                  className={`catalog-status-dot rounded-circle flex-shrink-0 ${statusDetails.className}`}
                   title={statusDetails.tooltip}
                   aria-label={statusDetails.tooltip}
                 >
@@ -140,8 +138,7 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
                 </span>
                 <button
                   type="button"
-                  className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center justify-content-center p-0"
-                  style={{ width: '28px', height: '28px' }}
+                  className="catalog-refresh btn btn-sm btn-outline-secondary d-inline-flex align-items-center justify-content-center p-0"
                   onClick={handleLivenessCheck}
                   disabled={isCheckingLiveness}
                   title="Check server status now"
@@ -161,7 +158,7 @@ export const CatalogServerCard: React.FC<CatalogServerCardProps> = ({ server, on
           </div>
         </div>
 
-        <p className="card-text text-muted flex-grow-1">{server.description}</p>
+        <p className="card-text catalog-server-description text-muted flex-grow-1">{server.description}</p>
 
         <div className="d-flex flex-wrap align-items-center gap-2 mb-3">
           <span className="badge bg-secondary">{server.category}</span>

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -40,17 +40,22 @@ const CatalogView: React.FC<CatalogViewProps> = ({ onTestServer }) => {
   };
 
   return (
-    <div>
-      <div className="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-3 pb-2 border-bottom">
-        <div>
-          <h2 className="mb-1">Server Catalog</h2>
+    <div className="catalog-view">
+      <div className="catalog-command-bar">
+        <div className="catalog-command-copy">
+          <span className="interface-eyebrow">Live endpoint index</span>
+          <h2 className="mb-1">Remote MCP server catalog</h2>
           <p className="text-muted mb-0">
-            Showing {filteredServers.length} of {allServers.length} servers
+            Inspect transport, protocol era, and authentication before you connect.
           </p>
+          <div className="catalog-counts" aria-live="polite">
+            <span><strong>{allServers.length}</strong> endpoints indexed</span>
+            <span><strong>{filteredServers.length}</strong> in current view</span>
+          </div>
         </div>
 
-        <div className="d-flex flex-column flex-md-row align-items-stretch align-items-md-end gap-2">
-          <div>
+        <div className="catalog-filters">
+          <div className="catalog-search-field">
             <label className="form-label" htmlFor={`${idPrefix}-catalog-search`}>
               Search servers
             </label>
@@ -64,7 +69,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({ onTestServer }) => {
             />
           </div>
 
-          <div>
+          <div className="catalog-auth-field">
             <label className="form-label d-block" htmlFor={`${idPrefix}-oauth-all`}>
               Authentication
             </label>
@@ -91,7 +96,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({ onTestServer }) => {
             </div>
           </div>
 
-          <div>
+          <div className="catalog-category-field">
             <label className="form-label" htmlFor={`${idPrefix}-catalog-category`}>
               Category
             </label>

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -141,9 +141,12 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
   // Return JSX directly without outer parentheses
   return (
     <>
-      <div className={`card mb-3 ${isConnected ? 'border-success' : ''}`} style={{ marginTop: '0', minHeight: '200px' }}>
+      <div className={`card mb-3 connection-console ${isConnected ? 'border-success' : ''}`}>
       <div className={`card-header d-flex justify-content-between align-items-center ${isConnected ? 'bg-success bg-opacity-10' : ''}`}>
-        <h5 className="mb-0">Server Connection</h5>
+        <div>
+          <span className="interface-eyebrow">Transport console</span>
+          <h5 className="mb-0">Connect a remote endpoint</h5>
+        </div>
         <div className="d-flex align-items-center gap-2">
           {transportType && <span className={`badge ${transportType === 'streamable-http' ? 'bg-success' : 'bg-primary'} me-2`}>{transportType === 'streamable-http' ? 'HTTP' : 'SSE'}</span>}
           {protocolEra && (
@@ -214,7 +217,7 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
       </div>
       <div className="card-body">
         <div className="mb-3">
-          <label htmlFor="serverUrl" className="form-label">MCP Server URL</label>
+          <label htmlFor="serverUrl" className="form-label">MCP endpoint URL</label>
           <div className="input-group">
             <input
               type="text"
@@ -260,7 +263,12 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
                   <option key={url} value={url} />
                 ))}
               </datalist>
-              <div className="form-text">For example, https://{placeholder}/ or http://localhost:3001</div>
+              <div className="form-text connection-help">
+                <span>Exact endpoint first</span>
+                <span>2026 discovery</span>
+                <span>2025 fallback</span>
+                <span>For example, https://{placeholder}/ or http://localhost:3001</span>
+              </div>
             </>
           )}
           {isConnecting && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 interface HeaderProps {
@@ -8,13 +8,8 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ theme, onToggleTheme }) => {
-  const navigate = useNavigate();
   const { currentUser, loginWithGoogle, logout } = useAuth();
   const authEnabled = import.meta.env.VITE_FIREBASE_AUTH_ENABLED === 'true';
-
-  const handleHomeClick = () => {
-    navigate('/');
-  };
 
   return (
     <header className="app-header">
@@ -28,19 +23,20 @@ const Header: React.FC<HeaderProps> = ({ theme, onToggleTheme }) => {
           <span className="hamburger"></span>
         </button>
 
-        <span
+        <Link
+          to="/"
           className="app-logo"
-          onClick={handleHomeClick}
+          aria-label="mcptest.io home"
         >
           <img src="/logo.png" alt="MCP Logo" width="40" height="40" />
-        </span>
-        <div className="app-brand-copy" onClick={handleHomeClick}>
+        </Link>
+        <Link to="/" className="app-brand-copy" aria-label="mcptest.io home">
           <span className="app-brand-eyebrow">Model Context Protocol</span>
           <h1 className="app-brand-title">mcptest.io</h1>
           <p className="app-brand-subtitle d-none d-md-block">
             Remote protocol workbench
           </p>
-        </div>
+        </Link>
       </div>
 
       <div className="app-header-actions d-none d-md-flex">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,6 @@ const Header: React.FC<HeaderProps> = ({ theme, onToggleTheme }) => {
           <span className="hamburger"></span>
         </button>
 
-        {/* MCP/AI Logo */}
         <span
           className="app-logo"
           onClick={handleHomeClick}
@@ -36,14 +35,23 @@ const Header: React.FC<HeaderProps> = ({ theme, onToggleTheme }) => {
           <img src="/logo.png" alt="MCP Logo" width="40" height="40" />
         </span>
         <div className="app-brand-copy" onClick={handleHomeClick}>
+          <span className="app-brand-eyebrow">Model Context Protocol</span>
           <h1 className="app-brand-title">mcptest.io</h1>
           <p className="app-brand-subtitle d-none d-md-block">
-            Test remote MCP servers
+            Remote protocol workbench
           </p>
         </div>
       </div>
 
       <div className="app-header-actions d-none d-md-flex">
+        <div className="protocol-matrix" aria-label="Supported MCP protocol eras">
+          <span className="protocol-matrix-label">Negotiation</span>
+          <span className="protocol-chip protocol-chip-modern">
+            <span className="protocol-chip-dot" aria-hidden="true"></span>
+            2026 stateless
+          </span>
+          <span className="protocol-chip">2025 compatible</span>
+        </div>
         <button
           onClick={onToggleTheme}
           className="btn btn-outline-secondary app-theme-toggle"

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -249,6 +249,15 @@ const SideNav: React.FC<SideNavProps> = ({
 
   return (
     <nav className="app-sidenav nav flex-column d-flex flex-grow-1">
+      <div className="sidenav-protocol-card" aria-label="Protocol negotiation status">
+        <div className="sidenav-protocol-heading">
+          <span className="protocol-chip-dot" aria-hidden="true"></span>
+          Auto negotiation
+        </div>
+        <strong>2026 ↔ 2025</strong>
+        <small>Stateless first · stateful fallback</small>
+      </div>
+
       {/* Playground Link */}
       <Link
         to="/"

--- a/src/components/SuggestedServersPanel.tsx
+++ b/src/components/SuggestedServersPanel.tsx
@@ -29,67 +29,38 @@ export const SuggestedServersPanel: React.FC<SuggestedServersPanelProps> = ({
   return (
     <div className="card mb-3 suggested-servers-panel">
       <div className="card-header">
-        <h6 className="mb-0">Suggested Servers</h6>
+        <div>
+          <span className="interface-eyebrow">Quick start matrix</span>
+          <h6 className="mb-0">Suggested servers</h6>
+        </div>
       </div>
       <div className="card-body p-3">
-        <small className="text-muted d-block mb-3">Not sure where to begin? Check our curated list of remote MCP servers.</small>
-        <ul className="list-group">
+        <small className="text-muted d-block mb-3">Connect to a curated public endpoint and inspect the negotiated protocol.</small>
+        <ul className="suggested-server-grid">
         {suggestedCatalogServers.map((server) => (
-          <li key={server.url} className="list-group-item suggested-server-row p-3">
-            <div
-              style={{
-                cursor: isConnected || isConnecting ? 'default' : 'pointer',
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: '12px',
-              }}
+          <li key={server.url} className="suggested-server-row">
+            <button
+              type="button"
+              className="suggested-server-action"
               onClick={() => handleServerClick(server.url)}
+              disabled={isConnected || isConnecting}
             >
               {server.logoUrl && (
                 <img
                   src={server.logoUrl}
                   alt={`${server.name} logo`}
-                  style={{
-                    width: '48px',
-                    height: '48px',
-                    objectFit: 'contain',
-                    flexShrink: 0,
-                  }}
+                  className="suggested-server-logo"
                 />
               )}
-              <div style={{ flexGrow: 1, overflow: 'hidden' }}>
-                <div
-                  style={{
-                    fontWeight: 600,
-                    fontSize: '16px',
-                    color: isConnected || isConnecting ? 'grey' : 'var(--primary-color)',
-                    textDecoration: isConnected || isConnecting ? 'none' : 'underline',
-                    marginBottom: '4px',
-                  }}
-                >
-                  {server.name}
+              <div className="suggested-server-copy">
+                <div className="suggested-server-title-row">
+                  <strong>{server.name}</strong>
+                  <span aria-hidden="true">↗</span>
                 </div>
-                <div
-                  style={{
-                    fontSize: '14px',
-                    color: '#666',
-                    marginBottom: '8px',
-                    lineHeight: '1.4',
-                  }}
-                >
-                  {server.description}
-                </div>
-                <small
-                  style={{
-                    color: '#999',
-                    fontSize: '12px',
-                  }}
-                  title={server.url}
-                >
-                  {server.url}
-                </small>
+                <p>{server.description}</p>
+                <small title={server.url}>{server.url}</small>
               </div>
-            </div>
+            </button>
           </li>
         ))}
         </ul>

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -840,7 +840,7 @@ const TabContent: React.FC<TabContentProps> = ({ tab, isActive, onUpdateTab, spa
                   />
                 </div>
               )}
-              <div className="col-md-6">
+              <div className={recentServers.length > 0 ? 'col-md-6' : 'col-12'}>
                 <SuggestedServersPanel
                   setServerUrl={setServerUrl}
                   handleConnect={handleConnectWrapper}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,30 +1,6 @@
 import React from 'react';
 import { ConnectionTab } from '../types';
 
-// Add CSS for active tab border override
-const tabStyles = `
-  .active-tab-override::after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background-color: var(--body-bg);
-    z-index: 1;
-  }
-`;
-
-// Inject styles
-if (typeof document !== 'undefined') {
-  const styleSheet = document.createElement('style');
-  styleSheet.textContent = tabStyles;
-  if (!document.head.querySelector('style[data-tab-styles]')) {
-    styleSheet.setAttribute('data-tab-styles', 'true');
-    document.head.appendChild(styleSheet);
-  }
-}
-
 interface TabsProps {
   tabs: ConnectionTab[];
   activeTabId: string;
@@ -55,16 +31,12 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTabId, onSelectTab, onCloseTab,
     >
       {tabs.map(tab => (
         <div key={tab.id} className="nav-item">
-          <a
+          <button
+            type="button"
             className={`nav-link ${activeTabId === tab.id ? 'active active-tab-override' : ''}`}
             onClick={() => onSelectTab(tab.id)}
-            href="#"
             role="tab"
-            style={{
-              borderRadius: '0.375rem 0.375rem 0 0',
-              position: 'relative',
-              zIndex: activeTabId === tab.id ? 2 : 0
-            }}
+            aria-selected={activeTabId === tab.id}
           >
             <span 
               className="me-2"
@@ -91,11 +63,11 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTabId, onSelectTab, onCloseTab,
                 aria-label="Close"
               ></button>
             )}
-          </a>
+          </button>
         </div>
       ))}
       <div className="nav-item">
-        <a className="nav-link" onClick={onNewTab} href="#">+ New</a>
+        <button type="button" className="nav-link" onClick={onNewTab}>+ New</button>
       </div>
     </div>
   );

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -30,10 +30,10 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTabId, onSelectTab, onCloseTab,
       role="tablist"
     >
       {tabs.map(tab => (
-        <div key={tab.id} className="nav-item">
+        <div key={tab.id} className="nav-item position-relative" role="presentation">
           <button
             type="button"
-            className={`nav-link ${activeTabId === tab.id ? 'active active-tab-override' : ''}`}
+            className={`nav-link ${tabs.length > 1 ? 'pe-5' : ''} ${activeTabId === tab.id ? 'active active-tab-override' : ''}`}
             onClick={() => onSelectTab(tab.id)}
             role="tab"
             aria-selected={activeTabId === tab.id}
@@ -52,18 +52,16 @@ const Tabs: React.FC<TabsProps> = ({ tabs, activeTabId, onSelectTab, onCloseTab,
               }}
             ></span>
             {tab.title}
-            {tabs.length > 1 && (
-              <button
-                type="button"
-                className="btn-close btn-close-sm ms-2"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCloseTab(tab.id);
-                }}
-                aria-label="Close"
-              ></button>
-            )}
           </button>
+          {tabs.length > 1 && (
+            <button
+              type="button"
+              className="btn-close btn-close-sm position-absolute top-50 end-0 translate-middle-y me-2"
+              style={{ zIndex: 2 }}
+              onClick={() => onCloseTab(tab.id)}
+              aria-label={`Close ${tab.title} tab`}
+            ></button>
+          )}
         </div>
       ))}
       <div className="nav-item">

--- a/src/index.css
+++ b/src/index.css
@@ -3042,7 +3042,7 @@ pre.bg-light code {
   background: #f7fffc;
 }
 
-@media (max-width: 1199.98px) {
+@media (max-width: 1319.98px) {
   .catalog-command-bar {
     grid-template-columns: 1fr;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
   --card-bg-secondary: #e7f0ef;
   --text-color: #0b1820;
   --text-muted: #58707b;
+  --text-accent: #067255;
   --primary-color: #079f75;
   --primary-hover: #067c5d;
   --primary-light: #47d9ae;
@@ -42,6 +43,7 @@
   --card-bg-secondary: #10242a;
   --text-color: #e7faf5;
   --text-muted: #88a5ad;
+  --text-accent: var(--primary-color);
   --primary-color: #36e0aa;
   --primary-hover: #64efc0;
   --primary-light: #8ff5d0;
@@ -2465,7 +2467,7 @@ span.health-indicator.health-indicator-gray {
 }
 
 .protocol-chip-modern {
-  color: var(--primary-color);
+  color: var(--text-accent);
   border-color: color-mix(in srgb, var(--primary-color) 35%, var(--border-color));
   background: color-mix(in srgb, var(--primary-color) 8%, var(--card-bg));
 }
@@ -2615,7 +2617,7 @@ span.health-indicator.health-indicator-gray {
 .interface-eyebrow {
   display: block;
   margin-bottom: 0.32rem;
-  color: var(--primary-color);
+  color: var(--text-accent);
   font-family: var(--font-family-mono);
   font-size: 0.62rem;
   font-weight: 700;
@@ -2854,7 +2856,7 @@ span.health-indicator.health-indicator-gray {
 .suggested-server-copy small {
   display: block;
   overflow: hidden;
-  color: var(--primary-color);
+  color: var(--text-accent);
   font-family: var(--font-family-mono);
   font-size: 0.62rem;
   text-overflow: ellipsis;

--- a/src/index.css
+++ b/src/index.css
@@ -6,65 +6,76 @@
 :root {
   --font-family-sans-serif: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
   --font-family-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Monaco', 'Inconsolata', 'Source Code Pro', monospace;
-  --body-bg: #f5f7f6;
-  --card-bg: #ffffff;
-  --card-bg-secondary: #eef3f0;
-  --text-color: #111827;
-  --text-muted: #667085;
-  --primary-color: #16a34a;
-  --primary-hover: #15803d;
-  --primary-light: #86efac;
-  --secondary-color: #64748b;
-  --secondary-hover: #475569;
-  --success-color: #16a34a;
-  --info-color: #0891b2;
+  --body-bg: #edf3f3;
+  --card-bg: #fbfefd;
+  --card-bg-secondary: #e7f0ef;
+  --text-color: #0b1820;
+  --text-muted: #58707b;
+  --primary-color: #079f75;
+  --primary-hover: #067c5d;
+  --primary-light: #47d9ae;
+  --secondary-color: #526b78;
+  --secondary-hover: #354e5a;
+  --success-color: #079f75;
+  --info-color: #0789a8;
+  --accent-cyan: #08a6c5;
+  --accent-violet: #7165e8;
   --danger-color: #dc2626;
   --warning-color: #d97706;
-  --border-color: #dbe4df;
+  --border-color: #cddbd9;
   --input-bg: #ffffff;
-  --input-border: #cfd9d3;
+  --input-border: #bfd0ce;
   --input-focus-border: var(--primary-color);
   --link-color: var(--primary-color);
-  --focus-ring: 0 0 0 4px rgba(22, 163, 74, 0.18);
-  --box-shadow: 0 1px 2px rgba(16, 24, 40, 0.06), 0 6px 16px -8px rgba(16, 24, 40, 0.16);
-  --box-shadow-lg: 0 2px 6px rgba(16, 24, 40, 0.07), 0 14px 32px -12px rgba(16, 24, 40, 0.22);
-  --box-shadow-xl: 0 4px 10px rgba(16, 24, 40, 0.08), 0 24px 56px -16px rgba(16, 24, 40, 0.28);
-  --border-radius: 0.75rem;
-  --accent-gradient: linear-gradient(135deg, #22c55e, #15803d);
+  --focus-ring: 0 0 0 4px rgba(7, 159, 117, 0.17);
+  --box-shadow: 0 1px 2px rgba(7, 24, 31, 0.05), 0 12px 30px -24px rgba(7, 38, 48, 0.4);
+  --box-shadow-lg: 0 2px 5px rgba(7, 24, 31, 0.06), 0 24px 50px -30px rgba(7, 38, 48, 0.55);
+  --box-shadow-xl: 0 3px 8px rgba(7, 24, 31, 0.08), 0 32px 72px -36px rgba(7, 38, 48, 0.7);
+  --border-radius: 0.9rem;
+  --accent-gradient: linear-gradient(120deg, #079f75, #08a6c5);
 }
 
 /* Dark Theme CSS Variables */
 :root[data-theme='dark'] {
-  --body-bg: #0b1120;
-  --card-bg: #111827;
-  --card-bg-secondary: #1f2937;
-  --text-color: #e5edf7;
-  --text-muted: #98a6ba;
-  --primary-color: #4ade80;
-  --primary-hover: #22c55e;
-  --primary-light: #bbf7d0;
-  --secondary-color: #94a3b8;
-  --secondary-hover: #cbd5e1;
-  --success-color: #4ade80;
-  --info-color: #38bdf8;
+  --body-bg: #061014;
+  --card-bg: #0a171c;
+  --card-bg-secondary: #10242a;
+  --text-color: #e7faf5;
+  --text-muted: #88a5ad;
+  --primary-color: #36e0aa;
+  --primary-hover: #64efc0;
+  --primary-light: #8ff5d0;
+  --secondary-color: #86a0a9;
+  --secondary-hover: #b5cbd1;
+  --success-color: #36e0aa;
+  --info-color: #51d8f4;
+  --accent-cyan: #51d8f4;
+  --accent-violet: #9a91ff;
   --danger-color: #f87171;
   --warning-color: #fbbf24;
-  --border-color: #2a3446;
-  --input-bg: #172033;
-  --input-border: #344054;
+  --border-color: #21383f;
+  --input-bg: #0d1e24;
+  --input-border: #2a4650;
   --input-focus-border: var(--primary-color);
   --link-color: var(--primary-light);
-  --focus-ring: 0 0 0 4px rgba(74, 222, 128, 0.24);
-  --box-shadow: 0 1px 2px rgba(0, 0, 0, 0.28), 0 8px 20px -10px rgba(0, 0, 0, 0.58), 0 0 0 1px rgba(148, 163, 184, 0.06);
-  --box-shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.32), 0 18px 40px -16px rgba(0, 0, 0, 0.72), 0 0 0 1px rgba(148, 163, 184, 0.08);
-  --box-shadow-xl: 0 4px 12px rgba(0, 0, 0, 0.36), 0 28px 64px -18px rgba(0, 0, 0, 0.82), 0 0 0 1px rgba(148, 163, 184, 0.1);
-  --accent-gradient: linear-gradient(135deg, #4ade80, #16a34a);
+  --focus-ring: 0 0 0 4px rgba(54, 224, 170, 0.2);
+  --box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35), 0 16px 34px -24px rgba(0, 0, 0, 0.9), 0 0 0 1px rgba(81, 216, 244, 0.035);
+  --box-shadow-lg: 0 2px 7px rgba(0, 0, 0, 0.42), 0 28px 60px -30px rgba(0, 0, 0, 0.95), 0 0 0 1px rgba(81, 216, 244, 0.05);
+  --box-shadow-xl: 0 4px 12px rgba(0, 0, 0, 0.5), 0 36px 76px -34px rgba(0, 0, 0, 1), 0 0 0 1px rgba(81, 216, 244, 0.08);
+  --accent-gradient: linear-gradient(120deg, #36e0aa, #51d8f4);
 }
 
 /* --- Global Styles --- */
 body {
   font-family: var(--font-family-sans-serif);
   background-color: var(--body-bg);
+  background-image:
+    radial-gradient(circle at 78% 8%, color-mix(in srgb, var(--accent-cyan) 10%, transparent), transparent 29rem),
+    radial-gradient(circle at 24% 92%, color-mix(in srgb, var(--primary-color) 8%, transparent), transparent 32rem),
+    linear-gradient(color-mix(in srgb, var(--text-muted) 7%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--text-muted) 7%, transparent) 1px, transparent 1px);
+  background-size: auto, auto, 32px 32px, 32px 32px;
+  background-attachment: fixed;
   color: var(--text-color);
   line-height: 1.6;
   font-size: 15px;
@@ -2339,4 +2350,823 @@ span.health-indicator.health-indicator-gray {
   z-index: 1000;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
   transition: opacity 0.3s, transform 0.3s;
+}
+
+/* --- Technical interface refresh --- */
+.app-shell {
+  isolation: isolate;
+}
+
+.app-workspace {
+  min-height: 0;
+  min-width: 0;
+}
+
+.app-header {
+  min-height: 5rem;
+  padding: 0.72rem clamp(1rem, 2vw, 1.75rem);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--primary-color) 6%, transparent), transparent 32%),
+    color-mix(in srgb, var(--card-bg) 90%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--primary-color) 22%, var(--border-color));
+  box-shadow: 0 14px 40px -32px rgba(3, 26, 34, 0.8);
+}
+
+.app-header::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 1px;
+  content: '';
+  background: linear-gradient(90deg, transparent, var(--primary-color), var(--accent-cyan), transparent);
+  opacity: 0.48;
+}
+
+.app-logo {
+  width: 2.8rem;
+  height: 2.8rem;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 25%, var(--border-color));
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--card-bg) 82%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, white 35%, transparent), 0 10px 24px -15px var(--primary-color);
+}
+
+.app-logo img {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.app-brand-copy {
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: 0.65rem;
+  align-items: end;
+}
+
+.app-brand-eyebrow {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.57rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.app-brand-title {
+  margin-top: 0.15rem;
+  font-size: 1.55rem;
+  letter-spacing: -0.045em;
+}
+
+.app-brand-subtitle {
+  padding-bottom: 0.05rem;
+  font-family: var(--font-family-mono);
+  font-size: 0.7rem;
+  letter-spacing: -0.02em;
+}
+
+.protocol-matrix {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--card-bg-secondary) 72%, transparent);
+}
+
+.protocol-matrix-label,
+.protocol-chip {
+  font-family: var(--font-family-mono);
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.protocol-matrix-label {
+  padding: 0 0.4rem;
+  color: var(--text-muted);
+}
+
+.protocol-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 1.85rem;
+  padding: 0.25rem 0.68rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--card-bg);
+}
+
+.protocol-chip-modern {
+  color: var(--primary-color);
+  border-color: color-mix(in srgb, var(--primary-color) 35%, var(--border-color));
+  background: color-mix(in srgb, var(--primary-color) 8%, var(--card-bg));
+}
+
+.protocol-chip-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--primary-color);
+  box-shadow: 0 0 0 0.22rem color-mix(in srgb, var(--primary-color) 14%, transparent), 0 0 1rem color-mix(in srgb, var(--primary-color) 65%, transparent);
+}
+
+.app-theme-toggle {
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  background: var(--card-bg);
+}
+
+.desktop-sidebar {
+  width: 264px;
+  height: 100%;
+  padding: 1rem 0.75rem !important;
+  border-right: 1px solid color-mix(in srgb, var(--primary-color) 15%, var(--border-color));
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--primary-color) 5%, transparent), transparent 28%),
+    color-mix(in srgb, var(--card-bg) 88%, var(--body-bg));
+}
+
+.app-sidenav {
+  gap: 0.2rem;
+}
+
+.sidenav-protocol-card {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  margin: 0.15rem 0.2rem 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--accent-cyan) 25%, var(--border-color));
+  border-radius: 0.85rem;
+  background:
+    radial-gradient(circle at 110% -20%, color-mix(in srgb, var(--accent-cyan) 17%, transparent), transparent 55%),
+    color-mix(in srgb, var(--card-bg-secondary) 72%, transparent);
+}
+
+.sidenav-protocol-card::after {
+  position: absolute;
+  right: -1rem;
+  bottom: -1.4rem;
+  width: 4.5rem;
+  height: 4.5rem;
+  content: '';
+  border: 1px solid color-mix(in srgb, var(--primary-color) 30%, transparent);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0.6rem color-mix(in srgb, var(--primary-color) 6%, transparent), 0 0 0 1.2rem color-mix(in srgb, var(--accent-cyan) 4%, transparent);
+}
+
+.sidenav-protocol-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.48rem;
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidenav-protocol-card strong {
+  margin-top: 0.18rem;
+  font-family: var(--font-family-mono);
+  font-size: 1rem;
+  letter-spacing: -0.04em;
+}
+
+.sidenav-protocol-card small {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+}
+
+.app-sidenav .nav-link {
+  min-height: 2.55rem;
+  padding: 0.58rem 0.82rem;
+  border: 1px solid transparent;
+  border-radius: 0.7rem;
+  font-weight: 500;
+}
+
+.app-sidenav .nav-link:hover,
+.app-sidenav .nav-link:focus {
+  border-color: color-mix(in srgb, var(--primary-color) 18%, var(--border-color));
+  background: color-mix(in srgb, var(--primary-color) 6%, var(--card-bg-secondary));
+}
+
+.app-sidenav .nav-link.active {
+  color: var(--primary-color);
+  border-color: color-mix(in srgb, var(--primary-color) 28%, var(--border-color));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--primary-color) 12%, transparent), color-mix(in srgb, var(--accent-cyan) 5%, transparent));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, white 22%, transparent);
+}
+
+.app-sidenav .nav-link.active::before {
+  top: 0.62rem;
+  bottom: 0.62rem;
+  left: 0.27rem;
+  width: 0.16rem;
+  box-shadow: 0 0 0.65rem var(--primary-color);
+}
+
+.main-content.p-3 {
+  padding: clamp(1rem, 2vw, 1.8rem) !important;
+}
+
+.main-content,
+.view-panel,
+.tab-content-panel,
+.playground-layout {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.main-content::before {
+  position: fixed;
+  z-index: -1;
+  top: 5rem;
+  right: 0;
+  bottom: 0;
+  left: 264px;
+  pointer-events: none;
+  content: '';
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 4%, transparent), transparent 35%);
+}
+
+.view-panel {
+  animation: panel-enter 220ms ease-out;
+}
+
+@keyframes panel-enter {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.interface-eyebrow {
+  display: block;
+  margin-bottom: 0.32rem;
+  color: var(--primary-color);
+  font-family: var(--font-family-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.card {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 10%, var(--border-color));
+  background: color-mix(in srgb, var(--card-bg) 96%, transparent);
+}
+
+.card:hover {
+  transform: none;
+}
+
+.card-header {
+  min-height: 3.6rem;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--primary-color) 7%, transparent), transparent 52%),
+    var(--card-bg-secondary);
+  border-bottom-color: color-mix(in srgb, var(--primary-color) 14%, var(--border-color));
+}
+
+.card-header::after {
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-cyan), transparent 70%);
+  opacity: 0.55;
+}
+
+.connection-console {
+  min-height: 220px;
+  border-color: color-mix(in srgb, var(--primary-color) 25%, var(--border-color));
+  box-shadow: var(--box-shadow-lg);
+}
+
+.connection-console .card-header {
+  padding: 1rem 1.2rem;
+}
+
+.connection-console .card-body {
+  padding: clamp(1rem, 2vw, 1.5rem);
+}
+
+.connection-console .form-label {
+  font-family: var(--font-family-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.connection-console .input-group {
+  padding: 0.22rem;
+  border: 1px solid var(--input-border);
+  border-radius: 0.85rem;
+  background: var(--input-bg);
+  box-shadow: inset 0 1px 2px color-mix(in srgb, var(--text-color) 4%, transparent);
+}
+
+.connection-console .input-group:focus-within {
+  border-color: var(--input-focus-border);
+  box-shadow: var(--focus-ring);
+}
+
+.connection-console .input-group .form-control {
+  min-height: 3rem;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  font-family: var(--font-family-mono);
+  font-size: 0.86rem;
+}
+
+.connection-console .input-group .btn {
+  min-width: 7rem;
+  border-radius: 0.62rem !important;
+}
+
+.connection-help {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.65rem;
+}
+
+.connection-help span:not(:last-child) {
+  display: inline-flex;
+  padding: 0.18rem 0.48rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--card-bg-secondary);
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.61rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.connection-help span:last-child {
+  flex-basis: 100%;
+}
+
+.btn-primary {
+  border-color: transparent;
+  background: var(--accent-gradient);
+  box-shadow: 0 10px 22px -14px color-mix(in srgb, var(--primary-color) 90%, black);
+}
+
+.btn-primary:hover {
+  border-color: transparent;
+  background: linear-gradient(120deg, var(--primary-hover), var(--accent-cyan));
+  box-shadow: 0 14px 28px -14px color-mix(in srgb, var(--primary-color) 95%, black);
+  transform: translateY(-1px);
+}
+
+.nav-tabs {
+  width: fit-content;
+  max-width: 100%;
+  margin-bottom: 0.85rem;
+  padding: 0.28rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.82rem;
+  background: color-mix(in srgb, var(--card-bg-secondary) 78%, transparent);
+  box-shadow: var(--box-shadow);
+}
+
+.nav-tabs .nav-link {
+  min-height: 2.35rem;
+  border: 1px solid transparent !important;
+  border-radius: 0.58rem !important;
+  background: transparent;
+  font-family: var(--font-family-mono);
+  font-size: 0.72rem;
+}
+
+.nav-tabs .nav-link.active {
+  border-color: color-mix(in srgb, var(--primary-color) 22%, var(--border-color)) !important;
+  background: var(--card-bg) !important;
+  box-shadow: 0 7px 16px -12px rgba(5, 24, 31, 0.7);
+}
+
+.nav-tabs .nav-link.active::after,
+.active-tab-override::after {
+  display: none;
+}
+
+.suggested-servers-panel .card-body {
+  padding: 1.1rem !important;
+}
+
+.suggested-server-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.suggested-servers-panel .suggested-server-row {
+  overflow: hidden;
+  min-width: 0;
+  padding: 0;
+  border: 1px solid var(--border-color) !important;
+  border-radius: 0.82rem;
+  background: color-mix(in srgb, var(--card-bg) 92%, transparent);
+  box-shadow: none;
+}
+
+.suggested-server-action {
+  display: flex;
+  width: 100%;
+  min-height: 100%;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem;
+  color: inherit;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.suggested-server-action:hover:not(:disabled),
+.suggested-server-action:focus-visible {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 8%, transparent), color-mix(in srgb, var(--accent-cyan) 5%, transparent));
+  outline: 0;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary-color) 32%, transparent);
+}
+
+.suggested-server-action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.suggested-server-logo,
+.catalog-server-logo {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.3rem;
+  object-fit: contain;
+  border: 1px solid var(--border-color);
+  border-radius: 0.72rem;
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.suggested-server-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.suggested-server-title-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+  color: var(--text-color);
+}
+
+.suggested-server-title-row span {
+  color: var(--primary-color);
+}
+
+.suggested-server-copy p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 0 0 0.55rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.suggested-server-copy small {
+  display: block;
+  overflow: hidden;
+  color: var(--primary-color);
+  font-family: var(--font-family-mono);
+  font-size: 0.62rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.catalog-command-bar {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(620px, 1.2fr);
+  gap: clamp(1.25rem, 3vw, 3rem);
+  align-items: end;
+  margin-bottom: 1rem;
+  padding: clamp(1.2rem, 2.5vw, 2rem);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 24%, var(--border-color));
+  border-radius: 1.15rem;
+  background:
+    radial-gradient(circle at 105% -15%, color-mix(in srgb, var(--accent-cyan) 15%, transparent), transparent 42%),
+    linear-gradient(120deg, color-mix(in srgb, var(--primary-color) 8%, transparent), transparent 42%),
+    var(--card-bg);
+  box-shadow: var(--box-shadow-lg);
+}
+
+.catalog-command-bar::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  content: '';
+  background: linear-gradient(var(--primary-color), var(--accent-cyan));
+  box-shadow: 0 0 1.2rem var(--primary-color);
+}
+
+.catalog-command-copy h2 {
+  font-size: clamp(1.7rem, 3vw, 2.35rem);
+  letter-spacing: -0.045em;
+}
+
+.catalog-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.catalog-counts span {
+  padding: 0.35rem 0.58rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--card-bg-secondary) 70%, transparent);
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+}
+
+.catalog-counts strong {
+  color: var(--text-color);
+}
+
+.catalog-filters {
+  display: grid;
+  grid-template-columns: minmax(210px, 1fr) auto minmax(150px, 0.6fr);
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.catalog-filters .form-label {
+  color: var(--text-muted);
+  font-family: var(--font-family-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.catalog-filters .form-control,
+.catalog-filters .form-select,
+.catalog-filters .btn {
+  min-height: 2.8rem;
+}
+
+.catalog-server-card {
+  min-height: 360px;
+  border-color: color-mix(in srgb, var(--primary-color) 13%, var(--border-color));
+}
+
+.catalog-server-card::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 2px;
+  content: '';
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-cyan), transparent 72%);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.catalog-server-card:hover {
+  border-color: color-mix(in srgb, var(--primary-color) 28%, var(--border-color));
+  box-shadow: var(--box-shadow-xl);
+  transform: translateY(-2px);
+}
+
+.catalog-server-card:hover::before {
+  opacity: 0.8;
+}
+
+.catalog-server-description {
+  line-height: 1.55;
+}
+
+.catalog-status-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  box-shadow: 0 0 0 0.24rem color-mix(in srgb, var(--success-color) 10%, transparent);
+}
+
+.catalog-refresh {
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 0.52rem;
+}
+
+.badge {
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  font-family: var(--font-family-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.view-panel .container-fluid.py-4 {
+  padding-top: 1rem !important;
+}
+
+.view-panel .container-fluid.py-4 > .row > .col {
+  padding: clamp(1.2rem, 3vw, 2.5rem);
+  border: 1px solid var(--border-color);
+  border-radius: 1.1rem;
+  background: color-mix(in srgb, var(--card-bg) 94%, transparent);
+  box-shadow: var(--box-shadow-lg);
+}
+
+.view-panel .container-fluid.py-4 .lead {
+  color: color-mix(in srgb, var(--text-color) 82%, var(--text-muted));
+  font-size: clamp(1rem, 1.5vw, 1.18rem);
+  line-height: 1.72;
+}
+
+.view-panel .container-fluid.py-4 h2 {
+  padding-top: 0.85rem;
+  border-top: 1px solid color-mix(in srgb, var(--primary-color) 13%, var(--border-color));
+}
+
+pre.bg-light {
+  position: relative;
+  color: #cdf5e9 !important;
+  border: 1px solid #21444a;
+  background:
+    linear-gradient(rgba(54, 224, 170, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(81, 216, 244, 0.035) 1px, transparent 1px),
+    #071418 !important;
+  background-size: 24px 24px !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 18px 34px -28px #000;
+}
+
+pre.bg-light code {
+  color: inherit;
+  font-family: var(--font-family-mono);
+}
+
+:root[data-theme='dark'] .app-logo {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.025), 0 10px 30px -15px var(--primary-color);
+}
+
+:root[data-theme='dark'] .btn-primary {
+  color: #03130f;
+}
+
+:root[data-theme='dark'] .catalog-server-logo,
+:root[data-theme='dark'] .suggested-server-logo {
+  background: #f7fffc;
+}
+
+@media (max-width: 1199.98px) {
+  .catalog-command-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-filters {
+    grid-template-columns: minmax(220px, 1fr) auto minmax(160px, 0.65fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .protocol-matrix-label,
+  .protocol-chip:not(.protocol-chip-modern) {
+    display: none;
+  }
+
+  .catalog-filters {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .catalog-search-field {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    min-height: 4.4rem;
+  }
+
+  .app-brand-copy {
+    display: block;
+  }
+
+  .app-brand-eyebrow {
+    display: none;
+  }
+
+  .mobile-sidebar {
+    width: min(88vw, 310px);
+    padding: 1rem 0.75rem;
+    background: var(--card-bg);
+  }
+
+  .main-content.p-3 {
+    padding: 0.75rem !important;
+  }
+
+  .main-content::before {
+    left: 0;
+  }
+
+  .connection-console .card-header {
+    flex-direction: column;
+    align-items: flex-start !important;
+    gap: 0.75rem;
+  }
+
+  .connection-console .card-header > div:last-child {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .connection-console .input-group {
+    display: grid;
+    gap: 0.25rem;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .connection-console .input-group .form-control,
+  .connection-console .input-group .btn {
+    width: 100%;
+    min-width: 0;
+    border-radius: 0.62rem !important;
+  }
+
+  .connection-console,
+  .suggested-servers-panel {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .connection-help span:last-child {
+    overflow-wrap: anywhere;
+  }
+
+  .playground-layout.row {
+    width: 100%;
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  .catalog-command-bar {
+    border-radius: 0.9rem;
+  }
+
+  .catalog-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-search-field {
+    grid-column: auto;
+  }
+
+  .catalog-filters .btn-group {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .suggested-server-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .view-panel .container-fluid.py-4 > .row > .col {
+    padding: 1.15rem;
+    border-radius: 0.85rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .view-panel,
+  .card,
+  .btn {
+    animation: none !important;
+    transition: none !important;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3058,6 +3058,10 @@ pre.bg-light code {
     display: none;
   }
 
+  .suggested-server-grid {
+    grid-template-columns: 1fr;
+  }
+
   .catalog-filters {
     grid-template-columns: 1fr 1fr;
   }
@@ -3150,10 +3154,6 @@ pre.bg-light code {
   .catalog-filters .btn-group {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-  }
-
-  .suggested-server-grid {
-    grid-template-columns: 1fr;
   }
 
   .view-panel .container-fluid.py-4 > .row > .col {


### PR DESCRIPTION
## Summary
- give the application shell a focused MCP/AI protocol-workbench visual system
- add visible 2026 stateless and 2025 compatibility negotiation cues
- redesign the endpoint console, tab rail, quick-start server matrix, catalog command bar, and server cards
- add polished light and dark themes with restrained grid, glow, data-label, and code-surface treatments
- improve mobile composition and replace clickable anchors/divs with proper buttons where touched

## Verification
- npm test -- --run (56 tests)
- npx tsc --noEmit
- npm run build (26 SEO server profiles generated)
- desktop light and dark visual review at 1440px
- mobile Chromium emulation at 390x844 with document/body width 390 and zero overflowing elements
- git diff --check

## Notes
The redesign keeps the existing information architecture and MCP behavior intact; it changes presentation and interaction affordances only.