### PR TITLE
Modernize dual-era MCP report execution

### DIFF
--- a/.propr/setup.sh
+++ b/.propr/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="${PROPR_WORKSPACE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+PROPR_CACHE_DIR="${PROPR_CACHE_DIR:-/tmp/propr-setup-cache}"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js 22 or newer is required to prepare this workspace." >&2
+  exit 1
+fi
+
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]")"
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  echo "Workspace setup requires Node.js 22 or newer. Current version: $(node -v)" >&2
+  exit 1
+fi
+
+export npm_config_cache="$PROPR_CACHE_DIR/npm"
+mkdir -p "$npm_config_cache"
+
+npm ci --prefix "$WORKSPACE"
+npm ci --prefix "$WORKSPACE/cors-proxy-worker"

--- a/cors-proxy-worker/src/index.test.ts
+++ b/cors-proxy-worker/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { fetchTargetRequest, getTargetRequestHeaders } from './index';
+import proxyWorker, {
+  PROXY_RESPONSE_SOURCE_HEADER,
+  fetchTargetRequest,
+  getTargetRequestHeaders,
+  withCorsResponseHeaders,
+} from './index';
 
 describe('proxy target credential forwarding', () => {
   it('replaces proxy authorization with the isolated target credential', () => {
@@ -72,5 +77,23 @@ describe('proxy target credential forwarding', () => {
 
     expect(requests).toHaveLength(1);
     expect(requests[0].url).toBe('https://example.com/mcp');
+  });
+
+  it('marks upstream responses separately from proxy-owned responses', async () => {
+    const targetResponse = withCorsResponseHeaders(
+      new Response('Target authentication required', { status: 401 }),
+      'target'
+    );
+    const proxyResponse = await proxyWorker.fetch(
+      new Request('https://proxy.mcptest.test/'),
+      { FIREBASE_PROJECT_ID: 'test-project' }
+    );
+
+    expect(targetResponse.headers.get(PROXY_RESPONSE_SOURCE_HEADER)).toBe('target');
+    expect(targetResponse.headers.get('access-control-expose-headers')).toContain(
+      PROXY_RESPONSE_SOURCE_HEADER.toLowerCase()
+    );
+    expect(proxyResponse.status).toBe(400);
+    expect(proxyResponse.headers.get(PROXY_RESPONSE_SOURCE_HEADER)).toBe('proxy');
   });
 });

--- a/cors-proxy-worker/src/index.test.ts
+++ b/cors-proxy-worker/src/index.test.ts
@@ -96,4 +96,29 @@ describe('proxy target credential forwarding', () => {
     expect(proxyResponse.status).toBe(400);
     expect(proxyResponse.headers.get(PROXY_RESPONSE_SOURCE_HEADER)).toBe('proxy');
   });
+
+  it('allows caller-provided custom target headers during preflight', async () => {
+    const response = await proxyWorker.fetch(
+      new Request('https://proxy.mcptest.test/', {
+        method: 'OPTIONS',
+        headers: {
+          'Access-Control-Request-Headers': 'content-type, x-tenant-id, x-vendor-auth',
+        },
+      }),
+      { FIREBASE_PROJECT_ID: 'test-project' }
+    );
+    const allowedHeaders = response.headers
+      .get('access-control-allow-headers')
+      ?.toLowerCase()
+      .split(', ');
+
+    expect(response.status).toBe(200);
+    expect(allowedHeaders).toEqual(expect.arrayContaining([
+      'authorization',
+      'mcp-protocol-version',
+      'x-mcp-authorization',
+      'x-tenant-id',
+      'x-vendor-auth',
+    ]));
+  });
 });

--- a/cors-proxy-worker/src/index.ts
+++ b/cors-proxy-worker/src/index.ts
@@ -221,7 +221,7 @@ function getCorsHeaders(source: ProxyResponseSource = 'proxy'): Record<string, s
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': '*',
+    'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type, Last-Event-ID, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id, X-MCP-Authorization, x-api-key',
     [PROXY_RESPONSE_SOURCE_HEADER]: source,
   };
 }

--- a/cors-proxy-worker/src/index.ts
+++ b/cors-proxy-worker/src/index.ts
@@ -7,6 +7,9 @@ interface Env {
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const MAX_TARGET_REDIRECTS = 20;
+export const PROXY_RESPONSE_SOURCE_HEADER = 'X-MCP-Proxy-Response-Source';
+
+type ProxyResponseSource = 'proxy' | 'target';
 
 export function getTargetRequestHeaders(requestHeaders: HeadersInit): Headers {
   const headers = new Headers(requestHeaders);
@@ -72,6 +75,21 @@ export async function fetchTargetRequest(
   }
 
   throw new Error('Target exceeded the maximum redirect count');
+}
+
+export function withCorsResponseHeaders(
+  response: Response,
+  source: ProxyResponseSource
+): Response {
+  const mutableResponse = new Response(response.body, response);
+  const corsHeaders = getCorsHeaders(source);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    mutableResponse.headers.set(key, value);
+  }
+
+  const exposedHeaders = Array.from(mutableResponse.headers.keys()).join(', ');
+  mutableResponse.headers.set('Access-Control-Expose-Headers', exposedHeaders);
+  return mutableResponse;
 }
 
 // Firebase public keys URL
@@ -169,20 +187,7 @@ export default {
       // Make the actual request to the target server
       const response = await fetchTargetRequest(newRequest);
 
-      // Create a mutable copy of the response with CORS headers
-      const mutableResponse = new Response(response.body, response);
-      
-      // Set CORS headers
-      const corsHeaders = getCorsHeaders();
-      for (const [key, value] of Object.entries(corsHeaders)) {
-        mutableResponse.headers.set(key, value);
-      }
-
-      // Allow the client to access any headers from the proxied response
-      const exposedHeaders = Array.from(mutableResponse.headers.keys()).join(', ');
-      mutableResponse.headers.set('Access-Control-Expose-Headers', exposedHeaders);
-      
-      return mutableResponse;
+      return withCorsResponseHeaders(response, 'target');
 
     } catch (error) {
       console.error('Proxy error:', error);
@@ -212,11 +217,12 @@ function handleOptions(request: Request): Response {
 /**
  * Returns standard CORS headers
  */
-function getCorsHeaders(): Record<string, string> {
+function getCorsHeaders(source: ProxyResponseSource = 'proxy'): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': '*',
+    [PROXY_RESPONSE_SOURCE_HEADER]: source,
   };
 }
 

--- a/cors-proxy-worker/src/index.ts
+++ b/cors-proxy-worker/src/index.ts
@@ -8,6 +8,19 @@ interface Env {
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const MAX_TARGET_REDIRECTS = 20;
 export const PROXY_RESPONSE_SOURCE_HEADER = 'X-MCP-Proxy-Response-Source';
+const REQUIRED_CORS_REQUEST_HEADERS = [
+  'Accept',
+  'Authorization',
+  'Content-Type',
+  'Last-Event-ID',
+  'MCP-Protocol-Version',
+  'Mcp-Method',
+  'Mcp-Name',
+  'Mcp-Session-Id',
+  'X-MCP-Authorization',
+  'x-api-key',
+];
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 type ProxyResponseSource = 'proxy' | 'target';
 
@@ -206,22 +219,62 @@ export default {
  * Handles CORS preflight (OPTIONS) requests
  */
 function handleOptions(request: Request): Response {
+  let allowedHeaders: string;
+  try {
+    allowedHeaders = getAllowedRequestHeaders(
+      request.headers.get('Access-Control-Request-Headers')
+    );
+  } catch (error) {
+    return new Response(
+      error instanceof Error ? error.message : 'Invalid CORS request headers.',
+      {
+        status: 400,
+        headers: {
+          ...getCorsHeaders(),
+          'Vary': 'Access-Control-Request-Headers',
+        },
+      }
+    );
+  }
+
   return new Response(null, { 
     headers: {
-      ...getCorsHeaders(),
+      ...getCorsHeaders('proxy', allowedHeaders),
       'Access-Control-Max-Age': '86400', // Cache preflight for 24 hours
+      'Vary': 'Access-Control-Request-Headers',
     }
   });
+}
+
+function getAllowedRequestHeaders(requestedHeaders: string | null): string {
+  const allowedHeaders = new Map(
+    REQUIRED_CORS_REQUEST_HEADERS.map(header => [header.toLowerCase(), header])
+  );
+
+  if (requestedHeaders) {
+    for (const requestedHeader of requestedHeaders.split(',')) {
+      const header = requestedHeader.trim();
+      if (!header || !HTTP_HEADER_NAME_PATTERN.test(header)) {
+        throw new Error('Error: Invalid Access-Control-Request-Headers value.');
+      }
+      allowedHeaders.set(header.toLowerCase(), header);
+    }
+  }
+
+  return Array.from(allowedHeaders.values()).join(', ');
 }
 
 /**
  * Returns standard CORS headers
  */
-function getCorsHeaders(source: ProxyResponseSource = 'proxy'): Record<string, string> {
+function getCorsHeaders(
+  source: ProxyResponseSource = 'proxy',
+  allowedHeaders = REQUIRED_CORS_REQUEST_HEADERS.join(', ')
+): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type, Last-Event-ID, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id, X-MCP-Authorization, x-api-key',
+    'Access-Control-Allow-Headers': allowedHeaders,
     [PROXY_RESPONSE_SOURCE_HEADER]: source,
   };
 }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { classifySavedCardAuthenticationFailure } from './App';
+
+describe('saved card authentication failures', () => {
+  it('does not request OAuth for a direct JSON-RPC Forbidden application error', () => {
+    const error = new Error('MCP error -32000: Forbidden operation');
+
+    expect(classifySavedCardAuthenticationFailure(error, false)).toBeUndefined();
+  });
+});

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,10 +1,55 @@
 import { describe, expect, it } from 'vitest';
 import { classifySavedCardAuthenticationFailure } from './App';
+import {
+  ProxiedAuthenticationError,
+  TransportConnectionError,
+} from './utils/transportDetection';
 
 describe('saved card authentication failures', () => {
   it('does not request OAuth for a direct JSON-RPC Forbidden application error', () => {
     const error = new Error('MCP error -32000: Forbidden operation');
 
     expect(classifySavedCardAuthenticationFailure(error, false)).toBeUndefined();
+  });
+
+  it('classifies a structured direct HTTP authentication status as target OAuth', () => {
+    const error = Object.assign(new Error('Request failed'), { status: 401 });
+
+    expect(classifySavedCardAuthenticationFailure(error, false)).toEqual({
+      status: 401,
+      source: 'target',
+    });
+  });
+
+  it('preserves target provenance through nested proxy connection failures', () => {
+    const targetError = new ProxiedAuthenticationError(
+      403,
+      'target',
+      new Error('Upstream denied the request')
+    );
+
+    expect(classifySavedCardAuthenticationFailure(
+      new TransportConnectionError([targetError]),
+      true
+    )).toEqual({ status: 403, source: 'target' });
+  });
+
+  it('keeps proxy-owned authentication failures out of target OAuth', () => {
+    const proxyError = new ProxiedAuthenticationError(
+      401,
+      'proxy',
+      new Error('Proxy session expired')
+    );
+
+    expect(classifySavedCardAuthenticationFailure(proxyError, true)).toEqual({
+      status: 401,
+      source: 'proxy',
+    });
+  });
+
+  it('does not guess the source of an unproven proxied HTTP status', () => {
+    const ambiguousError = Object.assign(new Error('Request failed'), { status: 401 });
+
+    expect(classifySavedCardAuthenticationFailure(ambiguousError, true)).toBeUndefined();
   });
 });

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -12,6 +12,14 @@ describe('saved card authentication failures', () => {
     expect(classifySavedCardAuthenticationFailure(error, false)).toBeUndefined();
   });
 
+  it('does not treat application-defined JSON-RPC data as an HTTP challenge', () => {
+    const error = Object.assign(new Error('MCP application error'), {
+      data: { status: 403 },
+    });
+
+    expect(classifySavedCardAuthenticationFailure(error, false)).toBeUndefined();
+  });
+
   it('classifies a structured direct HTTP authentication status as target OAuth', () => {
     const error = Object.assign(new Error('Request failed'), { status: 401 });
 

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -29,6 +29,14 @@ describe('saved card authentication failures', () => {
     });
   });
 
+  it('uses an observed direct response challenge for saved-card OAuth', () => {
+    expect(classifySavedCardAuthenticationFailure(
+      new Error('Transport rejected the request'),
+      false,
+      { status: 403, source: 'target' }
+    )).toEqual({ status: 403, source: 'target' });
+  });
+
   it('preserves target provenance through nested proxy connection failures', () => {
     const targetError = new ProxiedAuthenticationError(
       403,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,11 @@ import { formatErrorForDisplay } from './utils/errorHandling';
 import { getCatalogServerById } from './utils/catalogUtils';
 import { getCatalogServerIdFromPath } from './utils/catalogSeo';
 import { attemptParallelConnections } from './utils/transportDetection';
-import { getSavedCardConnectionPlan } from './utils/savedCardConnection';
+import {
+  getSavedCardConnectionPlan,
+  getSavedResourceUri,
+  SavedResourceCardMigrationError,
+} from './utils/savedCardConnection';
 
 // Constants for localStorage keys
 const SPACES_KEY = 'mcpSpaces'; // New key for dashboards
@@ -1232,6 +1236,9 @@ function App() {
       try {
         console.log(`[Execute Card ${cardId} Attempt ${attempt}/${MAX_RETRIES}] Starting execution. Card URL: ${card.serverUrl}`);
         lastError = null; // Clear last error on new attempt
+        const resourceUri = card.type === 'resource'
+          ? getSavedResourceUri(card.name, card.params)
+          : undefined;
 
         // --- Connection and Request Logic ---
         // Check for OAuth token first - use the original card.serverUrl for OAuth token lookup
@@ -1278,8 +1285,8 @@ function App() {
             console.log(`[Execute Card ${cardId} Attempt ${attempt}] Tool result received.`);
             setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, responseData: result.content, responseType: 'tool_result', error: null }));
         } else if (card.type === 'resource') {
-            console.log(`[Execute Card ${cardId} Attempt ${attempt}] Accessing resource: ${card.name}`);
-            result = await tempClient.readResource({ uri: card.name });
+            console.log(`[Execute Card ${cardId} Attempt ${attempt}] Accessing resource: ${resourceUri}`);
+            result = await tempClient.readResource({ uri: resourceUri as string });
             console.log(`[Execute Card ${cardId} Attempt ${attempt}] Resource result received.`);
             setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, responseData: result.contents, responseType: 'resource_result', error: null }));
         }
@@ -1321,12 +1328,14 @@ function App() {
           });
           
           // Mark error with auth information for UI handling
-          const errorWithAuthInfo = {
-            ...errorDetails,
-            isAuthError: is401Error,
-            serverUrl: card.serverUrl,
-            isProxied: shouldUseProxy
-          };
+          const errorWithAuthInfo = err instanceof SavedResourceCardMigrationError
+            ? errorDetails
+            : {
+                ...errorDetails,
+                isAuthError: is401Error,
+                serverUrl: card.serverUrl,
+                isProxied: shouldUseProxy
+              };
           
           setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, error: errorWithAuthInfo, responseData: null, responseType: 'error' }));
           break; // Exit the loop

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,25 +30,23 @@ import OAuthConfig from './components/OAuthConfig';
 // Import Data Sync Hook
 import { useDataSync } from './hooks/useDataSync';
 import { useMetaTags } from './hooks/useMetaTags';
+import { useAuth } from './context/AuthContext';
 
 import { v4 as uuidv4 } from 'uuid';
 
 // Import Types
 import {
-  Space, SpaceCard,
-  AccessResourceResultSchema, // Import the result schema
-  ConnectionTab
+  Space, SpaceCard, ConnectionTab
 } from './types';
 import type { CatalogServer } from './types/catalog';
 
 // Import Utils
 import { generateSpaceSlug, findSpaceBySlug, getSpaceUrl, extractSlugFromPath, parseServerUrl, parseResultShareUrl } from './utils/urlUtils';
-import { CorsAwareStreamableHTTPTransport } from './utils/corsAwareTransport';
-import { CorsAwareSSETransport } from './utils/corsAwareSseTransport';
 import { formatErrorForDisplay } from './utils/errorHandling';
 import { getCatalogServerById } from './utils/catalogUtils';
 import { getCatalogServerIdFromPath } from './utils/catalogSeo';
-import { createLegacyMcpClient, createNegotiatingMcpClient } from './utils/mcpClient';
+import { attemptParallelConnections } from './utils/transportDetection';
+import { getSavedCardConnectionPlan } from './utils/savedCardConnection';
 
 // Constants for localStorage keys
 const SPACES_KEY = 'mcpSpaces'; // New key for dashboards
@@ -144,6 +142,7 @@ declare global {
 }
 
 function App() {
+  const { currentUser } = useAuth();
   // --- State ---
   const [theme, setTheme] = useState<'light' | 'dark'>(getInitialTheme);
   const [spaces, setSpaces] = useState<Space[]>(() => {
@@ -1235,65 +1234,41 @@ function App() {
         lastError = null; // Clear last error on new attempt
 
         // --- Connection and Request Logic ---
-        let connectUrl: URL;
-        let serverUrl = card.serverUrl;
-        
         // Check for OAuth token first - use the original card.serverUrl for OAuth token lookup
         const originalServerHost = new URL(card.serverUrl).host;
         const oauthToken = sessionStorage.getItem(`oauth_access_token_${originalServerHost}`);
-        const transportOptions: any = {};
-        
-        if (oauthToken) {
-          console.log(`[Execute Card ${cardId}] Using OAuth token for authentication`);
-          // Use consistent Bearer token format for all services
-          transportOptions.headers = {
-            'Authorization': `Bearer ${oauthToken}`
-          };
-        }
-        
-        // Determine if proxy should be used
-        shouldUseProxy = false; // Reset for each attempt
-        
-        // If card.useProxy is explicitly set, respect that
-        if (card.useProxy !== undefined) {
-          shouldUseProxy = card.useProxy;
-        } else if (!oauthToken && import.meta.env.VITE_PROXY_URL) {
-          // If no OAuth token and proxy is available, use proxy by default
-          shouldUseProxy = true;
-        }
-        
-        // Apply proxy to the server URL if needed
-        if (shouldUseProxy && import.meta.env.VITE_PROXY_URL) {
-          const proxyUrl = import.meta.env.VITE_PROXY_URL;
-          serverUrl = `${proxyUrl}?target=${encodeURIComponent(card.serverUrl)}`;
-          console.log(`[Execute Card ${cardId}] Using proxy: ${proxyUrl}`);
-        }
-        
-        try {
-            connectUrl = new URL(serverUrl);
-            // Don't append /mcp if the URL already ends with /sse or /mcp
-            if (!connectUrl.pathname.endsWith('/mcp') && !connectUrl.pathname.endsWith('/sse')) {
-                connectUrl.pathname = (connectUrl.pathname.endsWith('/') ? connectUrl.pathname : connectUrl.pathname + '/') + 'mcp';
-            }
-        } catch (e) {
-            throw new Error(`Invalid Server URL format in card: ${card.serverUrl}`);
+        const proxyUrl = import.meta.env.VITE_PROXY_URL;
+        const proxySelected = Boolean(
+          proxyUrl && (card.useProxy !== undefined ? card.useProxy : !oauthToken)
+        );
+        const proxyAuthToken = proxySelected && currentUser
+          ? await currentUser.getIdToken()
+          : undefined;
+        const connectionPlan = getSavedCardConnectionPlan({
+          serverUrl: card.serverUrl,
+          useProxy: card.useProxy,
+          oauthToken,
+          proxyUrl,
+          proxyAuthToken,
+        });
+        shouldUseProxy = connectionPlan.usesProxy;
+
+        if (connectionPlan.usesProxy) {
+          console.log(`[Execute Card ${cardId}] Using authenticated proxy: ${proxyUrl}`);
+        } else if (oauthToken) {
+          console.log(`[Execute Card ${cardId}] Using OAuth target authentication`);
         }
 
-        // Use SSE transport for SSE endpoints, HTTP transport for others
-        let transport;
-        if (connectUrl.pathname.endsWith('/sse')) {
-          tempClient = createLegacyMcpClient(`mcp-card-executor-${cardId}-${attempt}`);
-          console.log(`[Execute Card ${cardId} Attempt ${attempt}] Using SSE transport for ${connectUrl.toString()}`);
-          transport = new CorsAwareSSETransport(connectUrl, transportOptions);
-        } else {
-          tempClient = createNegotiatingMcpClient(`mcp-card-executor-${cardId}-${attempt}`);
-          console.log(`[Execute Card ${cardId} Attempt ${attempt}] Using HTTP transport for ${connectUrl.toString()}`);
-          transport = new CorsAwareStreamableHTTPTransport(connectUrl, transportOptions);
-        }
-
-        console.log(`[Execute Card ${cardId} Attempt ${attempt}] Connecting temporary client...`);
-        await tempClient.connect(transport);
-        console.log(`[Execute Card ${cardId} Attempt ${attempt}] Temporary client connected.`);
+        const connection = await attemptParallelConnections(
+          connectionPlan.connectionUrl,
+          undefined,
+          connectionPlan.authToken,
+          connectionPlan.targetHeaders
+        );
+        tempClient = connection.client;
+        console.log(
+          `[Execute Card ${cardId} Attempt ${attempt}] Connected with ${connection.transportType} (${connection.protocolEra}${connection.protocolVersion ? `, ${connection.protocolVersion}` : ''}) at ${connection.url}`
+        );
 
         let result: any;
         if (card.type === 'tool') {
@@ -1303,12 +1278,9 @@ function App() {
             setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, responseData: result.content, responseType: 'tool_result', error: null }));
         } else if (card.type === 'resource') {
             console.log(`[Execute Card ${cardId} Attempt ${attempt}] Accessing resource: ${card.name}`);
-            result = await tempClient.request({
-                method: 'resources/access',
-                params: { uri: card.name, arguments: card.params }
-            }, AccessResourceResultSchema);
+            result = await tempClient.readResource({ uri: card.name });
             console.log(`[Execute Card ${cardId} Attempt ${attempt}] Resource result received.`);
-            setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, responseData: result.content, responseType: 'resource_result', error: null }));
+            setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: false, responseData: result.contents, responseType: 'resource_result', error: null }));
         }
         // --- Success: Break the retry loop ---
         break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,6 @@ const getAuthenticationHttpStatus = (
     data?: { status?: unknown };
     response?: { status?: unknown };
     cause?: unknown;
-    message?: unknown;
   };
   const status = [
     value.status,
@@ -121,16 +120,10 @@ const getAuthenticationHttpStatus = (
 
   const causeStatus = getAuthenticationHttpStatus(value.cause, seen);
   if (causeStatus) return causeStatus;
-
-  const message = typeof value.message === 'string' ? value.message : '';
-  if (/\b403\b|forbidden/i.test(message)) return 403;
-  if (/\b401\b|unauthorized|invalid_token|missing or invalid access token/i.test(message)) {
-    return 401;
-  }
   return undefined;
 };
 
-const classifySavedCardAuthenticationFailure = (
+export const classifySavedCardAuthenticationFailure = (
   error: unknown,
   usesProxy: boolean,
   observedChallenge?: ObservedAuthenticationChallenge

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,14 +99,12 @@ const getAuthenticationHttpStatus = (
   const value = error as {
     status?: unknown;
     statusCode?: unknown;
-    data?: { status?: unknown };
     response?: { status?: unknown };
     cause?: unknown;
   };
   const status = [
     value.status,
     value.statusCode,
-    value.data?.status,
     value.response?.status,
   ].find(candidate => candidate === 401 || candidate === 403);
   if (status === 401 || status === 403) return status;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,12 @@ import { generateSpaceSlug, findSpaceBySlug, getSpaceUrl, extractSlugFromPath, p
 import { formatErrorForDisplay } from './utils/errorHandling';
 import { getCatalogServerById } from './utils/catalogUtils';
 import { getCatalogServerIdFromPath } from './utils/catalogSeo';
-import { attemptParallelConnections } from './utils/transportDetection';
+import {
+  ProxiedAuthenticationError,
+  TransportConnectionError,
+  attemptParallelConnections,
+  type ObservedAuthenticationChallenge,
+} from './utils/transportDetection';
 import {
   getSavedCardConnectionPlan,
   getSavedResourceUri,
@@ -55,6 +60,91 @@ import {
 // Constants for localStorage keys
 const SPACES_KEY = 'mcpSpaces'; // New key for dashboards
 const TABS_KEY = 'mcpConnectionTabs'; // New key for tabs
+
+const getProxiedAuthenticationChallenge = (
+  error: unknown,
+  seen = new Set<object>()
+): ObservedAuthenticationChallenge | undefined => {
+  if (!error || typeof error !== 'object' || seen.has(error)) return undefined;
+  seen.add(error);
+
+  if (error instanceof ProxiedAuthenticationError) {
+    return { status: error.status, source: error.responseSource };
+  }
+
+  let proxyChallenge: ObservedAuthenticationChallenge | undefined;
+  if (error instanceof TransportConnectionError) {
+    for (const nestedError of error.errors) {
+      const challenge = getProxiedAuthenticationChallenge(nestedError, seen);
+      if (challenge?.source === 'target') return challenge;
+      if (challenge?.source === 'proxy') proxyChallenge = challenge;
+    }
+  }
+
+  const causeChallenge = getProxiedAuthenticationChallenge(
+    (error as { cause?: unknown }).cause,
+    seen
+  );
+  if (causeChallenge?.source === 'target') return causeChallenge;
+  return causeChallenge || proxyChallenge;
+};
+
+const getAuthenticationHttpStatus = (
+  error: unknown,
+  seen = new Set<object>()
+): 401 | 403 | undefined => {
+  if (!error || typeof error !== 'object' || seen.has(error)) return undefined;
+  seen.add(error);
+
+  const value = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    data?: { status?: unknown };
+    response?: { status?: unknown };
+    cause?: unknown;
+    message?: unknown;
+  };
+  const status = [
+    value.status,
+    value.statusCode,
+    value.data?.status,
+    value.response?.status,
+  ].find(candidate => candidate === 401 || candidate === 403);
+  if (status === 401 || status === 403) return status;
+
+  if (error instanceof TransportConnectionError) {
+    for (const nestedError of error.errors) {
+      const nestedStatus = getAuthenticationHttpStatus(nestedError, seen);
+      if (nestedStatus) return nestedStatus;
+    }
+  }
+
+  const causeStatus = getAuthenticationHttpStatus(value.cause, seen);
+  if (causeStatus) return causeStatus;
+
+  const message = typeof value.message === 'string' ? value.message : '';
+  if (/\b403\b|forbidden/i.test(message)) return 403;
+  if (/\b401\b|unauthorized|invalid_token|missing or invalid access token/i.test(message)) {
+    return 401;
+  }
+  return undefined;
+};
+
+const classifySavedCardAuthenticationFailure = (
+  error: unknown,
+  usesProxy: boolean,
+  observedChallenge?: ObservedAuthenticationChallenge
+): ObservedAuthenticationChallenge | undefined => {
+  const proxiedChallenge = observedChallenge || getProxiedAuthenticationChallenge(error);
+  if (proxiedChallenge) return proxiedChallenge;
+
+  // A generic proxied 401/403 has ambiguous provenance. Never turn it into a
+  // target OAuth prompt unless the proxy transport identified the responder.
+  if (usesProxy) return undefined;
+
+  const status = getAuthenticationHttpStatus(error);
+  return status ? { status, source: 'target' } : undefined;
+};
 
 // Helper function to get the initial theme
 const getInitialTheme = (): 'light' | 'dark' => {
@@ -1229,6 +1319,7 @@ function App() {
     setSpaces(prev => updateCardState(prev, spaceId, cardId, { loading: true, error: null, responseData: null, responseType: null }));
 
     let tempClient: any = null;
+    let activeConnection: Awaited<ReturnType<typeof attemptParallelConnections>> | null = null;
     let lastError: any = null;
     let shouldUseProxy = false; // Move this outside try block to make it accessible in catch block
 
@@ -1248,6 +1339,7 @@ function App() {
         const proxySelected = Boolean(
           proxyUrl && (card.useProxy !== undefined ? card.useProxy : !oauthToken)
         );
+        shouldUseProxy = proxySelected;
         const proxyAuthToken = proxySelected && currentUser
           ? await currentUser.getIdToken()
           : undefined;
@@ -1266,16 +1358,16 @@ function App() {
           console.log(`[Execute Card ${cardId}] Using OAuth target authentication`);
         }
 
-        const connection = await attemptParallelConnections(
+        activeConnection = await attemptParallelConnections(
           connectionPlan.connectionUrl,
           undefined,
           connectionPlan.authToken,
           connectionPlan.targetHeaders,
           connectionPlan.usesProxy
         );
-        tempClient = connection.client;
+        tempClient = activeConnection.client;
         console.log(
-          `[Execute Card ${cardId} Attempt ${attempt}] Connected with ${connection.transportType} (${connection.protocolEra}${connection.protocolVersion ? `, ${connection.protocolVersion}` : ''}) at ${connection.url}`
+          `[Execute Card ${cardId} Attempt ${attempt}] Connected with ${activeConnection.transportType} (${activeConnection.protocolEra}${activeConnection.protocolVersion ? `, ${activeConnection.protocolVersion}` : ''}) at ${activeConnection.url}`
         );
 
         let result: any;
@@ -1299,14 +1391,6 @@ function App() {
 
         // --- Check for different error types ---
         const isConflict = err.message?.includes('Conflict') || err.message?.includes('409') || err.status === 409;
-        const is401Error = err.message && (
-          err.message.includes('401') || 
-          err.message.toLowerCase().includes('unauthorized') ||
-          err.message.includes('invalid_token') ||
-          err.message.includes('Missing or invalid access token') ||
-          err.statusCode === 401 ||
-          err.status === 401
-        );
 
         if (isConflict && attempt < MAX_RETRIES) {
           console.log(`[Execute Card ${cardId} Attempt ${attempt}] Conflict detected, retrying after ${RETRY_DELAY_MS}ms...`);
@@ -1320,6 +1404,14 @@ function App() {
         } else {
           // --- Non-retryable error or max retries reached: Set final error state and break ---
           console.error(`[Execute Card ${cardId}] Unrecoverable error or max retries reached.`);
+
+          const authenticationChallenge = classifySavedCardAuthenticationFailure(
+            err,
+            shouldUseProxy,
+            activeConnection?.takeAuthenticationChallenge()
+          );
+          const isTargetAuthError = authenticationChallenge?.source === 'target';
+          const isProxyAuthError = authenticationChallenge?.source === 'proxy';
           
           // Use enhanced error formatting for better debugging information
           const errorDetails = formatErrorForDisplay(err, {
@@ -1330,9 +1422,25 @@ function App() {
           // Mark error with auth information for UI handling
           const errorWithAuthInfo = err instanceof SavedResourceCardMigrationError
             ? errorDetails
+            : isProxyAuthError
+            ? {
+                message: `Proxy sign-in/session error: ${errorDetails}`,
+                isAuthError: false,
+                isProxyAuthError: true,
+                authenticationSource: 'proxy',
+                status: authenticationChallenge.status,
+                serverUrl: card.serverUrl,
+                isProxied: true
+              }
             : {
                 ...errorDetails,
-                isAuthError: is401Error,
+                isAuthError: isTargetAuthError,
+                ...(authenticationChallenge
+                  ? {
+                      authenticationSource: authenticationChallenge.source,
+                      status: authenticationChallenge.status
+                    }
+                  : {}),
                 serverUrl: card.serverUrl,
                 isProxied: shouldUseProxy
               };
@@ -1357,6 +1465,7 @@ function App() {
               }
               tempClient = null; // Nullify ref after closing attempt
           }
+          activeConnection = null;
       }
     } // End of retry loop
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1426,7 +1426,7 @@ function App() {
                 isProxied: true
               }
             : {
-                ...errorDetails,
+                message: errorDetails,
                 isAuthError: isTargetAuthError,
                 ...(authenticationChallenge
                   ? {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1263,7 +1263,8 @@ function App() {
           connectionPlan.connectionUrl,
           undefined,
           connectionPlan.authToken,
-          connectionPlan.targetHeaders
+          connectionPlan.targetHeaders,
+          connectionPlan.usesProxy
         );
         tempClient = connection.client;
         console.log(

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -384,10 +384,11 @@ const ReportView: React.FC = () => {
                 <button 
                   className="btn btn-primary"
                   onClick={async () => {
+                    const authenticationUrl = report.authenticationUrl || report.serverUrl;
                     // Store the current state so we can return after OAuth
                     sessionStorage.setItem('oauth_return_view', JSON.stringify({
                       activeView: 'report',
-                      serverUrl: report.serverUrl,
+                      serverUrl: authenticationUrl,
                       timestamp: Date.now()
                     }));
                     
@@ -396,7 +397,7 @@ const ReportView: React.FC = () => {
                       const { generatePKCE } = await import('../utils/pkce');
                       const { v4: uuidv4 } = await import('uuid');
                       
-                      const oauthConfig = await getOAuthConfig(report.serverUrl);
+                      const oauthConfig = await getOAuthConfig(authenticationUrl);
                       if (!oauthConfig) {
                         alert('Failed to get OAuth configuration');
                         return;
@@ -404,9 +405,9 @@ const ReportView: React.FC = () => {
                       
                       const { code_verifier: codeVerifier, code_challenge: codeChallenge } = await generatePKCE();
                       sessionStorage.setItem('pkce_code_verifier', codeVerifier);
-                      sessionStorage.setItem('oauth_server_url', report.serverUrl);
+                      sessionStorage.setItem('oauth_server_url', authenticationUrl);
                       
-                      const serverHost = new URL(report.serverUrl.startsWith('http') ? report.serverUrl : `https://${report.serverUrl}`).hostname;
+                      const serverHost = new URL(authenticationUrl.startsWith('http') ? authenticationUrl : `https://${authenticationUrl}`).hostname;
                       sessionStorage.setItem(`oauth_endpoints_${serverHost}`, JSON.stringify(oauthConfig));
                       
                       let clientId: string | null = null;

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { getOAuthConfig, discoverOAuthEndpoints } from '../utils/oauthDiscovery';
-import { evaluateServer } from '../utils/evaluation';
+import { getOAuthConfig } from '../utils/oauthDiscovery';
+import {
+  evaluateServer,
+  getEvaluationMaxScore,
+  getEvaluationPercentage,
+  type EvaluationReport,
+} from '../utils/evaluation';
 
 // Helper functions for score display
 const getScoreColor = (score: number): string => {
@@ -51,7 +56,7 @@ const ReportView: React.FC = () => {
     }
     return '';
   });
-  const [report, setReport] = useState<any>(null);
+  const [report, setReport] = useState<EvaluationReport | null>(null);
   const [progress, setProgress] = useState<string[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
@@ -208,138 +213,6 @@ const ReportView: React.FC = () => {
     localStorage.setItem('mcpTestedServers', JSON.stringify(updatedServers));
   }, [testedServers]);
 
-  const checkOAuthAuthentication = useCallback(async (serverUrl: string): Promise<boolean> => {
-    try {
-      // Check if we already have an OAuth token for this server
-      const serverHost = new URL(serverUrl.startsWith('http') ? serverUrl : `https://${serverUrl}`).host;
-      const existingToken = sessionStorage.getItem(`oauth_access_token_${serverHost}`);
-      
-      if (existingToken) {
-        setProgress(prev => [...prev, 'Found existing OAuth token for server']);
-        return true;
-      }
-
-      // Check if server has OAuth endpoints
-      setProgress(prev => [...prev, 'Checking if server requires OAuth authentication...']);
-      const discovered = await discoverOAuthEndpoints(serverUrl);
-      
-      if (discovered) {
-        setProgress(prev => [...prev, 'Server requires OAuth authentication']);
-        
-        // Store the current state so we can return after OAuth
-        sessionStorage.setItem('oauth_return_view', JSON.stringify({
-          activeView: 'report',
-          serverUrl: serverUrl,
-          timestamp: Date.now()
-        }));
-        
-        // Ask user for OAuth authentication
-        const confirmAuth = confirm('This server requires OAuth authentication. Would you like to authenticate now?');
-        if (confirmAuth) {
-          // Start OAuth flow directly instead of navigating away
-          setProgress(prev => [...prev, 'Starting OAuth authentication...']);
-          
-          try {
-            // Import necessary OAuth utilities
-            const { getOAuthConfig } = await import('../utils/oauthDiscovery');
-            const { generatePKCE } = await import('../utils/pkce');
-            const { v4: uuidv4 } = await import('uuid');
-            
-            // Get OAuth configuration
-            const oauthConfig = await getOAuthConfig(serverUrl);
-            if (!oauthConfig) {
-              setProgress(prev => [...prev, 'Failed to get OAuth configuration']);
-              return false;
-            }
-            
-            // Generate PKCE parameters
-            const { code_verifier: codeVerifier, code_challenge: codeChallenge } = await generatePKCE();
-            sessionStorage.setItem('pkce_code_verifier', codeVerifier);
-            sessionStorage.setItem('oauth_server_url', serverUrl);
-            
-            // Extract server host
-            const serverHost = new URL(serverUrl.startsWith('http') ? serverUrl : `https://${serverUrl}`).hostname;
-            sessionStorage.setItem(`oauth_endpoints_${serverHost}`, JSON.stringify(oauthConfig));
-            
-            // Check for stored client registration
-            let clientId: string | null = null;
-            const serverClientKey = `oauth_client_${serverHost}`;
-            const storedServerClient = sessionStorage.getItem(serverClientKey);
-            
-            if (storedServerClient) {
-              try {
-                const clientData = JSON.parse(storedServerClient);
-                clientId = clientData.clientId;
-              } catch (e) {
-                console.error('[OAuth] Failed to parse stored client data:', e);
-              }
-            }
-            
-            // If no client ID, try dynamic registration
-            if (!clientId && oauthConfig.registrationEndpoint) {
-              const registrationData = {
-                client_name: 'MCP Test Client',
-                redirect_uris: [`${window.location.origin}/oauth/callback`],
-                grant_types: ['authorization_code'],
-                response_types: ['code'],
-                application_type: 'web',
-                token_endpoint_auth_method: 'none'
-              };
-              
-              const registrationResponse = await fetch(oauthConfig.registrationEndpoint, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(registrationData)
-              });
-              
-              if (registrationResponse.ok) {
-                const clientData = await registrationResponse.json();
-                clientId = clientData.client_id;
-                
-                // Store the client registration
-                sessionStorage.setItem(serverClientKey, JSON.stringify({
-                  clientId: clientData.client_id,
-                  clientSecret: clientData.client_secret
-                }));
-              }
-            }
-            
-            if (clientId && oauthConfig.authorizationEndpoint) {
-              // Build authorization URL
-              const authUrl = new URL(oauthConfig.authorizationEndpoint);
-              authUrl.searchParams.set('response_type', 'code');
-              authUrl.searchParams.set('client_id', clientId);
-              authUrl.searchParams.set('redirect_uri', `${window.location.origin}/oauth/callback`);
-              authUrl.searchParams.set('code_challenge', codeChallenge);
-              authUrl.searchParams.set('code_challenge_method', 'S256');
-              authUrl.searchParams.set('scope', oauthConfig.scope || 'openid profile email');
-              authUrl.searchParams.set('state', uuidv4());
-              
-              // Redirect to OAuth provider
-              window.location.href = authUrl.toString();
-              return false; // Prevent further execution as we're redirecting
-            } else {
-              setProgress(prev => [...prev, 'Failed to configure OAuth client']);
-              return false;
-            }
-          } catch (error) {
-            console.error('[OAuth] Error starting authentication:', error);
-            setProgress(prev => [...prev, 'OAuth authentication failed']);
-            return false;
-          }
-        } else {
-          setProgress(prev => [...prev, 'OAuth authentication cancelled by user']);
-          return false;
-        }
-      }
-      
-      return true; // No OAuth required or already authenticated
-    } catch (error) {
-      console.error('Error checking OAuth:', error);
-      return true; // Continue without OAuth on error
-    }
-  }, []);
-
   const handleRunReport = useCallback(async (urlToTest: string) => {
     if (!currentUser) {
       alert('Please login to run a report.');
@@ -361,14 +234,6 @@ const ReportView: React.FC = () => {
       navigate(`/report/${encodeURIComponent(urlToTest)}`);
     }
 
-    // Check if OAuth authentication is needed
-    const canProceed = await checkOAuthAuthentication(urlToTest);
-    if (!canProceed) {
-      setIsRunning(false);
-      isRunningRef.current = false;
-      return;
-    }
-
     // Get OAuth access token from sessionStorage if available
     const serverHost = new URL(urlToTest.startsWith('http') ? urlToTest : `https://${urlToTest}`).host;
     const oauthAccessToken = sessionStorage.getItem(`oauth_access_token_${serverHost}`);
@@ -387,7 +252,7 @@ const ReportView: React.FC = () => {
       
       // If report completed successfully, save to history
       if (reportData && reportData.finalScore !== undefined && !reportData.fatalError) {
-        addOrUpdateServer(urlToTest, reportData.finalScore);
+        addOrUpdateServer(urlToTest, Math.round(getEvaluationPercentage(reportData)));
       }
       
       // If authentication is required, show a button to authenticate
@@ -402,12 +267,18 @@ const ReportView: React.FC = () => {
       setIsRunning(false);
       isRunningRef.current = false;
     }
-  }, [currentUser, isRunning, navigate, urlParam, checkOAuthAuthentication, addOrUpdateServer]);
+  }, [currentUser, isRunning, navigate, urlParam, addOrUpdateServer]);
 
   // Assign handleRunReport to ref after it's defined
   useEffect(() => {
     handleRunReportRef.current = handleRunReport;
   }, [handleRunReport]);
+
+  const scoredSections = report
+    ? Object.entries(report.sections).filter(([key]) => key !== 'auth')
+    : [];
+  const reportMaxScore = report ? getEvaluationMaxScore(report) : 0;
+  const reportPercentage = report ? getEvaluationPercentage(report) : 0;
 
   return (
     <div className="container-fluid h-100 d-flex flex-column" style={{ paddingBottom: '2rem' }}>
@@ -416,6 +287,7 @@ const ReportView: React.FC = () => {
         <input
           type="text"
           className="form-control"
+          aria-label="MCP server URL"
           placeholder="Enter server URL (e.g., mcp.paypal.com)"
           value={serverUrl}
           onChange={(e) => setServerUrl(e.target.value)}
@@ -438,16 +310,18 @@ const ReportView: React.FC = () => {
                   key={server.url}
                   className="list-group-item d-flex justify-content-between align-items-center"
                 >
-                  <div
+                  <button
+                    type="button"
                     className="flex-grow-1"
-                    style={{ cursor: 'pointer' }}
+                    style={{ border: 0, background: 'transparent', padding: 0, textAlign: 'left' }}
                     onClick={() => setServerUrl(server.url)}
+                    aria-label={`Use ${server.url}`}
                   >
                     <div className="fw-bold">{server.url}</div>
                     <small className="text-muted">
                       Score: {server.score}% • Tested {new Date(server.timestamp).toLocaleString()}
                     </small>
-                  </div>
+                  </button>
                   <button
                     className="btn btn-sm btn-outline-danger"
                     onClick={(e) => {
@@ -455,6 +329,7 @@ const ReportView: React.FC = () => {
                       removeServer(server.url);
                     }}
                     title={`Remove ${server.url} from history`}
+                    aria-label={`Remove ${server.url} from history`}
                   >
                     <span aria-hidden="true">&times;</span>
                   </button>
@@ -467,7 +342,15 @@ const ReportView: React.FC = () => {
 
       {isRunning && (
         <div className="progress mb-3">
-          <div className="progress-bar progress-bar-striped progress-bar-animated" style={{ width: `${(progress.length / 10) * 100}%` }}></div>
+          <div
+            className="progress-bar progress-bar-striped progress-bar-animated"
+            role="progressbar"
+            aria-label="Report progress"
+            aria-valuenow={Math.min(progress.length * 10, 100)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            style={{ width: `${Math.min(progress.length * 10, 100)}%` }}
+          />
         </div>
       )}
 
@@ -484,11 +367,13 @@ const ReportView: React.FC = () => {
         <div className="card mb-4">
           <div className="card-header">
             <h4>Report for: {report.serverUrl}</h4>
-            <h3 className={`text-${getScoreColor(!report.sections.security ? (report.finalScore / 70) * 100 : (report.finalScore / 110) * 100)}`}>
-              Final Score: {report.finalScore} / {!report.sections.security ? 70 : 110} ({getScoreGrade(!report.sections.security ? (report.finalScore / 70) * 100 : (report.finalScore / 110) * 100)})
+            <h3 className={`text-${getScoreColor(reportPercentage)}`}>
+              Final Score: {report.finalScore} / {reportMaxScore} ({Math.round(reportPercentage)}% · {getScoreGrade(reportPercentage)})
             </h3>
             {!report.sections.security && (
-              <small className="text-muted">Note: OAuth not supported - score calculated out of 70 points</small>
+              <small className="text-muted">
+                OAuth security metadata was not included in this run; the base report is scored out of {reportMaxScore} points.
+              </small>
             )}
           </div>
           <div className="card-body">
@@ -589,18 +474,23 @@ const ReportView: React.FC = () => {
               </div>
             )}
             <div className="row g-3">
-              {Object.entries(report.sections as Record<string, any>).map(([key, section]) => (
+              {scoredSections.map(([key, section]) => {
+                const sectionPercentage = section.maxScore > 0
+                  ? section.score / section.maxScore * 100
+                  : 0;
+
+                return (
                 <div key={key} className="col-12">
                   <div className="card h-100 shadow-sm">
                     <div className="card-header">
                       <div className="d-flex justify-content-between align-items-start mb-2">
                         <h5 className="mb-0">{section.name}</h5>
                         <div className="d-flex align-items-center gap-2">
-                          <span className={`text-${getScoreColor(section.score / section.maxScore * 100)} fw-bold`}>
+                          <span className={`text-${getScoreColor(sectionPercentage)} fw-bold`}>
                             {section.score} / {section.maxScore} points
                           </span>
-                          <span className={`badge bg-${getScoreColor(section.score / section.maxScore * 100)}`}>
-                            {Math.round(section.score / section.maxScore * 100)}%
+                          <span className={`badge bg-${getScoreColor(sectionPercentage)}`}>
+                            {Math.round(sectionPercentage)}%
                           </span>
                         </div>
                       </div>
@@ -625,32 +515,28 @@ const ReportView: React.FC = () => {
                                 <div className={`d-flex align-items-start ${isSuccess ? 'text-success' : isError ? 'text-danger' : 'text-warning'}`}>
                                   <span style={{ marginRight: '10px', marginTop: '2px' }}>{isSuccess ? '✓' : isError ? '✗' : '⚠'}</span>
                                   <div className="flex-grow-1">
-                                    <div 
-                                      className="d-flex align-items-center"
-                                      style={{ 
-                                        cursor: hasMoreInfo ? 'pointer' : 'default',
-                                        transition: 'background-color 0.2s ease',
-                                        borderRadius: '4px',
-                                        padding: '2px 4px',
-                                        margin: '-2px -4px'
-                                      }}
-                                      onMouseEnter={(e) => hasMoreInfo && (e.currentTarget.style.backgroundColor = '#f8f9fa')}
-                                      onMouseLeave={(e) => hasMoreInfo && (e.currentTarget.style.backgroundColor = 'transparent')}
-                                      onClick={() => hasMoreInfo && toggleItemExpanded(itemKey)}
-                                    >
-                                      <div className="flex-grow-1">{detailText.substring(2)}</div>
-                                      {hasMoreInfo && (
+                                    {hasMoreInfo ? (
+                                      <button
+                                        type="button"
+                                        className="d-flex align-items-center w-100 text-start border-0 bg-transparent rounded px-1"
+                                        onClick={() => toggleItemExpanded(itemKey)}
+                                        aria-expanded={isExpanded}
+                                        aria-controls={`${itemKey}-details`}
+                                      >
+                                        <span className="flex-grow-1">{detailText.substring(2)}</span>
                                         <span 
                                           className="text-muted ms-2" 
                                           style={{ fontSize: '0.875rem' }}
-                                          title="Click to see more details"
+                                          aria-hidden="true"
                                         >
                                           {isExpanded ? '▼' : '▶'}
                                         </span>
-                                      )}
-                                    </div>
+                                      </button>
+                                    ) : (
+                                      <div className="px-1">{detailText.substring(2)}</div>
+                                    )}
                                     {isExpanded && (
-                                      <div className="mt-2" style={{ marginLeft: '20px' }}>
+                                      <div id={`${itemKey}-details`} className="mt-2" style={{ marginLeft: '20px' }}>
                                         {detailContext && (
                                           <div className="text-muted mb-2" style={{ fontSize: '0.875rem' }}>
                                             {detailContext}
@@ -676,7 +562,8 @@ const ReportView: React.FC = () => {
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -250,10 +250,8 @@ const ReportView: React.FC = () => {
       const reportData = await evaluateServer(urlToTest, token, onProgress, oauthAccessToken);
       setReport(reportData);
       
-      // If report completed successfully, save to history
-      if (reportData && reportData.finalScore !== undefined && !reportData.fatalError) {
-        addOrUpdateServer(urlToTest, Math.round(getEvaluationPercentage(reportData)));
-      }
+      // A resolved evaluation always has a typed score; failures reject instead.
+      addOrUpdateServer(urlToTest, Math.round(getEvaluationPercentage(reportData)));
       
       // If authentication is required, show a button to authenticate
       if (reportData && reportData.sections && reportData.sections.auth) {

--- a/src/hooks/useConnection.test.ts
+++ b/src/hooks/useConnection.test.ts
@@ -1,0 +1,106 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const connectionMocks = vi.hoisted(() => ({ attempt: vi.fn() }));
+
+vi.mock('../utils/transportDetection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/transportDetection')>();
+  return { ...actual, attemptParallelConnections: connectionMocks.attempt };
+});
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: null, loading: false }),
+}));
+
+vi.mock('../utils/analytics', () => ({ logEvent: vi.fn() }));
+
+vi.mock('../utils/oauthDiscovery', () => ({
+  getOAuthConfig: vi.fn(),
+  getOAuthServiceName: vi.fn(),
+  getOrRegisterOAuthClient: vi.fn(),
+  isOAuthService: vi.fn(() => false),
+}));
+
+import { useConnection } from './useConnection';
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const renderConnectionHook = () => {
+  let connection: ReturnType<typeof useConnection> | undefined;
+  const container = document.createElement('div');
+  const root: Root = createRoot(container);
+  const addLogEntry = vi.fn();
+
+  const Probe = () => {
+    connection = useConnection(addLogEntry, false, false);
+    return null;
+  };
+
+  act(() => {
+    root.render(React.createElement(Probe));
+  });
+
+  return {
+    get connection() {
+      if (!connection) throw new Error('Connection hook was not rendered');
+      return connection;
+    },
+    unmount() {
+      act(() => root.unmount());
+    },
+  };
+};
+
+describe('connection URL finalization', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    sessionStorage.clear();
+    connectionMocks.attempt.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['URL-valued', 'https://tenant.example/account'],
+    ['ordinary', 'production'],
+  ])('keeps a direct custom endpoint with a %s target parameter in connection state', async (_, target) => {
+    const endpoint = new URL('https://mcp.example/custom/endpoint');
+    endpoint.searchParams.set('target', target);
+    endpoint.searchParams.set('tenant', 'acme');
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client: { close: vi.fn().mockResolvedValue(undefined) },
+      url: endpoint.toString(),
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+    });
+    const view = renderConnectionHook();
+
+    await act(async () => {
+      await view.connection.handleConnect(
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        endpoint.toString()
+      );
+    });
+
+    expect(connectionMocks.attempt).toHaveBeenCalledOnce();
+    expect(connectionMocks.attempt.mock.calls[0][0]).toBe(endpoint.toString());
+    expect(connectionMocks.attempt.mock.calls[0][4]).toBe(false);
+    expect(view.connection.serverUrl).toBe(endpoint.toString());
+    expect(view.connection.connectionStatus).toBe('Connected');
+    expect(JSON.parse(localStorage.getItem('mcpRecentServers') || '[]')).toContainEqual({
+      url: endpoint.toString(),
+    });
+    view.unmount();
+  });
+});

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -855,7 +855,8 @@ export const useConnection = (
         targetUrl,
         abortControllerRef.current?.signal,
         latestAccessToken || undefined,
-        requestHeaders
+        requestHeaders,
+        false
       );
     };
 
@@ -888,7 +889,8 @@ export const useConnection = (
         connectionUrl,
         abortControllerRef.current?.signal,
         authToken,
-        targetHeaders
+        targetHeaders,
+        true
       );
     };
 

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -11,6 +11,20 @@ import { getOAuthConfig, isOAuthService, getOAuthServiceName, getOrRegisterOAuth
 const RECENT_SERVERS_KEY = 'mcpRecentServers';
 const MAX_RECENT_SERVERS = 100;
 
+const getConnectedServerUrl = (
+  finalUrl: string,
+  targetUrl: string,
+  usedProxy: boolean
+): string => {
+  if (!usedProxy) return finalUrl;
+
+  try {
+    return new URL(finalUrl).searchParams.get('target') || targetUrl;
+  } catch {
+    return targetUrl;
+  }
+};
+
 // Helper to load recent servers from localStorage
 const loadRecentServers = (): string[] => {
   try {
@@ -836,6 +850,7 @@ export const useConnection = (
     let finalProtocolEra: ProtocolEra | null = null;
     let finalProtocolVersion: string | null = null;
     let finalUrl: string | null = null;
+    let finalUsedProxy = false;
     let lastError: any = null;
     const timeoutPromise = new Promise<never>((_, reject) => 
         setTimeout(() => reject(new Error('Connection timeout after 30 seconds')), 30000)
@@ -907,6 +922,7 @@ export const useConnection = (
           finalProtocolEra = result.protocolEra;
           finalProtocolVersion = result.protocolVersion ?? null;
           finalUrl = result.url;
+          finalUsedProxy = false;
           connectionSuccess = true;
           addLogEntry({ type: 'info', data: `Connection successful using ${result.transportType} (${result.protocolEra}${result.protocolVersion ? `, ${result.protocolVersion}` : ''}) at ${result.url}` });
         } catch (error: any) {
@@ -929,6 +945,7 @@ export const useConnection = (
             finalProtocolEra = result.protocolEra;
             finalProtocolVersion = result.protocolVersion ?? null;
             finalUrl = result.url;
+            finalUsedProxy = true;
             connectionSuccess = true;
             addLogEntry({ type: 'info', data: `Proxy connection successful using ${result.transportType} (${result.protocolEra}${result.protocolVersion ? `, ${result.protocolVersion}` : ''}) at ${result.url}` });
           } else {
@@ -946,24 +963,10 @@ export const useConnection = (
             setProtocolEra(finalProtocolEra);
             setProtocolVersion(finalProtocolVersion);
             
-            // Extract the actual URL that was connected to (with correct endpoint)
-            let displayUrl = targetUrl; // Default to original target
-            try {
-                const finalUrlObj = new URL(finalUrl);
-                
-                // For proxy URLs, extract the target parameter
-                if (finalUrlObj.searchParams.has('target')) {
-                    displayUrl = finalUrlObj.searchParams.get('target') || targetUrl;
-                } else {
-                    // For direct URLs, use the final URL which includes the correct endpoint
-                    displayUrl = finalUrl;
-                }
-                
-                console.log(`[DEBUG] Setting display URL: ${displayUrl} (from finalUrl: ${finalUrl})`);
-            } catch (error) {
-                console.error('[DEBUG] Error parsing final URL:', error);
-                // Fall back to original target URL
-            }
+            const displayUrl = getConnectedServerUrl(finalUrl, targetUrl, finalUsedProxy);
+            console.log(
+              `[DEBUG] Setting display URL: ${displayUrl} (from finalUrl: ${finalUrl}, proxy: ${finalUsedProxy})`
+            );
             
             setServerUrl(displayUrl); // Set UI URL to the actual connected URL with endpoint
             setConnectionStatus('Connected');
@@ -971,7 +974,7 @@ export const useConnection = (
             addLogEntry({ type: 'info', data: `SDK Client Connected successfully.` });
             logEvent('connect_success', { 
               transport_type: finalTransportType,
-              is_proxied: isProxied,
+              is_proxied: finalUsedProxy,
             });
             setTools([]);
             setResources([]);
@@ -1063,7 +1066,7 @@ export const useConnection = (
         }
         cleanupConnection();
     }
-  }, [serverUrl, isConnecting, connectionStatus, recentServers, addLogEntry, cleanupConnection, useProxy, currentUser, isProxied, useOAuth, accessToken, getLatestAccessToken, requestHeaders]);
+  }, [serverUrl, isConnecting, connectionStatus, recentServers, addLogEntry, cleanupConnection, useProxy, currentUser, useOAuth, accessToken, getLatestAccessToken, requestHeaders]);
 
   // Clear connection error on successful connect
   const clearConnectionError = useCallback(() => {

--- a/src/hooks/useResourceAccess.test.ts
+++ b/src/hooks/useResourceAccess.test.ts
@@ -1,0 +1,64 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Client } from '@modelcontextprotocol/client';
+import { useResourceAccess } from './useResourceAccess';
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const renderResourceAccessHook = (client: Client, addLogEntry: ReturnType<typeof vi.fn>) => {
+  let resourceAccess: ReturnType<typeof useResourceAccess> | undefined;
+  const container = document.createElement('div');
+  const root: Root = createRoot(container);
+
+  const Probe = () => {
+    resourceAccess = useResourceAccess(client, addLogEntry, 'https://mcp.example/mcp');
+    return null;
+  };
+
+  act(() => root.render(React.createElement(Probe)));
+
+  return {
+    get resourceAccess() {
+      if (!resourceAccess) throw new Error('Resource access hook was not rendered');
+      return resourceAccess;
+    },
+    unmount() {
+      act(() => root.unmount());
+    },
+  };
+};
+
+describe('resource access', () => {
+  it('reads the expanded URI while persisting the reusable URI template', async () => {
+    const readResource = vi.fn().mockResolvedValue({
+      contents: [{ uri: 'mcp://documents/policies%2F2026', text: 'policy' }],
+    });
+    const addLogEntry = vi.fn();
+    const view = renderResourceAccessHook({ readResource } as unknown as Client, addLogEntry);
+
+    let result: Awaited<ReturnType<typeof view.resourceAccess.handleAccessResource>>;
+    await act(async () => {
+      result = await view.resourceAccess.handleAccessResource(
+        { uriTemplate: 'mcp://documents/{documentId}', name: 'Document' },
+        { documentId: 'policies/2026' }
+      );
+    });
+
+    expect(readResource).toHaveBeenCalledWith({
+      uri: 'mcp://documents/policies%2F2026',
+    });
+    expect(result?.callContext).toEqual({
+      serverUrl: 'https://mcp.example/mcp',
+      type: 'resource',
+      name: 'mcp://documents/{documentId}',
+      params: { documentId: 'policies/2026' },
+    });
+    expect(addLogEntry).toHaveBeenCalledWith(result);
+    view.unmount();
+  });
+});

--- a/src/hooks/useResourceAccess.ts
+++ b/src/hooks/useResourceAccess.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { LogEntry, ResourceTemplate } from '../types';
-import { parseUriTemplateArgs } from '../utils/uriUtils';
 import { Client } from "@modelcontextprotocol/client";
 import { formatErrorForDisplay } from '../utils/errorHandling';
+import { getSavedResourceUri } from '../utils/savedCardConnection';
 
 export const useResourceAccess = (
   client: Client | null,
@@ -22,36 +22,13 @@ export const useResourceAccess = (
     }
 
     let finalUri = selectedResourceTemplate.uriTemplate;
-    const templateArgs = parseUriTemplateArgs(finalUri);
-    let queryParamsStarted = false;
-
-    templateArgs.forEach(arg => {
-      const value = resourceArgs[arg];
-      if (value !== undefined && value !== null && value !== '') {
-        const pathRegex = new RegExp(`\\{${arg}\\}`, 'g');
-        if (finalUri.match(pathRegex)) {
-          finalUri = finalUri.replace(pathRegex, encodeURIComponent(String(value)));
-        } else {
-          finalUri += (queryParamsStarted ? '&' : '?') + `${encodeURIComponent(arg)}=${encodeURIComponent(String(value))}`;
-          queryParamsStarted = true;
-        }
-      } else {
-        // Remove optional template parts if arg is missing
-        finalUri = finalUri.replace(new RegExp(`{&${arg}}`, 'g'), '');
-        finalUri = finalUri.replace(new RegExp(`{\\?${arg},?`, 'g'), '?');
-        finalUri = finalUri.replace(new RegExp(`,${arg}`, 'g'), '');
-      }
-    });
-
-    // Clean up remaining template placeholders and trailing characters
-    finalUri = finalUri.replace(/\{\??[^}]+\}/g, '');
-    finalUri = finalUri.replace(/\?&/, '?').replace(/(\?|&)$/, '');
-
-    console.log("[DEBUG] Accessing resource:", finalUri);
-    addLogEntry({ type: 'info', data: `Accessing resource: ${finalUri}` });
 
     // Using the SDK client method for resource access
     try {
+      finalUri = getSavedResourceUri(selectedResourceTemplate.uriTemplate, resourceArgs);
+      console.log("[DEBUG] Accessing resource:", finalUri);
+      addLogEntry({ type: 'info', data: `Accessing resource: ${finalUri}` });
+
       addLogEntry({
         type: 'request', // Log the intent
         method: 'resources/read', // SDK uses 'read'
@@ -70,7 +47,9 @@ export const useResourceAccess = (
         callContext: {
           serverUrl: serverUrl,
           type: 'resource',
-          name: finalUri,
+          // Persist the template for future executions; legacy cards that
+          // already contain finalUri remain supported by getSavedResourceUri.
+          name: selectedResourceTemplate.uriTemplate,
           params: resourceArgs // Pass the original args used
         }
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,20 +58,6 @@ export interface Space {
   columns?: number; // Number of columns for card layout (1-4), default to 2
 }
 
-// --- Zod Schemas for SDK Interaction ---
-
-// Basic content part schema (adjust if needed based on actual content types)
-export const ContentPartSchema = z.object({
-  type: z.string(),
-}).passthrough(); // Allow other properties
-
-// Schema for the result of resources/access (assuming similar structure to tools/call)
-export const AccessResourceResultSchema = z.object({
-  content: z.array(ContentPartSchema),
-});
-
-export type AccessResourceResult = z.infer<typeof AccessResourceResultSchema>;
-
 // --- Transport Types ---
 export type TransportType = 'streamable-http' | 'legacy-sse';
 

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -127,6 +127,8 @@ describe('dual-era server evaluation', () => {
     expect(report.sections.transport.details[0].text).toContain('Streamable HTTP');
     expect(report.sections.cors.score).toBe(0);
     expect(report.sections.cors.details[0].text).toContain('proxy was required');
+    expect(report.sections.security).toBeUndefined();
+    expect(getEvaluationMaxScore(report)).toBe(70);
     expect(client.close).toHaveBeenCalledOnce();
   });
 
@@ -266,6 +268,182 @@ describe('dual-era server evaluation', () => {
     expect(report.sections.auth).toBeDefined();
     expect(report.sections.auth.details[0].context).toContain('MCP target returned HTTP 403');
     expect(report.sections.auth.details[0].metadata).toEqual({ route: 'proxy', status: 403 });
+  });
+
+  it('offers target authentication when a post-connect capability request returns 401', async () => {
+    const client = createClient();
+    client.listTools.mockRejectedValueOnce(Object.assign(
+      new Error('tools/list returned HTTP 401'),
+      { status: 401 }
+    ));
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/mcp',
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+    });
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeDefined();
+    expect(report.sections.auth.details[0]).toMatchObject({
+      context: 'tools/list returned HTTP 401',
+      metadata: {
+        method: 'tools/list',
+        route: 'direct',
+        status: 401,
+        authenticationSource: 'target',
+      },
+    });
+    expect(report.sections.capabilities.score).toBe(6);
+    expect(client.listResources).toHaveBeenCalledOnce();
+    expect(client.listPrompts).toHaveBeenCalledOnce();
+  });
+
+  it('does not offer target OAuth for a post-connect proxy-hop challenge', async () => {
+    const client = createClient();
+    let observedChallenge: { status: 401 | 403; source: 'proxy' | 'target' } | undefined;
+    client.listTools.mockImplementationOnce(async () => {
+      observedChallenge = { status: 403, source: 'proxy' };
+      throw Object.assign(new Error('Proxy rejected the Firebase token'), { status: 403 });
+    });
+    const takeAuthenticationChallenge = vi.fn(() => {
+      const challenge = observedChallenge;
+      observedChallenge = undefined;
+      return challenge;
+    });
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockResolvedValueOnce({
+        client,
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+        transportType: 'streamable-http',
+        protocolEra: 'modern',
+        takeAuthenticationChallenge,
+      });
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeUndefined();
+    expect(report.sections.capabilities.details[0].metadata).toMatchObject({
+      method: 'tools/list',
+      status: 403,
+      authenticationSource: 'proxy',
+      route: 'proxy',
+    });
+  });
+
+  it('offers target OAuth for a post-connect upstream challenge through the proxy', async () => {
+    const client = createClient();
+    let observedChallenge: { status: 401 | 403; source: 'proxy' | 'target' } | undefined;
+    client.listResources.mockImplementationOnce(async () => {
+      observedChallenge = { status: 403, source: 'target' };
+      throw Object.assign(new Error('Upstream target rejected resources/list'), { status: 403 });
+    });
+    const takeAuthenticationChallenge = () => {
+      const challenge = observedChallenge;
+      observedChallenge = undefined;
+      return challenge;
+    };
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockResolvedValueOnce({
+        client,
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+        transportType: 'streamable-http',
+        protocolEra: 'modern',
+        takeAuthenticationChallenge,
+      });
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth.details[0].metadata).toMatchObject({
+      method: 'resources/list',
+      route: 'proxy',
+      status: 403,
+      authenticationSource: 'target',
+    });
+    expect(report.sections.capabilities.score).toBe(7);
+  });
+
+  it('includes OAuth security posture when protected-resource metadata is supported', async () => {
+    const client = createClient();
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/mcp',
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+      protocolVersion: '2026-07-28',
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.pathname.includes('/.well-known/oauth-protected-resource')) {
+        return Response.json({
+          resource: 'https://mcp.example/mcp',
+          authorization_servers: ['https://auth.example'],
+        });
+      }
+      if (url.hostname === 'auth.example') {
+        return Response.json({
+          issuer: 'https://auth.example',
+          authorization_endpoint: 'https://auth.example/authorize',
+          token_endpoint: 'https://auth.example/token',
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      return new Response('Not found', { status: 404 });
+    }));
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.security).toMatchObject({
+      name: 'Security Posture',
+      score: 40,
+      maxScore: 40,
+    });
+    expect(report.sections.security.details.map(({ text }) => text)).toEqual(
+      expect.arrayContaining([
+        '✓ OAuth protected-resource metadata available',
+        '✓ OAuth authorization-server metadata available',
+        '✓ Token endpoint properly configured',
+        '✓ PKCE support enabled',
+      ])
+    );
+    expect(getEvaluationMaxScore(report)).toBe(110);
+    expect(report.finalScore).toBe(110);
+  });
+
+  it('retains the OAuth assessment for legacy authorization-server metadata', async () => {
+    const client = createClient();
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/mcp',
+      transportType: 'streamable-http',
+      protocolEra: 'legacy',
+      protocolVersion: '2025-11-25',
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.pathname === '/.well-known/oauth-authorization-server') {
+        return Response.json({
+          issuer: 'https://mcp.example',
+          authorization_endpoint: 'https://mcp.example/authorize',
+          token_endpoint: 'https://mcp.example/token',
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256'],
+        });
+      }
+      return new Response('Not found', { status: 404 });
+    }));
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.security).toMatchObject({ score: 40, maxScore: 40 });
+    expect(report.sections.security.details[0].text).toBe(
+      '⚠ OAuth protected-resource metadata not available'
+    );
+    expect(getEvaluationMaxScore(report)).toBe(110);
   });
 
   it('normalizes report scores from the sections included in that run', () => {

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -230,11 +230,37 @@ describe('dual-era server evaluation', () => {
 
     expect(report.sections.auth).toBeDefined();
     expect(report.sections.auth.details[0].context).toContain('Direct target returned HTTP 401');
-    expect(report.sections.auth.details[0].metadata).toEqual({ route: 'direct', status: 401 });
+    expect(report.sections.auth.details[0].metadata).toEqual({
+      route: 'direct',
+      status: 401,
+      endpoint: 'https://mcp.example/mcp',
+    });
     expect(report.sections.protocol.score).toBe(0);
     expect(report.sections.protocol.details[0].text).toContain('Direct target:');
     expect(report.sections.protocol.details[0].text).toContain('Authenticated proxy:');
     expect(JSON.stringify(report)).not.toContain('/mcp/v1/');
+  });
+
+  it('uses the challenged fallback endpoint for authentication', async () => {
+    const targetAuthError = Object.assign(new Error('Fallback returned HTTP 401'), {
+      status: 401,
+    });
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new TransportConnectionError(
+        [targetAuthError],
+        [{ candidateUrl: 'https://mcp.example/mcp', error: targetAuthError }]
+      ))
+      .mockRejectedValueOnce(new Error('Proxy network failure'));
+
+    const report = await evaluateServer('https://mcp.example', 'firebase-jwt', vi.fn());
+
+    expect(report.serverUrl).toBe('https://mcp.example/');
+    expect(report.authenticationUrl).toBe('https://mcp.example/mcp');
+    expect(report.sections.auth.details[0].metadata).toEqual({
+      route: 'direct',
+      status: 401,
+      endpoint: 'https://mcp.example/mcp',
+    });
   });
 
   it('does not mistake a proxy-hop authentication failure for target OAuth', async () => {
@@ -267,7 +293,11 @@ describe('dual-era server evaluation', () => {
 
     expect(report.sections.auth).toBeDefined();
     expect(report.sections.auth.details[0].context).toContain('MCP target returned HTTP 403');
-    expect(report.sections.auth.details[0].metadata).toEqual({ route: 'proxy', status: 403 });
+    expect(report.sections.auth.details[0].metadata).toEqual({
+      route: 'proxy',
+      status: 403,
+      endpoint: 'https://mcp.example/mcp',
+    });
   });
 
   it('offers target authentication when a post-connect capability request returns 401', async () => {

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -302,15 +302,22 @@ describe('dual-era server evaluation', () => {
 
   it('offers target authentication when a post-connect capability request returns 401', async () => {
     const client = createClient();
-    client.listTools.mockRejectedValueOnce(Object.assign(
-      new Error('tools/list returned HTTP 401'),
-      { status: 401 }
-    ));
+    let observedChallenge: { status: 401 | 403; source: 'proxy' | 'target' } | undefined;
+    client.listTools.mockImplementationOnce(async () => {
+      observedChallenge = { status: 401, source: 'target' };
+      throw new Error('tools/list returned HTTP 401');
+    });
+    const takeAuthenticationChallenge = vi.fn(() => {
+      const challenge = observedChallenge;
+      observedChallenge = undefined;
+      return challenge;
+    });
     connectionMocks.attempt.mockResolvedValueOnce({
       client,
       url: 'https://mcp.example/mcp',
       transportType: 'streamable-http',
       protocolEra: 'modern',
+      takeAuthenticationChallenge,
     });
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -1,26 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const connectionMocks = vi.hoisted(() => ({
-  attempt: vi.fn(),
-}));
+const connectionMocks = vi.hoisted(() => ({ attempt: vi.fn() }));
 
 vi.mock('./transportDetection', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./transportDetection')>();
-  return {
-    ...actual,
-    attemptParallelConnections: connectionMocks.attempt,
-  };
+  return { ...actual, attemptParallelConnections: connectionMocks.attempt };
 });
 
 import {
   evaluateServer,
   fetchForEvaluation,
+  getEvaluationCorsHeaders,
+  getEvaluationMaxScore,
+  getEvaluationPercentage,
   getEvaluationProxyHeaders,
+  getEvaluationTargetUrl,
   getEvaluationTransportProbeUrl,
 } from './evaluation';
 import { getRequestHeadersForCandidate } from './transportDetection';
 
-describe('evaluation proxy authentication', () => {
+const createClient = () => ({
+  listTools: vi.fn().mockResolvedValue({ tools: [] }),
+  listResources: vi.fn().mockResolvedValue({ resources: [] }),
+  listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+  close: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('dual-era server evaluation', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_PROXY_URL', 'https://proxy.mcptest.test/');
     vi.stubGlobal('fetch', vi.fn(async () => new Response('Not found', { status: 404 })));
@@ -45,14 +51,14 @@ describe('evaluation proxy authentication', () => {
     expect(headers.get('content-type')).toBe('application/json');
   });
 
-  it('uses the isolated target header when direct evaluation fetch falls back', async () => {
+  it('tries a direct fetch before falling back to the proxy', async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock
       .mockRejectedValueOnce(new Error('Direct CORS failure'))
       .mockResolvedValueOnce(new Response('proxied'));
 
     const response = await fetchForEvaluation(
-      'https://mcp.example/mcp',
+      'https://mcp.example/custom/endpoint',
       'firebase-jwt',
       { headers: { Accept: 'application/json' } },
       'oauth-access-token'
@@ -60,42 +66,42 @@ describe('evaluation proxy authentication', () => {
 
     expect(await response.text()).toBe('proxied');
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://mcp.example/custom/endpoint');
     const [proxyTarget, proxyInit] = fetchMock.mock.calls[1];
     expect(new URL(String(proxyTarget)).searchParams.get('target')).toBe(
-      'https://mcp.example/mcp'
+      'https://mcp.example/custom/endpoint'
     );
     const proxyHeaders = new Headers(proxyInit?.headers);
     expect(proxyHeaders.get('authorization')).toBe('Bearer firebase-jwt');
     expect(proxyHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
   });
 
-  it('rewrites the target inside an existing proxy URL for transport probes', () => {
+  it('rewrites only a terminal conventional path for comparison probes', () => {
     const probeUrl = getEvaluationTransportProbeUrl(
       'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
       'sse'
     );
 
     expect(new URL(probeUrl).searchParams.get('target')).toBe('https://mcp.example/sse');
+    expect(getEvaluationTransportProbeUrl('https://mcp.example/custom/grid', 'sse')).toBe(
+      'https://mcp.example/custom/grid'
+    );
   });
 
   it('uses Firebase for the proxy hop and OAuth only for the MCP target', async () => {
-    const client = {
-      listTools: vi.fn().mockResolvedValue({ tools: [] }),
-      listResources: vi.fn().mockResolvedValue({ resources: [] }),
-      listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
-      setLoggingLevel: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
+    const client = createClient();
     connectionMocks.attempt
       .mockRejectedValueOnce(new Error('Direct CORS failure'))
       .mockResolvedValueOnce({
         client,
-        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
+        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fcustom%2Fendpoint',
         transportType: 'streamable-http',
+        protocolEra: 'modern',
+        protocolVersion: '2026-07-28',
       });
 
-    await evaluateServer(
-      'https://mcp.example/mcp',
+    const report = await evaluateServer(
+      'https://mcp.example/custom/endpoint',
       'firebase-jwt',
       vi.fn(),
       'oauth-access-token'
@@ -103,54 +109,90 @@ describe('evaluation proxy authentication', () => {
 
     expect(connectionMocks.attempt).toHaveBeenCalledTimes(2);
     const [proxyUrl, , proxyAuthToken, targetHeaders] = connectionMocks.attempt.mock.calls[1];
-    expect(proxyUrl).toBe(
-      'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp'
-    );
     expect(proxyAuthToken).toBe('firebase-jwt');
-
     const outgoingTargetHeaders = getRequestHeadersForCandidate(proxyUrl, targetHeaders);
     expect(outgoingTargetHeaders.get('authorization')).toBeNull();
-    expect(outgoingTargetHeaders.get('x-mcp-authorization')).toBe(
-      'Bearer oauth-access-token'
-    );
-    const proxyFetch = vi.mocked(fetch).mock.calls.find(([input]) => (
-      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/sse'
-    ));
-    expect(proxyFetch).toBeDefined();
-    const probeHeaders = new Headers(proxyFetch?.[1]?.headers);
-    expect(probeHeaders.get('authorization')).toBe('Bearer firebase-jwt');
-    expect(probeHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
+    expect(outgoingTargetHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
+    expect(report.sections.protocol.details[0].metadata).toMatchObject({
+      protocolEra: 'modern',
+      protocolVersion: '2026-07-28',
+      endpoint: 'https://mcp.example/custom/endpoint',
+    });
+    expect(report.sections.transport.details[0].text).toContain('Streamable HTTP');
+    expect(report.sections.cors.score).toBe(0);
+    expect(report.sections.cors.details[0].text).toContain('proxy was required');
     expect(client.close).toHaveBeenCalledOnce();
   });
 
-  it('does not nest an already-proxied HTTP probe without OAuth', async () => {
-    const client = {
-      listTools: vi.fn().mockResolvedValue({ tools: [] }),
-      listResources: vi.fn().mockResolvedValue({ resources: [] }),
-      listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
-      setLoggingLevel: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
+  it('reports a stateful legacy-SSE connection without inventing pre-standard endpoints', async () => {
+    const client = createClient();
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/custom/events',
+      transportType: 'legacy-sse',
+      protocolEra: 'legacy',
+      protocolVersion: '2025-11-25',
+    });
+
+    const report = await evaluateServer(
+      'https://mcp.example/custom/events',
+      'firebase-jwt',
+      vi.fn()
+    );
+
+    expect(report.sections.protocol.details[0].text).toContain('stateful initialize');
+    expect(report.sections.transport.score).toBe(6);
+    expect(report.sections.transport.details[0].text).toContain('Deprecated HTTP+SSE');
+    expect(report.sections.cors.score).toBe(15);
+    expect(report.sections.cors.details[0].text).toContain('Direct browser');
+    expect(JSON.stringify(report)).not.toContain('/mcp/v1/');
+    expect(getEvaluationTargetUrl('https://mcp.example/custom/events')).toBe(
+      'https://mcp.example/custom/events'
+    );
+  });
+
+  it('uses era-specific CORS headers', () => {
+    expect(getEvaluationCorsHeaders('modern', false)).toEqual([
+      'content-type',
+      'accept',
+      'mcp-protocol-version',
+      'mcp-method',
+      'mcp-name',
+    ]);
+    expect(getEvaluationCorsHeaders('legacy', true)).toEqual([
+      'content-type',
+      'accept',
+      'mcp-protocol-version',
+      'mcp-session-id',
+      'last-event-id',
+      'authorization',
+    ]);
+  });
+
+  it('surfaces authentication failures without probing /mcp/v1 routes', async () => {
     connectionMocks.attempt
-      .mockRejectedValueOnce(new Error('Direct CORS failure'))
-      .mockResolvedValueOnce({
-        client,
-        url: 'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fsse',
-        transportType: 'legacy-sse',
-      });
+      .mockRejectedValueOnce(new Error('HTTP 401 Unauthorized'))
+      .mockRejectedValueOnce(new Error('HTTP 401 Unauthorized'));
 
-    await evaluateServer('https://mcp.example/sse', 'firebase-jwt', vi.fn());
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
-    const proxyFetch = vi.mocked(fetch).mock.calls.find(([input]) => (
-      new URL(String(input)).searchParams.get('target') === 'https://mcp.example/mcp'
-    ));
-    expect(proxyFetch).toBeDefined();
-    expect(
-      new URL(String(proxyFetch?.[0])).searchParams.get('target')
-    ).not.toContain('proxy.mcptest.test');
-    const probeHeaders = new Headers(proxyFetch?.[1]?.headers);
-    expect(probeHeaders.get('authorization')).toBe('Bearer firebase-jwt');
-    expect(probeHeaders.get('x-mcp-authorization')).toBeNull();
-    expect(client.close).toHaveBeenCalledOnce();
+    expect(report.sections.auth).toBeDefined();
+    expect(report.sections.protocol.score).toBe(0);
+    expect(JSON.stringify(report)).not.toContain('/mcp/v1/');
+  });
+
+  it('normalizes report scores from the sections included in that run', () => {
+    const report = {
+      serverUrl: 'https://mcp.example/mcp',
+      finalScore: 55,
+      sections: {
+        protocol: { name: 'Protocol', description: '', score: 15, maxScore: 15, details: [] },
+        security: { name: 'Security', description: '', score: 20, maxScore: 40, details: [] },
+        auth: { name: 'Auth', description: '', score: 0, maxScore: 1, details: [] },
+      },
+    };
+
+    expect(getEvaluationMaxScore(report)).toBe(55);
+    expect(getEvaluationPercentage(report)).toBe(100);
   });
 });

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -353,6 +353,29 @@ describe('dual-era server evaluation', () => {
     expect(report.sections.capabilities.score).toBe(6);
   });
 
+  it('does not treat application-defined JSON-RPC data as an HTTP challenge', async () => {
+    const client = createClient();
+    client.listTools.mockRejectedValueOnce(Object.assign(
+      new Error('tools/list returned a JSON-RPC application error'),
+      { data: { status: 401 } }
+    ));
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/mcp',
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+    });
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeUndefined();
+    expect(report.sections.capabilities.details[0].metadata).toEqual({
+      method: 'tools/list',
+      error: 'tools/list returned a JSON-RPC application error',
+    });
+    expect(report.sections.capabilities.score).toBe(6);
+  });
+
   it('does not offer target OAuth for a post-connect proxy-hop challenge', async () => {
     const client = createClient();
     let observedChallenge: { status: 401 | 403; source: 'proxy' | 'target' } | undefined;

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -300,6 +300,29 @@ describe('dual-era server evaluation', () => {
     expect(client.listPrompts).toHaveBeenCalledOnce();
   });
 
+  it('does not treat a JSON-RPC error code as an HTTP authentication status', async () => {
+    const client = createClient();
+    client.listTools.mockRejectedValueOnce(Object.assign(
+      new Error('tools/list returned a JSON-RPC application error'),
+      { code: 401 }
+    ));
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: 'https://mcp.example/mcp',
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+    });
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeUndefined();
+    expect(report.sections.capabilities.details[0].metadata).toEqual({
+      method: 'tools/list',
+      error: 'tools/list returned a JSON-RPC application error',
+    });
+    expect(report.sections.capabilities.score).toBe(6);
+  });
+
   it('does not offer target OAuth for a post-connect proxy-hop challenge', async () => {
     const client = createClient();
     let observedChallenge: { status: 401 | 403; source: 'proxy' | 'target' } | undefined;

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -18,6 +18,7 @@ import {
   getEvaluationTransportProbeUrl,
 } from './evaluation';
 import {
+  ProxiedAuthenticationError,
   TransportConnectionError,
   getRequestHeadersForCandidate,
 } from './transportDetection';
@@ -235,9 +236,11 @@ describe('dual-era server evaluation', () => {
   });
 
   it('does not mistake a proxy-hop authentication failure for target OAuth', async () => {
-    const proxyAuthError = Object.assign(new Error('Proxy returned HTTP 401'), {
-      status: 401,
-    });
+    const proxyAuthError = new ProxiedAuthenticationError(
+      401,
+      'proxy',
+      new Error('Firebase token was rejected')
+    );
     connectionMocks.attempt
       .mockRejectedValueOnce(new Error('Direct CORS failure'))
       .mockRejectedValueOnce(new TransportConnectionError([proxyAuthError]));
@@ -246,6 +249,23 @@ describe('dual-era server evaluation', () => {
 
     expect(report.sections.auth).toBeUndefined();
     expect(report.sections.protocol.details[0].text).toContain('Authenticated proxy:');
+  });
+
+  it('offers target OAuth for a verified upstream challenge observed through the proxy', async () => {
+    const targetAuthError = new ProxiedAuthenticationError(
+      403,
+      'target',
+      Object.assign(new Error('Upstream MCP target returned forbidden'), { status: 403 })
+    );
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockRejectedValueOnce(new TransportConnectionError([targetAuthError]));
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeDefined();
+    expect(report.sections.auth.details[0].context).toContain('MCP target returned HTTP 403');
+    expect(report.sections.auth.details[0].metadata).toEqual({ route: 'proxy', status: 403 });
   });
 
   it('normalizes report scores from the sections included in that run', () => {

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -17,7 +17,10 @@ import {
   getEvaluationTargetUrl,
   getEvaluationTransportProbeUrl,
 } from './evaluation';
-import { getRequestHeadersForCandidate } from './transportDetection';
+import {
+  TransportConnectionError,
+  getRequestHeadersForCandidate,
+} from './transportDetection';
 
 const createClient = () => ({
   listTools: vi.fn().mockResolvedValue({ tools: [] }),
@@ -79,7 +82,8 @@ describe('dual-era server evaluation', () => {
   it('rewrites only a terminal conventional path for comparison probes', () => {
     const probeUrl = getEvaluationTransportProbeUrl(
       'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fmcp',
-      'sse'
+      'sse',
+      true
     );
 
     expect(new URL(probeUrl).searchParams.get('target')).toBe('https://mcp.example/sse');
@@ -110,7 +114,8 @@ describe('dual-era server evaluation', () => {
     expect(connectionMocks.attempt).toHaveBeenCalledTimes(2);
     const [proxyUrl, , proxyAuthToken, targetHeaders] = connectionMocks.attempt.mock.calls[1];
     expect(proxyAuthToken).toBe('firebase-jwt');
-    const outgoingTargetHeaders = getRequestHeadersForCandidate(proxyUrl, targetHeaders);
+    expect(connectionMocks.attempt.mock.calls[1][4]).toBe(true);
+    const outgoingTargetHeaders = getRequestHeadersForCandidate(proxyUrl, targetHeaders, true);
     expect(outgoingTargetHeaders.get('authorization')).toBeNull();
     expect(outgoingTargetHeaders.get('x-mcp-authorization')).toBe('Bearer oauth-access-token');
     expect(report.sections.protocol.details[0].metadata).toMatchObject({
@@ -122,6 +127,47 @@ describe('dual-era server evaluation', () => {
     expect(report.sections.cors.score).toBe(0);
     expect(report.sections.cors.details[0].text).toContain('proxy was required');
     expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['URL-valued', 'https://tenant.example/account'],
+    ['ordinary', 'production'],
+  ])('preserves a direct custom endpoint with a %s target parameter', async (_, target) => {
+    const client = createClient();
+    const endpoint = new URL('https://mcp.example/custom/endpoint');
+    endpoint.searchParams.set('target', target);
+    endpoint.searchParams.set('tenant', 'acme');
+    connectionMocks.attempt.mockResolvedValueOnce({
+      client,
+      url: endpoint.toString(),
+      transportType: 'streamable-http',
+      protocolEra: 'modern',
+    });
+
+    const report = await evaluateServer(endpoint.toString(), 'firebase-jwt', vi.fn());
+
+    expect(connectionMocks.attempt.mock.calls[0][0]).toBe(endpoint.toString());
+    expect(connectionMocks.attempt.mock.calls[0][4]).toBe(false);
+    expect(report.sections.protocol.details[0].metadata).toMatchObject({
+      endpoint: endpoint.toString(),
+      route: 'direct',
+    });
+    expect(getEvaluationTargetUrl(endpoint.toString(), false)).toBe(endpoint.toString());
+  });
+
+  it('unwraps target only for an explicitly confirmed configured-proxy URL', () => {
+    const configuredProxy = (
+      'https://proxy.mcptest.test/?target=https%3A%2F%2Fmcp.example%2Fcustom%3Ftenant%3Dacme'
+    );
+    const otherProxy = (
+      'https://other-proxy.example/?target=https%3A%2F%2Fmcp.example%2Fcustom'
+    );
+
+    expect(getEvaluationTargetUrl(configuredProxy, true)).toBe(
+      'https://mcp.example/custom?tenant=acme'
+    );
+    expect(getEvaluationTargetUrl(configuredProxy, false)).toBe(configuredProxy);
+    expect(getEvaluationTargetUrl(otherProxy, true)).toBe(otherProxy);
   });
 
   it('reports a stateful legacy-SSE connection without inventing pre-standard endpoints', async () => {
@@ -169,16 +215,37 @@ describe('dual-era server evaluation', () => {
     ]);
   });
 
-  it('surfaces authentication failures without probing /mcp/v1 routes', async () => {
+  it('preserves a direct target authentication response when the proxy also fails', async () => {
+    const targetAuthError = Object.assign(new Error('Direct target returned HTTP 401'), {
+      status: 401,
+    });
     connectionMocks.attempt
-      .mockRejectedValueOnce(new Error('HTTP 401 Unauthorized'))
-      .mockRejectedValueOnce(new Error('HTTP 401 Unauthorized'));
+      .mockRejectedValueOnce(new TransportConnectionError([targetAuthError]))
+      .mockRejectedValueOnce(new Error('Proxy network failure'));
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
     expect(report.sections.auth).toBeDefined();
+    expect(report.sections.auth.details[0].context).toContain('Direct target returned HTTP 401');
+    expect(report.sections.auth.details[0].metadata).toEqual({ route: 'direct', status: 401 });
     expect(report.sections.protocol.score).toBe(0);
+    expect(report.sections.protocol.details[0].text).toContain('Direct target:');
+    expect(report.sections.protocol.details[0].text).toContain('Authenticated proxy:');
     expect(JSON.stringify(report)).not.toContain('/mcp/v1/');
+  });
+
+  it('does not mistake a proxy-hop authentication failure for target OAuth', async () => {
+    const proxyAuthError = Object.assign(new Error('Proxy returned HTTP 401'), {
+      status: 401,
+    });
+    connectionMocks.attempt
+      .mockRejectedValueOnce(new Error('Direct CORS failure'))
+      .mockRejectedValueOnce(new TransportConnectionError([proxyAuthError]));
+
+    const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
+
+    expect(report.sections.auth).toBeUndefined();
+    expect(report.sections.protocol.details[0].text).toContain('Authenticated proxy:');
   });
 
   it('normalizes report scores from the sections included in that run', () => {

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -324,13 +324,11 @@ const makeRouteFailure = (
   observedChallenge?: ObservedAuthenticationChallenge,
   connectedCandidateUrl?: string
 ): EvaluationRouteFailure => {
-  const proxyAuthChallenge = route === 'proxy'
-    ? observedChallenge || getProxyAuthenticationChallenge(error)
-    : undefined;
-  const httpStatus = proxyAuthChallenge?.status || getAuthenticationHttpStatus(error);
-  const authenticationSource = route === 'direct' && httpStatus
-    ? 'target'
-    : proxyAuthChallenge?.source;
+  const authenticationChallenge = observedChallenge || getProxyAuthenticationChallenge(error);
+  const httpStatus = authenticationChallenge?.status || getAuthenticationHttpStatus(error);
+  const authenticationSource = authenticationChallenge?.source || (
+    route === 'direct' && httpStatus ? 'target' : undefined
+  );
   const failedCandidateUrl = connectedCandidateUrl || (
     authenticationSource
       ? getAuthenticationCandidateUrl(error, authenticationSource)

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -187,7 +187,6 @@ const getAuthenticationHttpStatus = (
   const value = error as {
     status?: unknown;
     statusCode?: unknown;
-    code?: unknown;
     data?: { status?: unknown };
     response?: { status?: unknown };
     cause?: unknown;
@@ -196,7 +195,6 @@ const getAuthenticationHttpStatus = (
   const directStatuses = [
     value.status,
     value.statusCode,
-    value.code,
     value.data?.status,
     value.response?.status,
   ];

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -11,6 +11,7 @@ import {
   attemptParallelConnections,
   type ObservedAuthenticationChallenge,
   type ProxyAuthenticationSource,
+  type TransportCandidateFailure,
 } from './transportDetection';
 import type { TransportType } from '../types';
 
@@ -87,6 +88,7 @@ interface EvaluationSection {
 
 export interface EvaluationReport {
   serverUrl: string;
+  authenticationUrl?: string;
   finalScore: number;
   sections: Record<string, EvaluationSection>;
 }
@@ -277,25 +279,74 @@ interface EvaluationRouteFailure {
   message: string;
   httpStatus?: number;
   authenticationSource?: ProxyAuthenticationSource;
+  candidateUrl?: string;
 }
+
+const getAuthenticationCandidateUrl = (
+  error: unknown,
+  authenticationSource: ProxyAuthenticationSource,
+  seen = new Set<object>()
+): string | undefined => {
+  if (!error || typeof error !== 'object' || seen.has(error)) return undefined;
+  seen.add(error);
+
+  const value = error as {
+    candidateFailures?: readonly TransportCandidateFailure[];
+    cause?: unknown;
+    errors?: readonly unknown[];
+  };
+  if (Array.isArray(value.candidateFailures)) {
+    for (const failure of value.candidateFailures) {
+      const challenge = getProxyAuthenticationChallenge(failure.error);
+      const status = challenge?.status || getAuthenticationHttpStatus(failure.error);
+      const source = challenge?.source || 'target';
+      if ((status === 401 || status === 403) && source === authenticationSource) {
+        return failure.candidateUrl;
+      }
+    }
+  }
+
+  if (Array.isArray(value.errors)) {
+    for (const nestedError of value.errors) {
+      const candidateUrl = getAuthenticationCandidateUrl(
+        nestedError,
+        authenticationSource,
+        seen
+      );
+      if (candidateUrl) return candidateUrl;
+    }
+  }
+
+  return getAuthenticationCandidateUrl(value.cause, authenticationSource, seen);
+};
 
 const makeRouteFailure = (
   route: EvaluationRouteFailure['route'],
   error: unknown,
-  observedChallenge?: ObservedAuthenticationChallenge
+  observedChallenge?: ObservedAuthenticationChallenge,
+  connectedCandidateUrl?: string
 ): EvaluationRouteFailure => {
   const proxyAuthChallenge = route === 'proxy'
     ? observedChallenge || getProxyAuthenticationChallenge(error)
     : undefined;
   const httpStatus = proxyAuthChallenge?.status || getAuthenticationHttpStatus(error);
+  const authenticationSource = route === 'direct' && httpStatus
+    ? 'target'
+    : proxyAuthChallenge?.source;
+  const failedCandidateUrl = connectedCandidateUrl || (
+    authenticationSource
+      ? getAuthenticationCandidateUrl(error, authenticationSource)
+      : undefined
+  );
   return {
     route,
     error,
     message: errorMessage(error),
     httpStatus,
-    authenticationSource: route === 'direct' && httpStatus
-      ? 'target'
-      : proxyAuthChallenge?.source,
+    authenticationSource,
+    candidateUrl: failedCandidateUrl
+      ? getEvaluationTargetUrl(failedCandidateUrl, route === 'proxy')
+      : undefined,
   };
 };
 
@@ -420,7 +471,8 @@ const evaluateCapabilities = async (
       const failure = makeRouteFailure(
         connection.usedProxy ? 'proxy' : 'direct',
         error,
-        connection.takeAuthenticationChallenge?.()
+        connection.takeAuthenticationChallenge?.(),
+        connection.url
       );
       if (
         (failure.httpStatus === 401 || failure.httpStatus === 403)
@@ -718,6 +770,7 @@ export async function evaluateServer(
       'Performance was not scored because negotiation failed.'
     );
     if (targetAuthFailure) {
+      report.authenticationUrl = targetAuthFailure.candidateUrl || serverUrl;
       report.sections.auth = {
         name: 'Authentication Required',
         description: 'The MCP endpoint rejected unauthenticated negotiation',
@@ -729,6 +782,7 @@ export async function evaluateServer(
           metadata: {
             route: targetAuthFailure.route,
             status: targetAuthFailure.httpStatus,
+            endpoint: report.authenticationUrl,
           },
         }],
       };
@@ -772,6 +826,8 @@ export async function evaluateServer(
   const capabilityEvaluation = await evaluateCapabilities(connection);
   report.sections.capabilities = capabilityEvaluation.section;
   if (capabilityEvaluation.targetAuthenticationFailures.length > 0) {
+    report.authenticationUrl = capabilityEvaluation.targetAuthenticationFailures[0].candidateUrl
+      || getEvaluationTargetUrl(connection.url, connection.usedProxy);
     report.sections.auth = {
       name: 'Authentication Required',
       description: 'The MCP endpoint rejected standardized capability requests',
@@ -785,6 +841,7 @@ export async function evaluateServer(
           route: failure.route,
           status: failure.httpStatus,
           authenticationSource: failure.authenticationSource,
+          endpoint: failure.candidateUrl || report.authenticationUrl,
         },
       })),
     };

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -1,6 +1,6 @@
-// src/utils/evaluation.ts
-import { Client } from "@modelcontextprotocol/client";
+import type { Client, ProtocolEra } from '@modelcontextprotocol/client';
 import { attemptParallelConnections } from './transportDetection';
+import type { TransportType } from '../types';
 
 const getProxyUrl = (): string | undefined => import.meta.env.VITE_PROXY_URL;
 
@@ -13,6 +13,21 @@ const isConfiguredProxyTarget = (value: string, proxyUrl: string): boolean => {
     && candidate.searchParams.has('target');
 };
 
+const normalizeServerUrl = (value: string): string => {
+  const withProtocol = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  return new URL(withProtocol).toString();
+};
+
+export const getEvaluationTargetUrl = (connectionUrl: string): string => {
+  const outerUrl = new URL(connectionUrl);
+  return outerUrl.searchParams.get('target') || outerUrl.toString();
+};
+
+/**
+ * Retained for callers that need to compare a negotiated HTTP/SSE sibling.
+ * Custom paths remain exact; only a terminal conventional transport segment is
+ * replaced.
+ */
 export function getEvaluationTransportProbeUrl(
   connectionUrl: string,
   targetTransport: 'mcp' | 'sse'
@@ -25,9 +40,7 @@ export function getEvaluationTransportProbeUrl(
     && proxyTarget
     && isConfiguredProxyTarget(connectionUrl, proxyUrl)
   );
-  const targetUrl = isProxied
-    ? new URL(proxyTarget as string)
-    : outerUrl;
+  const targetUrl = isProxied ? new URL(proxyTarget as string) : outerUrl;
 
   targetUrl.pathname = targetUrl.pathname.replace(/\/(?:mcp|sse)\/?$/, `/${targetTransport}`);
 
@@ -39,7 +52,7 @@ export function getEvaluationTransportProbeUrl(
 interface DetailItem {
   text: string;
   context?: string;
-  metadata?: any;
+  metadata?: unknown;
 }
 
 interface EvaluationSection {
@@ -50,11 +63,22 @@ interface EvaluationSection {
   details: DetailItem[];
 }
 
-interface EvaluationReport {
+export interface EvaluationReport {
   serverUrl: string;
   finalScore: number;
   sections: Record<string, EvaluationSection>;
 }
+
+export const getEvaluationMaxScore = (report: EvaluationReport): number => (
+  Object.entries(report.sections)
+    .filter(([key]) => key !== 'auth')
+    .reduce((total, [, section]) => total + section.maxScore, 0)
+);
+
+export const getEvaluationPercentage = (report: EvaluationReport): number => {
+  const maxScore = getEvaluationMaxScore(report);
+  return maxScore > 0 ? report.finalScore / maxScore * 100 : 0;
+};
 
 export function getEvaluationProxyHeaders(
   requestHeaders: HeadersInit | undefined,
@@ -71,6 +95,11 @@ export function getEvaluationProxyHeaders(
   return headers;
 }
 
+/**
+ * Fetches the target directly first so evaluation does not silently measure the
+ * proxy. When direct browser access fails, the configured proxy is authenticated
+ * with Firebase and the MCP credential is kept on the isolated target channel.
+ */
 export async function fetchForEvaluation(
   url: string,
   firebaseToken: string,
@@ -85,1156 +114,380 @@ export async function fetchForEvaluation(
     });
   }
 
-  const headers = new Headers(options.headers);
-
-  // Try direct fetch first if we have an OAuth token
+  const directHeaders = new Headers(options.headers);
   if (oauthToken) {
-    headers.set('Authorization', `Bearer ${oauthToken}`);
-    try {
-      return await fetch(url, { ...options, headers });
-    } catch (error) {
-      console.log('[Evaluation] Direct fetch failed, falling back to proxy');
-    }
+    directHeaders.set('Authorization', `Bearer ${oauthToken}`);
   }
 
-  // Fallback to proxy if direct fetch fails or no OAuth token
-  if (!proxyUrl) {
-    throw new Error('Direct connection failed and no proxy configured');
+  try {
+    return await fetch(url, { ...options, headers: directHeaders });
+  } catch (error) {
+    if (!proxyUrl) throw error;
+    console.log('[Evaluation] Direct fetch failed, falling back to proxy');
   }
-  
+
   const target = new URL(proxyUrl);
   target.searchParams.set('target', url);
-  const proxyHeaders = getEvaluationProxyHeaders(options.headers, firebaseToken, oauthToken);
-  
-  return fetch(target, { ...options, headers: proxyHeaders });
+  return fetch(target, {
+    ...options,
+    headers: getEvaluationProxyHeaders(options.headers, firebaseToken, oauthToken),
+  });
 }
 
-export async function evaluateServer(serverUrl: string, token: string, onProgress: (message: string) => void, oauthAccessToken?: string | null): Promise<EvaluationReport> {
-  // Check if we need OAuth authentication for this server
-  let accessToken: string | null = oauthAccessToken || null;
-  
-  if (accessToken) {
-    onProgress('Using OAuth access token for server authentication');
-  }
-  // Ensure serverUrl has protocol
-  if (!serverUrl.startsWith('http://') && !serverUrl.startsWith('https://')) {
-    serverUrl = `https://${serverUrl}`;
-  }
+export const getEvaluationCorsHeaders = (
+  protocolEra: ProtocolEra,
+  authenticated: boolean
+): string[] => {
+  const headers = ['content-type', 'accept', 'mcp-protocol-version'];
 
-  const report: EvaluationReport = {
-    serverUrl,
-    finalScore: 0,
-    sections: {}
-  };
-
-  let oauthSupported = false;  // Track if OAuth is supported
-  let mcpClient: Client | null = null;
-  let connectionUrl = '';
-  let usedProxy = false;
-  let transportType: 'streamable-http' | 'legacy-sse' | null = null;
-
-  // First, try to establish a connection using the shared connection logic
-  onProgress('Establishing MCP connection to server...');
-  
-  // Create an abort controller for the connection
-  const abortController = new AbortController();
-  
-  try {
-    // Always try direct connection first
-    try {
-      onProgress('Attempting direct connection to server...');
-      const authTokenToUse = accessToken || undefined;
-      const connectionResult = await attemptParallelConnections(serverUrl, abortController.signal, authTokenToUse);
-      mcpClient = connectionResult.client;
-      connectionUrl = connectionResult.url;
-      transportType = connectionResult.transportType;
-      const authType = accessToken ? 'with OAuth' : 'without auth';
-      onProgress(`Connected successfully using ${connectionResult.transportType} transport (direct ${authType})`);
-    } catch (directError: any) {
-      // Direct connection failed, only try proxy if configured
-      const proxyUrl = getProxyUrl();
-      if (proxyUrl) {
-        onProgress('Direct connection failed, attempting proxy connection...');
-        const proxyConnectionUrl = new URL(proxyUrl);
-        proxyConnectionUrl.searchParams.set('target', serverUrl);
-        const targetHeaders = accessToken
-          ? { Authorization: `Bearer ${accessToken}` }
-          : undefined;
-        const connectionResult = await attemptParallelConnections(
-          proxyConnectionUrl.toString(),
-          abortController.signal,
-          token,
-          targetHeaders
-        );
-        mcpClient = connectionResult.client;
-        connectionUrl = connectionResult.url;
-        transportType = connectionResult.transportType;
-        usedProxy = true;
-        const authType = accessToken
-          ? 'with Firebase proxy auth and OAuth target auth'
-          : 'with Firebase proxy auth';
-        onProgress(`Connected successfully using ${connectionResult.transportType} transport (proxy ${authType})`);
-      } else {
-        throw directError;
-      }
-    }
-  } catch (connectionError) {
-    onProgress('Failed to establish MCP connection using standard transports');
-    
-    // Check if this is an authentication issue
-    if (!accessToken) {
-      onProgress('Checking if server requires OAuth authentication...');
-      try {
-        const testResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            protocolVersion: '2024-11-05',
-            capabilities: {}
-          })
-        });
-        
-        if (testResponse.status === 401 || testResponse.status === 403) {
-          // Server requires authentication
-          onProgress('Server requires OAuth authentication. Please authenticate first.');
-          report.sections.auth = {
-            name: 'Authentication Required',
-            description: 'Server requires OAuth authentication before evaluation',
-            score: 0,
-            maxScore: 0,
-            details: [
-              { text: '⚠️ Server returned 401/403 - OAuth authentication required', context: 'The server requires OAuth authentication to access MCP endpoints.' },
-              { text: '⚠️ Please authenticate with the server before running the report', context: 'Use the authenticate button to complete OAuth flow before evaluation.' }
-            ]
-          };
-          report.finalScore = 0;
-          return report;
-        }
-      } catch (error) {
-        // Continue with evaluation even if initial test fails
-      }
-    }
-  }
-
-  // 1. Core Protocol Adherence (15 points)
-  onProgress('Checking Core Protocol Adherence...');
-  const protocolSection: EvaluationSection = {
-    name: 'Core Protocol Adherence',
-    description: 'Validates MCP protocol implementation and required endpoints',
-    score: 0,
-    maxScore: 15,
-    details: []
-  };
-
-  let response: Response | null = null;
-  let initData: any = null;
-
-  // If we successfully connected with the MCP client, use that information
-  if (mcpClient) {
-    protocolSection.score += 10;
-    protocolSection.details.push({
-      text: '✓ Server responds to MCP initialize request',
-      context: 'The server correctly implements the MCP initialize endpoint, allowing clients to establish protocol version and capabilities.',
-      metadata: {
-        endpoint: '/mcp/v1/initialize',
-        transport: usedProxy ? 'proxy' : 'direct',
-        connectionUrl: connectionUrl,
-        serverInfo: initData || {}
-      }
-    });
-    
-    // Since we connected successfully, we know it returns JSON
-    protocolSection.score += 5;
-    protocolSection.details.push({
-      text: '✓ Server returns proper JSON content type',
-      context: 'MCP requires JSON-RPC 2.0 format. The server correctly sets Content-Type: application/json header.',
-      metadata: {
-        contentType: 'application/json',
-        method: 'verified from successful connection',
-        headers: 'application/json (from successful MCP client connection)'
-      }
-    });
-    
-    // Note: The MCP SDK client doesn't expose the initialize response data directly
-    // We'll check capabilities by making actual requests below
+  if (protocolEra === 'modern') {
+    headers.push('mcp-method', 'mcp-name');
   } else {
-    // Fallback to direct HTTP check if client connection failed
-    try {
-      // Check if server responds to basic MCP request
-      response = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          protocolVersion: '2024-11-05',
-          capabilities: {}
-        })
-      }, accessToken);
-
-      if (response.ok) {
-        protocolSection.score += 10;
-        protocolSection.details.push({
-          text: '✓ Server responds to MCP initialize request',
-          context: 'The server correctly implements the MCP initialize endpoint, allowing clients to establish protocol version and capabilities.',
-          metadata: {
-            endpoint: `${serverUrl}/mcp/v1/initialize`,
-            method: 'POST',
-            requestBody: {
-              protocolVersion: '2024-11-05',
-              capabilities: {}
-            },
-            responseStatus: response.status,
-            responseData: initData || null
-          }
-        });
-        
-        // Clone response before reading body
-        const responseClone = response.clone();
-        try {
-          initData = await responseClone.json();
-        } catch (e) {
-          console.error('Failed to parse initialize response:', e);
-        }
-      } else {
-        protocolSection.details.push({
-          text: `✗ Server returned ${response.status} for initialize request`,
-          context: 'The initialize endpoint is required for MCP protocol handshake. Without it, clients cannot establish a connection.',
-          metadata: { status: response.status }
-        });
-      }
-
-      // Check for proper content type
-      const contentType = response.headers.get('content-type');
-      if (contentType?.includes('application/json')) {
-        protocolSection.score += 5;
-        protocolSection.details.push({
-          text: '✓ Server returns proper JSON content type',
-          context: 'MCP requires JSON-RPC 2.0 format. The server correctly sets Content-Type: application/json header.',
-          metadata: {
-            contentType: contentType,
-            headers: Object.fromEntries(response.headers.entries())
-          }
-        });
-      } else {
-        protocolSection.details.push({
-          text: '✗ Server does not return JSON content type',
-          context: `MCP requires JSON-RPC 2.0 format. Server returned: ${contentType || 'no content type'}`,
-          metadata: { contentType }
-        });
-      }
-    } catch (error: any) {
-      protocolSection.details.push({
-        text: `✗ Failed to connect to server: ${error.message || error}`,
-        context: 'Connection failure prevents any MCP protocol validation. Check server availability and CORS configuration.',
-        metadata: {
-          error: 'connection_failed',
-          errorMessage: error.message,
-          endpoint: `${serverUrl}/mcp/v1/initialize`,
-          method: 'POST'
-        }
-      });
-    }
+    headers.push('mcp-session-id', 'last-event-id');
   }
 
-  report.sections.protocol = protocolSection;
-  report.finalScore += protocolSection.score;
+  if (authenticated) headers.push('authorization');
+  return headers;
+};
 
-  // 2. MCP Capabilities (10 points)
-  onProgress('Checking MCP Capabilities...');
-  const capabilitiesSection: EvaluationSection = {
+const errorMessage = (error: unknown): string => (
+  error instanceof Error ? error.message : String(error)
+);
+
+const isMethodNotFound = (error: unknown): boolean => {
+  const value = error as { code?: number; message?: string };
+  return value?.code === -32601 || /method not found/i.test(value?.message || '');
+};
+
+const makeSkippedSection = (
+  name: string,
+  description: string,
+  maxScore: number,
+  reason: string
+): EvaluationSection => ({
+  name,
+  description,
+  score: 0,
+  maxScore,
+  details: [{ text: `⚠ ${reason}` }],
+});
+
+interface ConnectedEvaluation {
+  client: Client;
+  url: string;
+  transportType: TransportType;
+  protocolEra: ProtocolEra;
+  protocolVersion?: string;
+  usedProxy: boolean;
+  directError?: string;
+}
+
+const connectForEvaluation = async (
+  serverUrl: string,
+  firebaseToken: string,
+  oauthToken: string | null,
+  onProgress: (message: string) => void
+): Promise<ConnectedEvaluation> => {
+  const abortController = new AbortController();
+
+  try {
+    onProgress('Attempting direct MCP negotiation...');
+    const direct = await attemptParallelConnections(
+      serverUrl,
+      abortController.signal,
+      oauthToken || undefined
+    );
+    return { ...direct, usedProxy: false };
+  } catch (directError) {
+    const proxyUrl = getProxyUrl();
+    if (!proxyUrl) throw directError;
+
+    onProgress('Direct negotiation failed; retrying through the authenticated CORS proxy...');
+    const proxyConnectionUrl = new URL(proxyUrl);
+    proxyConnectionUrl.searchParams.set('target', serverUrl);
+    const targetHeaders = oauthToken
+      ? { Authorization: `Bearer ${oauthToken}` }
+      : undefined;
+    const proxied = await attemptParallelConnections(
+      proxyConnectionUrl.toString(),
+      abortController.signal,
+      firebaseToken,
+      targetHeaders
+    );
+    return { ...proxied, usedProxy: true, directError: errorMessage(directError) };
+  }
+};
+
+const evaluateCapabilities = async (client: Client): Promise<EvaluationSection> => {
+  const section: EvaluationSection = {
     name: 'MCP Capabilities',
-    description: 'Validates server MCP feature support (tools, resources, prompts)',
+    description: 'Exercises standardized tools, resources, and prompts discovery methods',
     score: 0,
     maxScore: 10,
-    details: []
+    details: [],
   };
+  const checks: Array<{
+    name: string;
+    method: string;
+    points: number;
+    run: () => Promise<unknown>;
+    count: (result: any) => number;
+  }> = [
+    {
+      name: 'tools',
+      method: 'tools/list',
+      points: 4,
+      run: () => client.listTools(),
+      count: (result) => Array.isArray(result?.tools) ? result.tools.length : 0,
+    },
+    {
+      name: 'resources',
+      method: 'resources/list',
+      points: 3,
+      run: () => client.listResources(),
+      count: (result) => Array.isArray(result?.resources) ? result.resources.length : 0,
+    },
+    {
+      name: 'prompts',
+      method: 'prompts/list',
+      points: 3,
+      run: () => client.listPrompts(),
+      count: (result) => Array.isArray(result?.prompts) ? result.prompts.length : 0,
+    },
+  ];
 
-  try {
-    // If we have an MCP client, try to get capabilities through proper methods
-    if (mcpClient) {
-      try {
-        // List available tools
-        const toolsResponse = await mcpClient.listTools();
-        if (toolsResponse?.tools && Array.isArray(toolsResponse.tools)) {
-          if (toolsResponse.tools.length > 0) {
-            capabilitiesSection.score += 3;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports tools capability',
-              context: `Tools allow servers to expose executable functions. Found ${toolsResponse.tools.length} tools.`,
-              metadata: {
-                method: 'tools/list',
-                response: 'success',
-                toolCount: toolsResponse.tools.length,
-                tools: toolsResponse.tools.map((tool: any) => ({
-                  name: tool.name,
-                  description: tool.description,
-                  inputSchema: tool.inputSchema
-                }))
-              }
-            });
-          } else {
-            capabilitiesSection.score += 3;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports tools capability',
-              context: 'Server has tools capability enabled but currently exposes no tools.',
-              metadata: {
-                method: 'tools/list',
-                response: 'success',
-                toolCount: 0,
-                tools: []
-              }
-            });
-          }
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Invalid response format for tools listing',
-            context: 'Server returned an unexpected response format. Expected { tools: [...] }.',
-            metadata: {
-              method: 'tools/list',
-              response: 'invalid_format',
-              actualResponse: toolsResponse
-            }
-          });
-        }
-      } catch (e: any) {
-        // Check if it's a method not found error which means tools aren't supported
-        if (e.message?.includes('method not found') || e.code === -32601) {
-          capabilitiesSection.details.push({
-            text: '✗ Server does not support tools capability',
-            context: 'Tools are a core MCP feature for exposing server functionality. Add tools to capabilities.',
-            metadata: {
-              method: 'tools/list',
-              error: 'method_not_found',
-              errorMessage: e.message
-            }
-          });
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Failed to check tools capability',
-            context: `Error occurred while checking tools support: ${e.message}`,
-            metadata: {
-              method: 'tools/list',
-              error: 'request_failed',
-              errorMessage: e.message,
-              errorCode: e.code
-            }
-          });
-        }
-      }
-
-      try {
-        // List available resources  
-        const resourcesResponse = await mcpClient.listResources();
-        if (resourcesResponse?.resources && Array.isArray(resourcesResponse.resources)) {
-          if (resourcesResponse.resources.length > 0) {
-            capabilitiesSection.score += 3;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports resources capability',
-              context: `Resources allow servers to expose data. Found ${resourcesResponse.resources.length} resources.`,
-              metadata: {
-                method: 'resources/list',
-                response: 'success',
-                resourceCount: resourcesResponse.resources.length,
-                resources: resourcesResponse.resources.map((resource: any) => ({
-                  uri: resource.uri,
-                  name: resource.name,
-                  description: resource.description,
-                  mimeType: resource.mimeType
-                }))
-              }
-            });
-          } else {
-            capabilitiesSection.score += 3;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports resources capability',
-              context: 'Server has resources capability enabled but currently exposes no resources.',
-              metadata: {
-                method: 'resources/list',
-                response: 'success',
-                resourceCount: 0,
-                resources: []
-              }
-            });
-          }
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Invalid response format for resources listing',
-            context: 'Server returned an unexpected response format. Expected { resources: [...] }.',
-            metadata: {
-              method: 'resources/list',
-              response: 'invalid_format',
-              actualResponse: resourcesResponse
-            }
-          });
-        }
-      } catch (e: any) {
-        // Check if it's a method not found error which means resources aren't supported
-        if (e.message?.includes('method not found') || e.code === -32601) {
-          capabilitiesSection.details.push({
-            text: '✗ Server does not support resources capability',
-            context: 'Resources enable data sharing between server and client. Add resources to capabilities.',
-            metadata: {
-              method: 'resources/list',
-              error: 'method_not_found',
-              errorMessage: e.message
-            }
-          });
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Failed to check resources capability',
-            context: `Error occurred while checking resources support: ${e.message}`,
-            metadata: {
-              method: 'resources/list',
-              error: 'request_failed',
-              errorMessage: e.message,
-              errorCode: e.code
-            }
-          });
-        }
-      }
-
-      try {
-        // List available prompts
-        const promptsResponse = await mcpClient.listPrompts();
-        if (promptsResponse?.prompts && Array.isArray(promptsResponse.prompts)) {
-          if (promptsResponse.prompts.length > 0) {
-            capabilitiesSection.score += 2;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports prompts capability',
-              context: `Prompts allow servers to define reusable prompt templates. Found ${promptsResponse.prompts.length} prompts.`,
-              metadata: {
-                method: 'prompts/list',
-                response: 'success',
-                promptCount: promptsResponse.prompts.length,
-                prompts: promptsResponse.prompts.map((prompt: any) => ({
-                  name: prompt.name,
-                  description: prompt.description,
-                  arguments: prompt.arguments
-                }))
-              }
-            });
-          } else {
-            capabilitiesSection.score += 2;
-            capabilitiesSection.details.push({
-              text: '✓ Server supports prompts capability',
-              context: 'Server has prompts capability enabled but currently exposes no prompts.',
-              metadata: {
-                method: 'prompts/list',
-                response: 'success',
-                promptCount: 0,
-                prompts: []
-              }
-            });
-          }
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Invalid response format for prompts listing',
-            context: 'Server returned an unexpected response format. Expected { prompts: [...] }.',
-            metadata: {
-              method: 'prompts/list',
-              response: 'invalid_format',
-              actualResponse: promptsResponse
-            }
-          });
-        }
-      } catch (e: any) {
-        // Check if it's a method not found error which means prompts aren't supported
-        if (e.message?.includes('method not found') || e.code === -32601) {
-          capabilitiesSection.details.push({
-            text: '✗ Server does not support prompts capability',
-            context: 'Prompts help standardize LLM interactions. Add prompts to capabilities.',
-            metadata: {
-              method: 'prompts/list',
-              error: 'method_not_found',
-              errorMessage: e.message
-            }
-          });
-        } else {
-          capabilitiesSection.details.push({
-            text: '✗ Failed to check prompts capability',
-            context: `Error occurred while checking prompts support: ${e.message}`,
-            metadata: {
-              method: 'prompts/list',
-              error: 'request_failed',
-              errorMessage: e.message,
-              errorCode: e.code
-            }
-          });
-        }
-      }
-
-      // Logging capability check
-      // Try to check if the server accepts logging messages
-      try {
-        // Send a test log message
-        await mcpClient.setLoggingLevel({ level: 'info' });
-        capabilitiesSection.score += 2;
-        capabilitiesSection.details.push({
-          text: '✓ Server supports logging capability',
-          context: 'Logging enables debugging and monitoring of MCP interactions.',
-          metadata: {
-            method: 'logging/setLevel',
-            response: 'success',
-            testLevel: 'info'
-          }
-        });
-      } catch (e: any) {
-        // If method not found, logging is not supported
-        if (e.message?.includes('method not found') || e.code === -32601) {
-          capabilitiesSection.details.push({
-            text: '✗ Server does not support logging capability',
-            context: 'Logging is useful for debugging MCP integrations. Add logging to capabilities.',
-            metadata: {
-              method: 'logging/setLevel',
-              error: 'method_not_found',
-              errorMessage: e.message
-            }
-          });
-        } else {
-          // For other errors, assume logging is supported since we connected successfully
-          capabilitiesSection.score += 2;
-          capabilitiesSection.details.push({
-            text: '✓ Server supports logging capability',
-            context: 'Logging enables debugging and monitoring of MCP interactions.',
-            metadata: {
-              method: 'connection_successful',
-              note: 'Inferred from successful connection'
-            }
-          });
-        }
-      }
-    } else if (initData) {
-      // Fallback to checking initialize response data
-      
-      // Check for tools support
-      if (initData.capabilities?.tools) {
-        capabilitiesSection.score += 3;
-        capabilitiesSection.details.push({
-          text: '✓ Server supports tools capability',
-          context: 'Tools allow servers to expose executable functions that clients can invoke.',
-          metadata: { tools: initData.capabilities.tools }
-        });
-      } else {
-        capabilitiesSection.details.push({
-          text: '✗ Server does not support tools capability',
-          context: 'Tools are a core MCP feature for exposing server functionality. Add tools to capabilities.'
-        });
-      }
-
-      // Check for resources support
-      if (initData.capabilities?.resources) {
-        capabilitiesSection.score += 3;
-        capabilitiesSection.details.push({
-          text: '✓ Server supports resources capability',
-          context: 'Resources allow servers to expose data that clients can read and subscribe to.',
-          metadata: { resources: initData.capabilities.resources }
-        });
-      } else {
-        capabilitiesSection.details.push({
-          text: '✗ Server does not support resources capability',
-          context: 'Resources enable data sharing between server and client. Add resources to capabilities.'
-        });
-      }
-
-      // Check for prompts support
-      if (initData.capabilities?.prompts) {
-        capabilitiesSection.score += 2;
-        capabilitiesSection.details.push({
-          text: '✓ Server supports prompts capability',
-          context: 'Prompts allow servers to define reusable prompt templates for LLM interactions.',
-          metadata: { prompts: initData.capabilities.prompts }
-        });
-      } else {
-        capabilitiesSection.details.push({
-          text: '✗ Server does not support prompts capability',
-          context: 'Prompts help standardize LLM interactions. Add prompts to capabilities.'
-        });
-      }
-
-      // Check for logging support
-      if (initData.capabilities?.logging) {
-        capabilitiesSection.score += 2;
-        capabilitiesSection.details.push({
-          text: '✓ Server supports logging capability',
-          context: 'Logging enables debugging and monitoring of MCP interactions.',
-          metadata: { logging: initData.capabilities.logging }
-        });
-      } else {
-        capabilitiesSection.details.push({
-          text: '✗ Server does not support logging capability',
-          context: 'Logging is useful for debugging MCP integrations. Add logging to capabilities.'
-        });
-      }
-    } else {
-      capabilitiesSection.details.push({
-        text: '✗ Unable to check MCP capabilities',
-        context: 'Server must respond successfully to initialize request to validate capabilities.'
-      });
-    }
-  } catch (error: any) {
-    capabilitiesSection.details.push({
-      text: `✗ Failed to parse capabilities: ${error.message || error}`,
-      context: 'Error parsing server response. Ensure server returns valid JSON-RPC 2.0 format.',
-      metadata: {
-        error: 'capabilities_check_failed',
-        errorMessage: error.message
-      }
-    });
-  }
-
-  report.sections.capabilities = capabilitiesSection;
-  report.finalScore += capabilitiesSection.score;
-
-  // 3. Transport Layer Modernity (15 points)
-  onProgress('Checking Transport Layer Modernity...');
-  const transportSection: EvaluationSection = {
-    name: 'Transport Layer Modernity',
-    description: 'Evaluates transport methods and protocol support',
-    score: 0,
-    maxScore: 15,
-    details: []
-  };
-
-  // If we connected with the MCP client, we know the transport worked
-  if (mcpClient && transportType) {
-    if (transportType === 'streamable-http') {
-      transportSection.score += 10;
-      transportSection.details.push({
-        text: '✓ Server supports HTTP streaming (modern standard)',
-        context: 'HTTP streaming (NDJSON) enables real-time bidirectional communication, essential for long-running MCP operations.',
-        metadata: {
-          transportType: 'HTTP/NDJSON',
-          endpoint: connectionUrl,
-          capabilities: 'bidirectional streaming'
-        }
-      });
-      
-      // Also check for SSE support even when using HTTP streaming
-      try {
-        const sseCheckUrl = getEvaluationTransportProbeUrl(connectionUrl, 'sse');
-        const sseResponse = await fetchForEvaluation(sseCheckUrl, token, {
-          method: 'GET',
-          headers: { 'Accept': 'text/event-stream' }
-        }, accessToken);
-        
-        if (sseResponse.ok && sseResponse.headers.get('content-type')?.includes('text/event-stream')) {
-          transportSection.details.push({
-            text: '✓ Server also supports SSE (Server-Sent Events)',
-            context: 'Server-Sent Events (SSE) provides unidirectional streaming from server to client as an alternative transport option.',
-            metadata: {
-              transportType: 'SSE',
-              endpoint: sseCheckUrl,
-              capabilities: 'unidirectional streaming',
-              contentType: sseResponse.headers.get('content-type'),
-              supported: true
-            }
-          });
-        }
-      } catch (e) {
-        // SSE check failed, but that's okay since we have HTTP streaming
-      }
-    } else if (transportType === 'legacy-sse') {
-      // SSE gets no points but no penalty
-      transportSection.details.push({
-        text: '✓ Server supports SSE (Server-Sent Events)',
-        context: 'Server-Sent Events (SSE) provides unidirectional streaming from server to client. While HTTP/NDJSON is preferred for bidirectional communication, SSE remains a valid transport option.',
-        metadata: {
-          transportType: 'SSE',
-          endpoint: connectionUrl,
-          capabilities: 'unidirectional streaming',
-          supported: true,
-          contentType: 'text/event-stream'
-        }
-      });
-      
-      // Also check if HTTP streaming is supported
-      try {
-        const httpCheckUrl = getEvaluationTransportProbeUrl(connectionUrl, 'mcp');
-        const httpResponse = await fetchForEvaluation(httpCheckUrl, token, {
-          method: 'POST',
-          headers: { 
-            'Content-Type': 'application/json',
-            'Accept': 'application/x-ndjson'
-          },
-          body: JSON.stringify({
-            protocolVersion: '2024-11-05',
-            capabilities: {}
-          })
-        }, accessToken);
-        
-        if (httpResponse.ok && httpResponse.headers.get('content-type')?.includes('application/x-ndjson')) {
-          transportSection.details.push({
-            text: '✓ Server also supports HTTP streaming (modern standard)',
-            context: 'HTTP streaming (NDJSON) enables real-time bidirectional communication as a more modern alternative.',
-            metadata: {
-              transportType: 'HTTP/NDJSON',
-              endpoint: httpCheckUrl,
-              capabilities: 'bidirectional streaming',
-              contentType: httpResponse.headers.get('content-type'),
-              supported: true
-            }
-          });
-        }
-      } catch (e) {
-        // HTTP streaming check failed, but that's okay since we have SSE
-      }
-    }
-    
-    // Give points for modern HTTP protocols since connection succeeded
-    transportSection.score += 5;
-    transportSection.details.push({
-      text: '✓ Server uses modern HTTP protocols',
-      context: 'Server supports HTTP/2 or HTTP/3, providing improved performance through multiplexing and reduced latency.',
-      metadata: {
-        detectionMethod: 'successful_mcp_connection',
-        note: 'Protocol version inferred from successful MCP client connection',
-        transportUsed: transportType
-      }
-    });
-  } else {
-    // Fallback to manual transport checks if no MCP client
+  for (const check of checks) {
     try {
-      // Check for HTTP streaming support (preferred over SSE)
-    const streamResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/stream`, token, {
-      method: 'POST',
-      headers: { 
-        'Content-Type': 'application/json',
-        'Accept': 'application/x-ndjson, text/event-stream'
-      },
-      body: JSON.stringify({
-        protocolVersion: '2024-11-05',
-        capabilities: {}
-      })
-    }, accessToken);
-
-    if (streamResponse.ok && 
-        streamResponse.headers.get('content-type')?.includes('application/x-ndjson')) {
-      transportSection.score += 10;
-      transportSection.details.push({
-        text: '✓ Server supports HTTP streaming (modern standard)',
-        context: 'HTTP streaming (NDJSON) enables real-time bidirectional communication, essential for long-running MCP operations.',
-        metadata: { 
-          transportType: 'HTTP/NDJSON',
-          endpoint: `${serverUrl}/mcp/v1/stream`,
-          capabilities: 'bidirectional streaming',
-          contentType: streamResponse.headers.get('content-type') 
-        }
+      const startedAt = Date.now();
+      const result = await check.run();
+      const durationMs = Date.now() - startedAt;
+      const itemCount = check.count(result);
+      section.score += check.points;
+      section.details.push({
+        text: `✓ ${check.method} succeeded (${itemCount} ${check.name})`,
+        context: `The server implements the standard ${check.name} discovery method, including valid empty lists.`,
+        metadata: { method: check.method, itemCount, durationMs },
       });
-    } else {
-      transportSection.details.push({
-        text: '✗ Server does not support HTTP streaming',
-        context: `Streaming is required for efficient real-time MCP communication. Request returned: ${streamResponse.status} ${streamResponse.statusText}`,
-        metadata: { status: streamResponse.status, statusText: streamResponse.statusText }
-      });
-    }
-    
-    // Always check for SSE support (legacy)
-    try {
-      const sseResponse = await fetchForEvaluation(`${serverUrl}/sse`, token, {
-        method: 'GET',
-        headers: { 'Accept': 'text/event-stream' }
-      }, accessToken);
-
-      if (sseResponse.ok && sseResponse.headers.get('content-type')?.includes('text/event-stream')) {
-        transportSection.details.push({
-          text: '✓ Server supports SSE (Server-Sent Events)',
-          context: 'Server-Sent Events (SSE) provides unidirectional streaming from server to client. While HTTP/NDJSON is preferred for bidirectional communication, SSE remains a valid transport option.',
-          metadata: {
-            transportType: 'SSE',
-            endpoint: `${serverUrl}/sse`,
-            capabilities: 'unidirectional streaming',
-            contentType: sseResponse.headers.get('content-type'),
-            supported: true
-          }
-        });
-      } else {
-        transportSection.details.push({
-          text: '✗ Server does not support SSE',
-          context: 'SSE endpoint not available or returned error.',
-          metadata: {
-            transportType: 'SSE',
-            endpoint: `${serverUrl}/sse`,
-            status: sseResponse.status,
-            supported: false
-          }
-        });
-      }
-    } catch (e: any) {
-      transportSection.details.push({
-        text: '✗ Server does not support SSE',
-        context: `SSE check failed: ${e.message}`,
-        metadata: {
-          transportType: 'SSE',
-          endpoint: `${serverUrl}/sse`,
-          error: e.message,
-          supported: false
-        }
-      });
-    }
-
-    // Check for HTTP/2 support by examining response
-    if (streamResponse && streamResponse.ok) {
-      transportSection.score += 5;
-      transportSection.details.push({
-        text: '✓ Server uses modern HTTP protocols',
-        context: 'Server supports HTTP/2 or HTTP/3, providing improved performance through multiplexing and reduced latency.',
-        metadata: {
-          detectionMethod: 'http_response_analysis',
-          responseStatus: streamResponse.status,
-          note: 'Modern protocol support detected through successful HTTP streaming endpoint'
-        }
-      });
-    } else {
-      transportSection.details.push({
-        text: '✗ Unable to verify modern HTTP protocol support',
-        context: 'Could not confirm HTTP/2 or HTTP/3 support due to connection issues.',
-        metadata: {
-          detectionMethod: 'http_response_analysis',
-          note: 'Unable to verify protocol version'
-        }
-      });
-    }
-    } catch (error: any) {
-      transportSection.details.push({
-        text: `✗ Transport check failed: ${error.message || error}`,
-        context: 'Unable to validate transport layer capabilities. This may indicate network issues or server configuration problems.',
-        metadata: {
-          error: 'transport_check_failed',
-          errorMessage: error.message,
-          endpoint: `${serverUrl}/mcp/v1/stream`
-        }
+    } catch (error) {
+      section.details.push({
+        text: `${isMethodNotFound(error) ? '⚠' : '✗'} ${check.method} ${isMethodNotFound(error) ? 'is not supported' : 'failed'}`,
+        context: isMethodNotFound(error)
+          ? `${check.name} are optional; the server correctly returned method-not-found.`
+          : errorMessage(error),
+        metadata: { method: check.method, error: errorMessage(error) },
       });
     }
   }
 
-  report.sections.transport = transportSection;
-  report.finalScore += transportSection.score;
+  return section;
+};
 
-  // 3. Security Posture (40 points if OAuth supported, otherwise excluded)
-  onProgress('Checking Security Posture...');
-  
-  try {
-    // Check for OAuth discovery endpoint
-    const oauthDiscoveryResponse = await fetchForEvaluation(`${serverUrl}/.well-known/oauth-authorization-server`, token, {}, accessToken);
-    
-    if (oauthDiscoveryResponse.ok) {
-      // OAuth is supported, include security section
-      oauthSupported = true;
-      const securitySection: EvaluationSection = {
-        name: 'Security Posture',
-        description: 'Evaluates OAuth 2.1 implementation and security headers',
-        score: 0,
-        maxScore: 40,
-        details: []
-      };
-
-      const discoveryData = await oauthDiscoveryResponse.json();
-      
-      securitySection.score += 20;
-      securitySection.details.push({
-        text: '✓ OAuth 2.1 discovery endpoint available',
-        context: 'OAuth 2.1 discovery allows automatic configuration of authentication endpoints, improving security and user experience.',
-        metadata: {
-          discoveryEndpoint: `${serverUrl}/.well-known/oauth-authorization-server`,
-          responseStatus: oauthDiscoveryResponse.status,
-          discoveryData: discoveryData
-        }
-      });
-      if (discoveryData.token_endpoint) {
-        securitySection.score += 10;
-        securitySection.details.push({
-          text: '✓ Token endpoint properly configured',
-          context: 'Token endpoint enables secure exchange of authorization codes for access tokens.',
-          metadata: {
-            tokenEndpoint: discoveryData.token_endpoint,
-            supportedGrantTypes: discoveryData.grant_types_supported || []
-          }
-        });
-      } else {
-        securitySection.details.push({
-          text: '✗ Token endpoint not configured',
-          context: 'Missing token endpoint prevents OAuth token exchange. Check OAuth discovery configuration.'
-        });
-      }
-      
-      if (discoveryData.code_challenge_methods_supported?.includes('S256')) {
-        securitySection.score += 10;
-        securitySection.details.push({
-          text: '✓ PKCE support enabled',
-          context: 'Proof Key for Code Exchange (PKCE) provides additional security for public clients, preventing authorization code interception attacks.',
-          metadata: {
-            supportedMethods: discoveryData.code_challenge_methods_supported,
-            requiredMethod: 'S256'
-          }
-        });
-      } else {
-        securitySection.details.push({
-          text: '✗ PKCE support not enabled',
-          context: 'PKCE is required by OAuth 2.1 for public clients. Enable S256 code challenge method for enhanced security.'
-        });
-      }
-
-      report.sections.security = securitySection;
-      report.finalScore += securitySection.score;
-    } else {
-      // OAuth not supported - don't include in scoring
-      onProgress('OAuth not supported by server - excluding from scoring');
-    }
-  } catch (error) {
-    // OAuth check failed - assume not supported
-    onProgress('OAuth check failed - excluding from scoring');
-  }
-
-  // 4. Web Client Accessibility (15 points)
-  onProgress('Checking Web Client Accessibility (CORS)...');
-  const corsSection: EvaluationSection = {
+const evaluateBrowserAccessibility = (
+  connection: ConnectedEvaluation,
+  authenticated: boolean
+): EvaluationSection => {
+  const endpointUrl = getEvaluationTargetUrl(connection.url);
+  const requiredHeaders = getEvaluationCorsHeaders(connection.protocolEra, authenticated);
+  const section: EvaluationSection = {
     name: 'Web Client Accessibility',
-    description: 'Validates CORS configuration for browser-based clients',
-    score: 0,
+    description: 'Validates direct-browser MCP access at the negotiated endpoint',
+    score: connection.usedProxy ? 0 : 15,
     maxScore: 15,
-    details: []
+    details: [],
   };
 
-  try {
-    // Use the actual site URL for CORS testing
-    const siteUrl = window.location.origin;
-    
-    // CORS preflight check
-    const corsResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
-      method: 'OPTIONS',
-      headers: {
-        'Origin': siteUrl,
-        'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'content-type,authorization'
-      }
-    }, accessToken);
-
-    // Collect all CORS headers from the response
-    const corsHeaders: Record<string, string> = {};
-    const allResponseHeaders: Record<string, string> = {};
-    
-    // Collect ALL response headers
-    corsResponse.headers.forEach((value, key) => {
-      allResponseHeaders[key] = value;
+  if (connection.usedProxy) {
+    section.details.push({
+      text: '✗ Direct browser negotiation failed; the authenticated proxy was required',
+      context: connection.directError
+        || 'The direct route did not complete MCP negotiation in this browser.',
+      metadata: { endpoint: endpointUrl, requiredHeaders },
     });
-    
-    // Collect specific CORS headers
-    const corsHeaderNames = [
-      'access-control-allow-origin',
-      'access-control-allow-methods',
-      'access-control-allow-headers',
-      'access-control-allow-credentials',
-      'access-control-max-age',
-      'access-control-expose-headers'
-    ];
-    
-    corsHeaderNames.forEach(headerName => {
-      const value = corsResponse.headers.get(headerName);
-      if (value) {
-        corsHeaders[headerName] = value;
-      }
-    });
-
-    const allowOrigin = corsResponse.headers.get('access-control-allow-origin');
-    const allowMethods = corsResponse.headers.get('access-control-allow-methods');
-    const allowHeaders = corsResponse.headers.get('access-control-allow-headers');
-
-    if (allowOrigin && (allowOrigin === '*' || allowOrigin === siteUrl)) {
-      corsSection.score += 5;
-      corsSection.details.push({
-        text: '✓ CORS origin properly configured',
-        context: `Server allows cross-origin requests from ${allowOrigin}. This enables browser-based MCP clients to connect.`,
-        metadata: {
-          'Access-Control-Allow-Origin': allowOrigin,
-          testedOrigin: siteUrl,
-          responseStatus: corsResponse.status,
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders
-        }
-      });
-    } else {
-      corsSection.details.push({
-        text: '✗ CORS origin not properly configured',
-        context: 'Browser clients cannot connect without proper CORS headers. Add Access-Control-Allow-Origin header to enable web access.',
-        metadata: {
-          'Access-Control-Allow-Origin': allowOrigin || 'not present',
-          testedOrigin: siteUrl,
-          responseStatus: corsResponse.status,
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders,
-          hint: `Expected origin to be '*' or '${siteUrl}'`
-        }
-      });
-    }
-
-    if (allowMethods?.includes('POST')) {
-      corsSection.score += 5;
-      corsSection.details.push({
-        text: '✓ CORS methods properly configured',
-        context: 'Server allows required HTTP methods (POST) for MCP operations from browser clients.',
-        metadata: {
-          'Access-Control-Allow-Methods': allowMethods,
-          requiredMethods: ['POST', 'OPTIONS'],
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders
-        }
-      });
-    } else {
-      corsSection.details.push({
-        text: '✗ CORS methods not properly configured',
-        context: 'POST method must be allowed for MCP requests. Add POST to Access-Control-Allow-Methods header.',
-        metadata: {
-          'Access-Control-Allow-Methods': allowMethods || 'not present',
-          requiredMethods: ['POST', 'OPTIONS'],
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders,
-          hint: 'Ensure the header includes at least: POST, OPTIONS'
-        }
-      });
-    }
-
-    if (allowHeaders?.toLowerCase().includes('authorization')) {
-      corsSection.score += 5;
-      corsSection.details.push({
-        text: '✓ CORS headers properly configured',
-        context: 'Authorization header is allowed, enabling secure API token transmission from browser clients.',
-        metadata: {
-          'Access-Control-Allow-Headers': allowHeaders,
-          requiredHeaders: ['content-type', 'authorization'],
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders
-        }
-      });
-    } else {
-      corsSection.details.push({
-        text: '✗ CORS headers not properly configured',
-        context: 'Authorization header must be allowed for API authentication. Add to Access-Control-Allow-Headers.',
-        metadata: {
-          'Access-Control-Allow-Headers': allowHeaders || 'not present',
-          requiredHeaders: ['content-type', 'authorization'],
-          allCorsHeaders: corsHeaders,
-          allResponseHeaders: allResponseHeaders,
-          hint: 'Ensure the header includes at least: content-type, authorization'
-        }
-      });
-    }
-  } catch (error: any) {
-    corsSection.details.push({
-      text: `✗ CORS check failed: ${error.message || error}`,
-      context: 'Unable to validate CORS configuration. This typically indicates the server does not handle OPTIONS preflight requests.',
-      metadata: {
-        error: 'cors_check_failed',
-        errorMessage: error.message,
-        endpoint: `${serverUrl}/mcp/v1/initialize`,
-        method: 'OPTIONS',
-        testedOrigin: window.location.origin,
-        hint: 'Ensure your server responds to OPTIONS preflight requests with appropriate CORS headers'
-      }
-    });
+    return section;
   }
 
-  report.sections.cors = corsSection;
-  report.finalScore += corsSection.score;
+  section.details.push(
+    {
+      text: '✓ Direct browser MCP negotiation succeeded',
+      context: 'The browser enforced CORS while the official SDK completed protocol negotiation without the proxy.',
+      metadata: { endpoint: endpointUrl, origin: window.location.origin },
+    },
+    {
+      text: `✓ ${connection.protocolEra === 'modern' ? 'Stateless' : 'Stateful'} MCP request headers passed browser enforcement`,
+      metadata: { requiredHeaders },
+    },
+    {
+      text: '✓ MCP responses were readable and passed SDK schema validation',
+      metadata: { transportType: connection.transportType },
+    }
+  );
 
-  // 5. Performance Baseline (15 points)
-  onProgress('Checking Performance Baseline...');
-  const performanceSection: EvaluationSection = {
+  return section;
+};
+
+const performanceSection = (durationMs: number): EvaluationSection => {
+  let score = 4;
+  let category = 'slow';
+  if (durationMs < 500) {
+    score = 15;
+    category = 'excellent';
+  } else if (durationMs < 1_000) {
+    score = 12;
+    category = 'good';
+  } else if (durationMs < 2_500) {
+    score = 8;
+    category = 'fair';
+  }
+
+  return {
     name: 'Performance Baseline',
-    description: 'Measures server response time and latency',
-    score: 0,
+    description: 'Measures end-to-end endpoint selection and protocol negotiation',
+    score,
     maxScore: 15,
-    details: []
+    details: [{
+      text: `${score >= 12 ? '✓' : score >= 8 ? '⚠' : '✗'} ${category} negotiation time: ${durationMs}ms`,
+      metadata: { durationMs, category, measurement: 'Endpoint selection, MCP connect, and era negotiation' },
+    }],
+  };
+};
+
+export async function evaluateServer(
+  inputUrl: string,
+  firebaseToken: string,
+  onProgress: (message: string) => void,
+  oauthAccessToken?: string | null
+): Promise<EvaluationReport> {
+  const serverUrl = normalizeServerUrl(inputUrl);
+  const oauthToken = oauthAccessToken || null;
+  const report: EvaluationReport = { serverUrl, finalScore: 0, sections: {} };
+  let connection: ConnectedEvaluation | null = null;
+  const connectionStartedAt = Date.now();
+
+  onProgress('Establishing MCP connection with automatic 2026/2025 negotiation...');
+  try {
+    connection = await connectForEvaluation(
+      serverUrl,
+      firebaseToken,
+      oauthToken,
+      onProgress
+    );
+  } catch (error) {
+    const message = errorMessage(error);
+    report.sections.protocol = makeSkippedSection(
+      'Core Protocol Adherence',
+      'Validates MCP lifecycle and JSON-RPC negotiation',
+      15,
+      `MCP negotiation failed: ${message}`
+    );
+    report.sections.capabilities = makeSkippedSection(
+      'MCP Capabilities',
+      'Exercises standardized tools, resources, and prompts discovery methods',
+      10,
+      'Capability checks were skipped because no MCP connection was established.'
+    );
+    report.sections.transport = makeSkippedSection(
+      'Transport Layer Modernity',
+      'Identifies Streamable HTTP or deprecated HTTP+SSE',
+      15,
+      'No standard MCP transport completed negotiation.'
+    );
+    report.sections.cors = makeSkippedSection(
+      'Web Client Accessibility',
+      'Validates direct-browser MCP access at the negotiated endpoint',
+      15,
+      'Browser accessibility could not be isolated because neither direct nor proxied MCP negotiation succeeded.'
+    );
+    report.sections.performance = makeSkippedSection(
+      'Performance Baseline',
+      'Measures end-to-end endpoint selection and protocol negotiation',
+      15,
+      'Performance was not scored because negotiation failed.'
+    );
+    if (/\b(?:401|403|unauthori[sz]ed|forbidden|authentication)\b/i.test(message)) {
+      report.sections.auth = {
+        name: 'Authentication Required',
+        description: 'The MCP endpoint rejected unauthenticated negotiation',
+        score: 0,
+        maxScore: 1,
+        details: [{
+          text: '⚠ Authenticate with the server and run the report again.',
+          context: message,
+        }],
+      };
+    }
+    report.finalScore = report.sections.cors.score;
+    onProgress('Evaluation finished without an MCP connection.');
+    return report;
+  }
+
+  const durationMs = Date.now() - connectionStartedAt;
+  const protocolLabel = connection.protocolEra === 'modern'
+    ? 'stateless server/discover lifecycle'
+    : 'stateful initialize lifecycle';
+  report.sections.protocol = {
+    name: 'Core Protocol Adherence',
+    description: 'Validates MCP lifecycle and JSON-RPC negotiation',
+    score: 15,
+    maxScore: 15,
+    details: [
+      {
+        text: `✓ Negotiated the ${protocolLabel}`,
+        context: connection.protocolEra === 'modern'
+          ? 'The server accepted MCP 2026 self-describing requests without a transport session.'
+          : 'The server completed the 2025-compatible initialize and initialized exchange.',
+        metadata: {
+          protocolEra: connection.protocolEra,
+          protocolVersion: connection.protocolVersion,
+          endpoint: getEvaluationTargetUrl(connection.url),
+          route: connection.usedProxy ? 'authenticated proxy' : 'direct',
+        },
+      },
+      {
+        text: '✓ JSON-RPC messages passed official SDK validation',
+        context: 'Successful SDK negotiation verifies the JSON-RPC envelope and lifecycle response schemas.',
+      },
+    ],
+  };
+  onProgress(`Negotiated ${connection.protocolEra} MCP${connection.protocolVersion ? ` ${connection.protocolVersion}` : ''}.`);
+
+  onProgress('Exercising tools, resources, and prompts discovery...');
+  report.sections.capabilities = await evaluateCapabilities(connection.client);
+
+  const modernTransport = connection.transportType === 'streamable-http';
+  report.sections.transport = {
+    name: 'Transport Layer Modernity',
+    description: 'Identifies Streamable HTTP or deprecated HTTP+SSE',
+    score: modernTransport ? 15 : 6,
+    maxScore: 15,
+    details: [{
+      text: modernTransport
+        ? '✓ Streamable HTTP negotiated successfully'
+        : '⚠ Deprecated HTTP+SSE negotiated successfully',
+      context: modernTransport
+        ? 'Streamable HTTP uses POST with JSON or per-request SSE responses and supports both MCP lifecycle eras.'
+        : 'The two-endpoint HTTP+SSE transport remains compatible but is deprecated in MCP 2026.',
+      metadata: {
+        transportType: connection.transportType,
+        endpoint: getEvaluationTargetUrl(connection.url),
+        protocolEra: connection.protocolEra,
+      },
+    }],
   };
 
+  onProgress('Confirming direct-browser MCP accessibility at the negotiated endpoint...');
+  report.sections.cors = evaluateBrowserAccessibility(connection, Boolean(oauthToken));
+
+  report.sections.performance = performanceSection(durationMs);
+  report.finalScore = Object.entries(report.sections)
+    .filter(([key]) => key !== 'auth')
+    .reduce((total, [, section]) => total + section.score, 0);
+
   try {
-    const startTime = Date.now();
-    const perfResponse = await fetchForEvaluation(`${serverUrl}/mcp/v1/initialize`, token, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        protocolVersion: '2024-11-05',
-        capabilities: {}
-      })
-    }, accessToken);
-    const responseTime = Date.now() - startTime;
-
-    if (responseTime < 200) {
-      performanceSection.score = 15;
-      performanceSection.details.push({
-        text: `✓ Excellent response time: ${responseTime}ms`,
-        context: 'Sub-200ms response time ensures smooth real-time interactions for MCP clients.',
-        metadata: {
-          responseTime: `${responseTime}ms`,
-          endpoint: `${serverUrl}/mcp/v1/initialize`,
-          performanceCategory: 'excellent',
-          threshold: '<200ms'
-        }
-      });
-    } else if (responseTime < 500) {
-      performanceSection.score = 12;
-      performanceSection.details.push({
-        text: `✓ Good response time: ${responseTime}ms`,
-        context: 'Response time under 500ms provides acceptable user experience for most MCP operations.',
-        metadata: {
-          responseTime: `${responseTime}ms`,
-          endpoint: `${serverUrl}/mcp/v1/initialize`,
-          performanceCategory: 'good',
-          threshold: '200-500ms'
-        }
-      });
-    } else if (responseTime < 1000) {
-      performanceSection.score = 8;
-      performanceSection.details.push({
-        text: `⚠ Fair response time: ${responseTime}ms`,
-        context: 'Response time between 500ms-1s may cause noticeable delays in interactive MCP sessions.',
-        metadata: {
-          responseTime: `${responseTime}ms`,
-          endpoint: `${serverUrl}/mcp/v1/initialize`,
-          performanceCategory: 'fair',
-          threshold: '500-1000ms'
-        }
-      });
-    } else {
-      performanceSection.score = 4;
-      performanceSection.details.push({
-        text: `✗ Poor response time: ${responseTime}ms`,
-        context: 'Response time over 1s significantly impacts user experience. Consider optimizing server performance or infrastructure.',
-        metadata: {
-          responseTime: `${responseTime}ms`,
-          endpoint: `${serverUrl}/mcp/v1/initialize`,
-          performanceCategory: 'poor',
-          threshold: '>1000ms'
-        }
-      });
-    }
-  } catch (error: any) {
-    performanceSection.details.push({
-      text: `✗ Performance check failed: ${error.message || error}`,
-      context: 'Unable to measure server response time. This may indicate connectivity issues or server unavailability.',
-      metadata: {
-        error: 'performance_check_failed',
-        errorMessage: error.message,
-        endpoint: `${serverUrl}/mcp/v1/initialize`
-      }
-    });
+    await connection.client.close();
+  } catch (error) {
+    console.error('[Evaluation] Failed to close MCP client:', error);
   }
 
-  report.sections.performance = performanceSection;
-  report.finalScore += performanceSection.score;
-  
-  // Calculate maximum possible score
-  // Protocol (15) + Capabilities (10) + Transport (15) + Security (40) + CORS (15) + Performance (15) = 110 with OAuth
-  // Protocol (15) + Capabilities (10) + Transport (15) + CORS (15) + Performance (15) = 70 without OAuth
-  const maxPossibleScore = oauthSupported ? 110 : 70;
-  
-  // Clean up MCP client if we created one
-  if (mcpClient) {
-    try {
-      await mcpClient.close();
-    } catch (e) {
-      console.error('Error closing MCP client:', e);
-    }
-  }
-  
   onProgress('Evaluation complete.');
   return report;
 }

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -1,7 +1,15 @@
-import type { Client, ProtocolEra } from '@modelcontextprotocol/client';
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  type Client,
+  type FetchLike,
+  type OAuthProtectedResourceMetadata,
+  type ProtocolEra,
+} from '@modelcontextprotocol/client';
 import {
   ProxiedAuthenticationError,
   attemptParallelConnections,
+  type ObservedAuthenticationChallenge,
   type ProxyAuthenticationSource,
 } from './transportDetection';
 import type { TransportType } from '../types';
@@ -262,6 +270,7 @@ interface ConnectedEvaluation {
   protocolVersion?: string;
   usedProxy: boolean;
   directError?: string;
+  takeAuthenticationChallenge?: () => ObservedAuthenticationChallenge | undefined;
 }
 
 interface EvaluationRouteFailure {
@@ -274,10 +283,11 @@ interface EvaluationRouteFailure {
 
 const makeRouteFailure = (
   route: EvaluationRouteFailure['route'],
-  error: unknown
+  error: unknown,
+  observedChallenge?: ObservedAuthenticationChallenge
 ): EvaluationRouteFailure => {
   const proxyAuthChallenge = route === 'proxy'
-    ? getProxyAuthenticationChallenge(error)
+    ? observedChallenge || getProxyAuthenticationChallenge(error)
     : undefined;
   const httpStatus = proxyAuthChallenge?.status || getAuthenticationHttpStatus(error);
   return {
@@ -347,7 +357,14 @@ const connectForEvaluation = async (
   }
 };
 
-const evaluateCapabilities = async (client: Client): Promise<EvaluationSection> => {
+interface CapabilityEvaluation {
+  section: EvaluationSection;
+  targetAuthenticationFailures: Array<EvaluationRouteFailure & { method: string }>;
+}
+
+const evaluateCapabilities = async (
+  connection: ConnectedEvaluation
+): Promise<CapabilityEvaluation> => {
   const section: EvaluationSection = {
     name: 'MCP Capabilities',
     description: 'Exercises standardized tools, resources, and prompts discovery methods',
@@ -355,6 +372,7 @@ const evaluateCapabilities = async (client: Client): Promise<EvaluationSection> 
     maxScore: 10,
     details: [],
   };
+  const targetAuthenticationFailures: CapabilityEvaluation['targetAuthenticationFailures'] = [];
   const checks: Array<{
     name: string;
     method: string;
@@ -366,26 +384,28 @@ const evaluateCapabilities = async (client: Client): Promise<EvaluationSection> 
       name: 'tools',
       method: 'tools/list',
       points: 4,
-      run: () => client.listTools(),
+      run: () => connection.client.listTools(),
       count: (result) => Array.isArray(result?.tools) ? result.tools.length : 0,
     },
     {
       name: 'resources',
       method: 'resources/list',
       points: 3,
-      run: () => client.listResources(),
+      run: () => connection.client.listResources(),
       count: (result) => Array.isArray(result?.resources) ? result.resources.length : 0,
     },
     {
       name: 'prompts',
       method: 'prompts/list',
       points: 3,
-      run: () => client.listPrompts(),
+      run: () => connection.client.listPrompts(),
       count: (result) => Array.isArray(result?.prompts) ? result.prompts.length : 0,
     },
   ];
 
   for (const check of checks) {
+    // Discard any challenge already handled while negotiating the connection.
+    connection.takeAuthenticationChallenge?.();
     try {
       const startedAt = Date.now();
       const result = await check.run();
@@ -397,15 +417,177 @@ const evaluateCapabilities = async (client: Client): Promise<EvaluationSection> 
         context: `The server implements the standard ${check.name} discovery method, including valid empty lists.`,
         metadata: { method: check.method, itemCount, durationMs },
       });
+      connection.takeAuthenticationChallenge?.();
     } catch (error) {
+      const failure = makeRouteFailure(
+        connection.usedProxy ? 'proxy' : 'direct',
+        error,
+        connection.takeAuthenticationChallenge?.()
+      );
+      if (
+        (failure.httpStatus === 401 || failure.httpStatus === 403)
+        && failure.authenticationSource === 'target'
+      ) {
+        targetAuthenticationFailures.push({ ...failure, method: check.method });
+      }
+      const methodNotFound = isMethodNotFound(error);
       section.details.push({
-        text: `${isMethodNotFound(error) ? '⚠' : '✗'} ${check.method} ${isMethodNotFound(error) ? 'is not supported' : 'failed'}`,
-        context: isMethodNotFound(error)
+        text: `${methodNotFound ? '⚠' : '✗'} ${check.method} ${methodNotFound ? 'is not supported' : 'failed'}`,
+        context: methodNotFound
           ? `${check.name} are optional; the server correctly returned method-not-found.`
-          : errorMessage(error),
-        metadata: { method: check.method, error: errorMessage(error) },
+          : failure.message,
+        metadata: {
+          method: check.method,
+          error: failure.message,
+          ...(failure.httpStatus ? { status: failure.httpStatus } : {}),
+          ...(failure.authenticationSource
+            ? { authenticationSource: failure.authenticationSource, route: failure.route }
+            : {}),
+        },
       });
     }
+  }
+
+  return { section, targetAuthenticationFailures };
+};
+
+type AuthorizationServerMetadata = NonNullable<
+  Awaited<ReturnType<typeof discoverAuthorizationServerMetadata>>
+>;
+
+const metadataFetchForEvaluation = (firebaseToken: string): FetchLike => (
+  input,
+  init
+) => {
+  const request = input instanceof Request ? input : new Request(input, init);
+  return fetchForEvaluation(request.url, firebaseToken, {
+    method: request.method,
+    headers: request.headers,
+    signal: request.signal,
+  });
+};
+
+const evaluateSecurityPosture = async (
+  connection: ConnectedEvaluation,
+  firebaseToken: string
+): Promise<EvaluationSection | undefined> => {
+  const endpoint = getEvaluationTargetUrl(connection.url, connection.usedProxy);
+  const metadataFetch = metadataFetchForEvaluation(firebaseToken);
+  let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
+
+  try {
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+      endpoint,
+      { protocolVersion: connection.protocolVersion },
+      metadataFetch
+    );
+  } catch {
+    // Protected-resource metadata is optional for older OAuth-enabled servers.
+  }
+
+  const endpointUrl = new URL(endpoint);
+  const authorizationServers = resourceMetadata?.authorization_servers?.length
+    ? resourceMetadata.authorization_servers
+    : [endpointUrl.origin];
+  let authorizationServer: string | undefined;
+  let authorizationMetadata: AuthorizationServerMetadata | undefined;
+
+  for (const candidate of authorizationServers) {
+    try {
+      const metadata = await discoverAuthorizationServerMetadata(candidate, {
+        fetchFn: metadataFetch,
+        protocolVersion: connection.protocolVersion,
+      });
+      if (metadata) {
+        authorizationServer = candidate;
+        authorizationMetadata = metadata;
+        break;
+      }
+    } catch {
+      // Continue when one advertised authorization server has unavailable metadata.
+    }
+  }
+
+  if (!resourceMetadata && !authorizationMetadata) return undefined;
+
+  const section: EvaluationSection = {
+    name: 'Security Posture',
+    description: 'Evaluates OAuth protected-resource and authorization-server metadata',
+    score: 0,
+    maxScore: 40,
+    details: [],
+  };
+
+  if (resourceMetadata) {
+    section.details.push({
+      text: '✓ OAuth protected-resource metadata available',
+      context: 'The MCP endpoint publishes standardized metadata identifying its authorization servers and protected resource.',
+      metadata: {
+        endpoint,
+        resource: resourceMetadata.resource,
+        authorizationServers: resourceMetadata.authorization_servers || [],
+        scopesSupported: resourceMetadata.scopes_supported || [],
+      },
+    });
+  } else {
+    section.details.push({
+      text: '⚠ OAuth protected-resource metadata not available',
+      context: 'Authorization-server metadata was discovered through the legacy origin fallback.',
+      metadata: { endpoint },
+    });
+  }
+
+  if (authorizationMetadata) {
+    section.score += 20;
+    section.details.push({
+      text: '✓ OAuth authorization-server metadata available',
+      context: 'Standard metadata allows clients to configure authorization endpoints without hard-coded assumptions.',
+      metadata: {
+        authorizationServer,
+        issuer: authorizationMetadata.issuer,
+        authorizationEndpoint: authorizationMetadata.authorization_endpoint,
+      },
+    });
+  } else {
+    section.details.push({
+      text: '✗ Authorization-server metadata not available',
+      context: 'The protected resource advertises OAuth, but none of its authorization servers returned valid standardized metadata.',
+      metadata: { authorizationServers },
+    });
+  }
+
+  if (authorizationMetadata?.token_endpoint) {
+    section.score += 10;
+    section.details.push({
+      text: '✓ Token endpoint properly configured',
+      context: 'A published token endpoint enables the secure exchange of authorization grants for access tokens.',
+      metadata: {
+        tokenEndpoint: authorizationMetadata.token_endpoint,
+        supportedGrantTypes: authorizationMetadata.grant_types_supported || [],
+      },
+    });
+  } else {
+    section.details.push({
+      text: '✗ Token endpoint not configured',
+      context: 'The authorization-server metadata does not publish a token endpoint.',
+    });
+  }
+
+  if (authorizationMetadata?.code_challenge_methods_supported?.includes('S256')) {
+    section.score += 10;
+    section.details.push({
+      text: '✓ PKCE support enabled',
+      context: 'S256 PKCE protects authorization codes used by public clients.',
+      metadata: {
+        supportedMethods: authorizationMetadata.code_challenge_methods_supported,
+        requiredMethod: 'S256',
+      },
+    });
+  } else {
+    section.details.push({
+      text: '✗ PKCE S256 support not advertised',
+      context: 'OAuth public clients require S256 PKCE support for authorization-code protection.',
+    });
   }
 
   return section;
@@ -589,7 +771,26 @@ export async function evaluateServer(
   onProgress(`Negotiated ${connection.protocolEra} MCP${connection.protocolVersion ? ` ${connection.protocolVersion}` : ''}.`);
 
   onProgress('Exercising tools, resources, and prompts discovery...');
-  report.sections.capabilities = await evaluateCapabilities(connection.client);
+  const capabilityEvaluation = await evaluateCapabilities(connection);
+  report.sections.capabilities = capabilityEvaluation.section;
+  if (capabilityEvaluation.targetAuthenticationFailures.length > 0) {
+    report.sections.auth = {
+      name: 'Authentication Required',
+      description: 'The MCP endpoint rejected standardized capability requests',
+      score: 0,
+      maxScore: 1,
+      details: capabilityEvaluation.targetAuthenticationFailures.map((failure) => ({
+        text: `⚠ Authenticate with the server and retry ${failure.method}.`,
+        context: failure.message,
+        metadata: {
+          method: failure.method,
+          route: failure.route,
+          status: failure.httpStatus,
+          authenticationSource: failure.authenticationSource,
+        },
+      })),
+    };
+  }
 
   const modernTransport = connection.transportType === 'streamable-http';
   report.sections.transport = {
@@ -611,6 +812,14 @@ export async function evaluateServer(
       },
     }],
   };
+
+  onProgress('Checking OAuth security metadata...');
+  const securitySection = await evaluateSecurityPosture(connection, firebaseToken);
+  if (securitySection) {
+    report.sections.security = securitySection;
+  } else {
+    onProgress('OAuth security metadata is unavailable; excluding it from scoring.');
+  }
 
   onProgress('Confirming direct-browser MCP accessibility at the negotiated endpoint...');
   report.sections.cors = evaluateBrowserAccessibility(connection, Boolean(oauthToken));

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -1,5 +1,9 @@
 import type { Client, ProtocolEra } from '@modelcontextprotocol/client';
-import { attemptParallelConnections } from './transportDetection';
+import {
+  ProxiedAuthenticationError,
+  attemptParallelConnections,
+  type ProxyAuthenticationSource,
+} from './transportDetection';
 import type { TransportType } from '../types';
 
 const getProxyUrl = (): string | undefined => import.meta.env.VITE_PROXY_URL;
@@ -201,6 +205,37 @@ const getAuthenticationHttpStatus = (
   return getAuthenticationHttpStatus(value.cause, seen);
 };
 
+interface ProxyAuthenticationChallenge {
+  status: 401 | 403;
+  source: ProxyAuthenticationSource;
+}
+
+const getProxyAuthenticationChallenge = (
+  error: unknown,
+  seen = new Set<object>()
+): ProxyAuthenticationChallenge | undefined => {
+  if (!error || typeof error !== 'object' || seen.has(error)) return undefined;
+  seen.add(error);
+
+  if (error instanceof ProxiedAuthenticationError) {
+    return { status: error.status, source: error.responseSource };
+  }
+
+  const value = error as { cause?: unknown; errors?: readonly unknown[] };
+  let proxyChallenge: ProxyAuthenticationChallenge | undefined;
+  if (Array.isArray(value.errors)) {
+    for (const nestedError of value.errors) {
+      const nestedChallenge = getProxyAuthenticationChallenge(nestedError, seen);
+      if (nestedChallenge?.source === 'target') return nestedChallenge;
+      if (nestedChallenge?.source === 'proxy') proxyChallenge = nestedChallenge;
+    }
+  }
+
+  const causeChallenge = getProxyAuthenticationChallenge(value.cause, seen);
+  if (causeChallenge?.source === 'target') return causeChallenge;
+  return causeChallenge || proxyChallenge;
+};
+
 const isMethodNotFound = (error: unknown): boolean => {
   const value = error as { code?: number; message?: string };
   return value?.code === -32601 || /method not found/i.test(value?.message || '');
@@ -234,17 +269,27 @@ interface EvaluationRouteFailure {
   error: unknown;
   message: string;
   httpStatus?: number;
+  authenticationSource?: ProxyAuthenticationSource;
 }
 
 const makeRouteFailure = (
   route: EvaluationRouteFailure['route'],
   error: unknown
-): EvaluationRouteFailure => ({
-  route,
-  error,
-  message: errorMessage(error),
-  httpStatus: getAuthenticationHttpStatus(error),
-});
+): EvaluationRouteFailure => {
+  const proxyAuthChallenge = route === 'proxy'
+    ? getProxyAuthenticationChallenge(error)
+    : undefined;
+  const httpStatus = proxyAuthChallenge?.status || getAuthenticationHttpStatus(error);
+  return {
+    route,
+    error,
+    message: errorMessage(error),
+    httpStatus,
+    authenticationSource: route === 'direct' && httpStatus
+      ? 'target'
+      : proxyAuthChallenge?.source,
+  };
+};
 
 class EvaluationConnectionError extends Error {
   constructor(readonly failures: readonly EvaluationRouteFailure[]) {
@@ -459,8 +504,8 @@ export async function evaluateServer(
     const message = errorMessage(error);
     const failures = error instanceof EvaluationConnectionError ? error.failures : [];
     const targetAuthFailure = failures.find((failure) => (
-      failure.route === 'direct'
-      && (failure.httpStatus === 401 || failure.httpStatus === 403)
+      (failure.httpStatus === 401 || failure.httpStatus === 403)
+      && failure.authenticationSource === 'target'
     ));
     report.sections.protocol = makeSkippedSection(
       'Core Protocol Adherence',
@@ -502,7 +547,7 @@ export async function evaluateServer(
           text: '⚠ Authenticate with the server and run the report again.',
           context: targetAuthFailure.message,
           metadata: {
-            route: 'direct',
+            route: targetAuthFailure.route,
             status: targetAuthFailure.httpStatus,
           },
         }],

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -18,9 +18,17 @@ const normalizeServerUrl = (value: string): string => {
   return new URL(withProtocol).toString();
 };
 
-export const getEvaluationTargetUrl = (connectionUrl: string): string => {
+export const getEvaluationTargetUrl = (
+  connectionUrl: string,
+  usesProxy = false
+): string => {
   const outerUrl = new URL(connectionUrl);
-  return outerUrl.searchParams.get('target') || outerUrl.toString();
+  const proxyUrl = getProxyUrl();
+  if (!usesProxy || !proxyUrl || !isConfiguredProxyTarget(connectionUrl, proxyUrl)) {
+    return outerUrl.toString();
+  }
+
+  return new URL(outerUrl.searchParams.get('target') as string).toString();
 };
 
 /**
@@ -30,13 +38,15 @@ export const getEvaluationTargetUrl = (connectionUrl: string): string => {
  */
 export function getEvaluationTransportProbeUrl(
   connectionUrl: string,
-  targetTransport: 'mcp' | 'sse'
+  targetTransport: 'mcp' | 'sse',
+  usesProxy = false
 ): string {
   const outerUrl = new URL(connectionUrl);
   const proxyUrl = getProxyUrl();
   const proxyTarget = outerUrl.searchParams.get('target');
   const isProxied = Boolean(
-    proxyUrl
+    usesProxy
+    && proxyUrl
     && proxyTarget
     && isConfiguredProxyTarget(connectionUrl, proxyUrl)
   );
@@ -104,10 +114,11 @@ export async function fetchForEvaluation(
   url: string,
   firebaseToken: string,
   options: RequestInit = {},
-  oauthToken?: string | null
+  oauthToken?: string | null,
+  usesProxy = false
 ): Promise<Response> {
   const proxyUrl = getProxyUrl();
-  if (proxyUrl && isConfiguredProxyTarget(url, proxyUrl)) {
+  if (usesProxy && proxyUrl && isConfiguredProxyTarget(url, proxyUrl)) {
     return fetch(url, {
       ...options,
       headers: getEvaluationProxyHeaders(options.headers, firebaseToken, oauthToken),
@@ -154,6 +165,42 @@ const errorMessage = (error: unknown): string => (
   error instanceof Error ? error.message : String(error)
 );
 
+const getAuthenticationHttpStatus = (
+  error: unknown,
+  seen = new Set<object>()
+): 401 | 403 | undefined => {
+  if (!error || typeof error !== 'object' || seen.has(error)) return undefined;
+  seen.add(error);
+
+  const value = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    data?: { status?: unknown };
+    response?: { status?: unknown };
+    cause?: unknown;
+    errors?: readonly unknown[];
+  };
+  const directStatuses = [
+    value.status,
+    value.statusCode,
+    value.code,
+    value.data?.status,
+    value.response?.status,
+  ];
+  const directStatus = directStatuses.find((status) => status === 401 || status === 403);
+  if (directStatus === 401 || directStatus === 403) return directStatus;
+
+  if (Array.isArray(value.errors)) {
+    for (const nestedError of value.errors) {
+      const nestedStatus = getAuthenticationHttpStatus(nestedError, seen);
+      if (nestedStatus !== undefined) return nestedStatus;
+    }
+  }
+
+  return getAuthenticationHttpStatus(value.cause, seen);
+};
+
 const isMethodNotFound = (error: unknown): boolean => {
   const value = error as { code?: number; message?: string };
   return value?.code === -32601 || /method not found/i.test(value?.message || '');
@@ -182,6 +229,32 @@ interface ConnectedEvaluation {
   directError?: string;
 }
 
+interface EvaluationRouteFailure {
+  route: 'direct' | 'proxy';
+  error: unknown;
+  message: string;
+  httpStatus?: number;
+}
+
+const makeRouteFailure = (
+  route: EvaluationRouteFailure['route'],
+  error: unknown
+): EvaluationRouteFailure => ({
+  route,
+  error,
+  message: errorMessage(error),
+  httpStatus: getAuthenticationHttpStatus(error),
+});
+
+class EvaluationConnectionError extends Error {
+  constructor(readonly failures: readonly EvaluationRouteFailure[]) {
+    super(failures.map((failure) => (
+      `${failure.route === 'direct' ? 'Direct target' : 'Authenticated proxy'}: ${failure.message}`
+    )).join('; '));
+    this.name = 'EvaluationConnectionError';
+  }
+}
+
 const connectForEvaluation = async (
   serverUrl: string,
   firebaseToken: string,
@@ -195,26 +268,37 @@ const connectForEvaluation = async (
     const direct = await attemptParallelConnections(
       serverUrl,
       abortController.signal,
-      oauthToken || undefined
+      oauthToken || undefined,
+      undefined,
+      false
     );
     return { ...direct, usedProxy: false };
   } catch (directError) {
+    const directFailure = makeRouteFailure('direct', directError);
     const proxyUrl = getProxyUrl();
-    if (!proxyUrl) throw directError;
+    if (!proxyUrl) throw new EvaluationConnectionError([directFailure]);
 
-    onProgress('Direct negotiation failed; retrying through the authenticated CORS proxy...');
-    const proxyConnectionUrl = new URL(proxyUrl);
-    proxyConnectionUrl.searchParams.set('target', serverUrl);
-    const targetHeaders = oauthToken
-      ? { Authorization: `Bearer ${oauthToken}` }
-      : undefined;
-    const proxied = await attemptParallelConnections(
-      proxyConnectionUrl.toString(),
-      abortController.signal,
-      firebaseToken,
-      targetHeaders
-    );
-    return { ...proxied, usedProxy: true, directError: errorMessage(directError) };
+    try {
+      onProgress('Direct negotiation failed; retrying through the authenticated CORS proxy...');
+      const proxyConnectionUrl = new URL(proxyUrl);
+      proxyConnectionUrl.searchParams.set('target', serverUrl);
+      const targetHeaders = oauthToken
+        ? { Authorization: `Bearer ${oauthToken}` }
+        : undefined;
+      const proxied = await attemptParallelConnections(
+        proxyConnectionUrl.toString(),
+        abortController.signal,
+        firebaseToken,
+        targetHeaders,
+        true
+      );
+      return { ...proxied, usedProxy: true, directError: directFailure.message };
+    } catch (proxyError) {
+      throw new EvaluationConnectionError([
+        directFailure,
+        makeRouteFailure('proxy', proxyError),
+      ]);
+    }
   }
 };
 
@@ -286,7 +370,7 @@ const evaluateBrowserAccessibility = (
   connection: ConnectedEvaluation,
   authenticated: boolean
 ): EvaluationSection => {
-  const endpointUrl = getEvaluationTargetUrl(connection.url);
+  const endpointUrl = getEvaluationTargetUrl(connection.url, connection.usedProxy);
   const requiredHeaders = getEvaluationCorsHeaders(connection.protocolEra, authenticated);
   const section: EvaluationSection = {
     name: 'Web Client Accessibility',
@@ -373,6 +457,11 @@ export async function evaluateServer(
     );
   } catch (error) {
     const message = errorMessage(error);
+    const failures = error instanceof EvaluationConnectionError ? error.failures : [];
+    const targetAuthFailure = failures.find((failure) => (
+      failure.route === 'direct'
+      && (failure.httpStatus === 401 || failure.httpStatus === 403)
+    ));
     report.sections.protocol = makeSkippedSection(
       'Core Protocol Adherence',
       'Validates MCP lifecycle and JSON-RPC negotiation',
@@ -403,7 +492,7 @@ export async function evaluateServer(
       15,
       'Performance was not scored because negotiation failed.'
     );
-    if (/\b(?:401|403|unauthori[sz]ed|forbidden|authentication)\b/i.test(message)) {
+    if (targetAuthFailure) {
       report.sections.auth = {
         name: 'Authentication Required',
         description: 'The MCP endpoint rejected unauthenticated negotiation',
@@ -411,7 +500,11 @@ export async function evaluateServer(
         maxScore: 1,
         details: [{
           text: '⚠ Authenticate with the server and run the report again.',
-          context: message,
+          context: targetAuthFailure.message,
+          metadata: {
+            route: 'direct',
+            status: targetAuthFailure.httpStatus,
+          },
         }],
       };
     }
@@ -438,7 +531,7 @@ export async function evaluateServer(
         metadata: {
           protocolEra: connection.protocolEra,
           protocolVersion: connection.protocolVersion,
-          endpoint: getEvaluationTargetUrl(connection.url),
+          endpoint: getEvaluationTargetUrl(connection.url, connection.usedProxy),
           route: connection.usedProxy ? 'authenticated proxy' : 'direct',
         },
       },
@@ -468,7 +561,7 @@ export async function evaluateServer(
         : 'The two-endpoint HTTP+SSE transport remains compatible but is deprecated in MCP 2026.',
       metadata: {
         transportType: connection.transportType,
-        endpoint: getEvaluationTargetUrl(connection.url),
+        endpoint: getEvaluationTargetUrl(connection.url, connection.usedProxy),
         protocolEra: connection.protocolEra,
       },
     }],

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -189,7 +189,6 @@ const getAuthenticationHttpStatus = (
   const value = error as {
     status?: unknown;
     statusCode?: unknown;
-    data?: { status?: unknown };
     response?: { status?: unknown };
     cause?: unknown;
     errors?: readonly unknown[];
@@ -197,7 +196,6 @@ const getAuthenticationHttpStatus = (
   const directStatuses = [
     value.status,
     value.statusCode,
-    value.data?.status,
     value.response?.status,
   ];
   const directStatus = directStatuses.find((status) => status === 401 || status === 403);

--- a/src/utils/savedCardConnection.test.ts
+++ b/src/utils/savedCardConnection.test.ts
@@ -70,10 +70,24 @@ describe('saved dashboard card connections', () => {
     );
   });
 
-  it('surfaces a migration error when legacy resource parameters have no URI template', () => {
-    expect(() => getSavedResourceUri(
+  it('keeps legacy cards whose saved URI was already expanded', () => {
+    expect(getSavedResourceUri(
       'mcp://documents/policies/2026',
       { tenant: 'Acme Corp' }
-    )).toThrow(/saved resource card migration required.*not a URI template/i);
+    )).toBe('mcp://documents/policies/2026');
+  });
+
+  it('surfaces a migration error for parameters absent from a saved URI template', () => {
+    expect(() => getSavedResourceUri(
+      'mcp://documents/{documentId}',
+      { documentId: 'policies/2026', tenant: 'Acme Corp' }
+    )).toThrow(/saved resource card migration required.*"tenant".*not present/i);
+  });
+
+  it('uses the SDK URI-template implementation for list values', () => {
+    expect(getSavedResourceUri(
+      'mcp://search{?tags}',
+      { tags: ['stateful', 'stateless'] }
+    )).toBe('mcp://search?tags=stateful,stateless');
   });
 });

--- a/src/utils/savedCardConnection.test.ts
+++ b/src/utils/savedCardConnection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getSavedCardConnectionPlan } from './savedCardConnection';
+import {
+  getSavedCardConnectionPlan,
+  getSavedResourceUri,
+} from './savedCardConnection';
 
 describe('saved dashboard card connections', () => {
   it('preserves an exact custom endpoint for direct OAuth connections', () => {
@@ -49,5 +52,28 @@ describe('saved dashboard card connections', () => {
       useProxy: true,
       proxyUrl: 'https://proxy.mcptest.test/',
     })).toThrow('Sign in is required');
+  });
+
+  it('expands a parameterized saved resource card into a resources/read URI', () => {
+    const uri = getSavedResourceUri(
+      'mcp://documents/{tenant}/{documentId}{?format,locale}',
+      {
+        tenant: 'Acme Corp',
+        documentId: 'policies/2026',
+        format: 'application/json',
+        locale: 'en-US',
+      }
+    );
+
+    expect(uri).toBe(
+      'mcp://documents/Acme%20Corp/policies%2F2026?format=application%2Fjson&locale=en-US'
+    );
+  });
+
+  it('surfaces a migration error when legacy resource parameters have no URI template', () => {
+    expect(() => getSavedResourceUri(
+      'mcp://documents/policies/2026',
+      { tenant: 'Acme Corp' }
+    )).toThrow(/saved resource card migration required.*not a URI template/i);
   });
 });

--- a/src/utils/savedCardConnection.test.ts
+++ b/src/utils/savedCardConnection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getSavedCardConnectionPlan } from './savedCardConnection';
+
+describe('saved dashboard card connections', () => {
+  it('preserves an exact custom endpoint for direct OAuth connections', () => {
+    expect(getSavedCardConnectionPlan({
+      serverUrl: 'https://mcp.example/custom/endpoint',
+      useProxy: false,
+      oauthToken: 'target-token',
+      proxyUrl: 'https://proxy.mcptest.test/',
+    })).toEqual({
+      connectionUrl: 'https://mcp.example/custom/endpoint',
+      authToken: 'target-token',
+      usesProxy: false,
+    });
+  });
+
+  it('separates proxy authentication from target OAuth authentication', () => {
+    const plan = getSavedCardConnectionPlan({
+      serverUrl: 'https://mcp.example/custom/endpoint?tenant=acme',
+      useProxy: true,
+      oauthToken: 'target-token',
+      proxyUrl: 'https://proxy.mcptest.test/gateway?region=eu',
+      proxyAuthToken: 'firebase-token',
+    });
+
+    expect(new URL(plan.connectionUrl).searchParams.get('target')).toBe(
+      'https://mcp.example/custom/endpoint?tenant=acme'
+    );
+    expect(new URL(plan.connectionUrl).searchParams.get('region')).toBe('eu');
+    expect(plan.authToken).toBe('firebase-token');
+    expect(new Headers(plan.targetHeaders).get('authorization')).toBe('Bearer target-token');
+    expect(plan.usesProxy).toBe(true);
+  });
+
+  it('keeps proxy-by-default behavior for legacy saved cards', () => {
+    const plan = getSavedCardConnectionPlan({
+      serverUrl: 'https://mcp.example/mcp',
+      proxyUrl: 'https://proxy.mcptest.test/',
+      proxyAuthToken: 'firebase-token',
+    });
+
+    expect(plan.usesProxy).toBe(true);
+  });
+
+  it('requires authentication only when the saved card selects the proxy', () => {
+    expect(() => getSavedCardConnectionPlan({
+      serverUrl: 'https://mcp.example/mcp',
+      useProxy: true,
+      proxyUrl: 'https://proxy.mcptest.test/',
+    })).toThrow('Sign in is required');
+  });
+});

--- a/src/utils/savedCardConnection.test.ts
+++ b/src/utils/savedCardConnection.test.ts
@@ -90,4 +90,23 @@ describe('saved dashboard card connections', () => {
       { tags: ['stateful', 'stateless'] }
     )).toBe('mcp://search?tags=stateful,stateless');
   });
+
+  it('omits optional resource parameters left unset by the form', () => {
+    expect(getSavedResourceUri(
+      'mcp://documents/{documentId}{?format,locale,filter}',
+      {
+        documentId: 'policies/2026',
+        format: '',
+        locale: undefined,
+        filter: null,
+      }
+    )).toBe('mcp://documents/policies%2F2026');
+  });
+
+  it('omits an empty optional list', () => {
+    expect(getSavedResourceUri(
+      'mcp://search{?tags}',
+      { tags: [] }
+    )).toBe('mcp://search');
+  });
 });

--- a/src/utils/savedCardConnection.ts
+++ b/src/utils/savedCardConnection.ts
@@ -13,6 +13,208 @@ export interface SavedCardConnectionPlan {
   usesProxy: boolean;
 }
 
+interface UriTemplateOperator {
+  prefix: string;
+  separator: string;
+  named: boolean;
+  emptyValue: string;
+  allowReserved: boolean;
+}
+
+interface UriTemplateVariable {
+  name: string;
+  explode: boolean;
+  prefixLength?: number;
+}
+
+const URI_TEMPLATE_OPERATORS: Record<string, UriTemplateOperator> = {
+  '': { prefix: '', separator: ',', named: false, emptyValue: '', allowReserved: false },
+  '+': { prefix: '', separator: ',', named: false, emptyValue: '', allowReserved: true },
+  '#': { prefix: '#', separator: ',', named: false, emptyValue: '', allowReserved: true },
+  '.': { prefix: '.', separator: '.', named: false, emptyValue: '', allowReserved: false },
+  '/': { prefix: '/', separator: '/', named: false, emptyValue: '', allowReserved: false },
+  ';': { prefix: ';', separator: ';', named: true, emptyValue: '', allowReserved: false },
+  '?': { prefix: '?', separator: '&', named: true, emptyValue: '=', allowReserved: false },
+  '&': { prefix: '&', separator: '&', named: true, emptyValue: '=', allowReserved: false },
+};
+
+export class SavedResourceCardMigrationError extends Error {
+  constructor(message: string) {
+    super(`Saved resource card migration required: ${message}`);
+    this.name = 'SavedResourceCardMigrationError';
+  }
+}
+
+const parseTemplateExpression = (expression: string): {
+  operator: UriTemplateOperator;
+  variables: UriTemplateVariable[];
+} => {
+  const operatorKey = Object.prototype.hasOwnProperty.call(
+    URI_TEMPLATE_OPERATORS,
+    expression[0]
+  )
+    ? expression[0]
+    : '';
+  const variableList = operatorKey ? expression.slice(1) : expression;
+  if (!variableList) {
+    throw new SavedResourceCardMigrationError('the saved URI template is invalid.');
+  }
+
+  const variables = variableList.split(',').map(variable => {
+    const match = /^([A-Za-z0-9_.%]+)(?::([1-9][0-9]{0,3})|(\*))?$/.exec(variable);
+    if (!match) {
+      throw new SavedResourceCardMigrationError(
+        `the URI template variable "${variable}" is not supported.`
+      );
+    }
+    return {
+      name: match[1],
+      explode: Boolean(match[3]),
+      prefixLength: match[2] ? Number(match[2]) : undefined,
+    };
+  });
+
+  return { operator: URI_TEMPLATE_OPERATORS[operatorKey], variables };
+};
+
+const encodeTemplateValue = (value: string, allowReserved: boolean): string => {
+  const encodeCharacter = (character: string) => encodeURIComponent(character)
+    .replace(/[!'()*]/g, match => `%${match.charCodeAt(0).toString(16).toUpperCase()}`);
+  const reservedCharacter = /[:/?#\[\]@!$&'()*+,;=]/;
+
+  return Array.from(value)
+    .map(character => allowReserved && reservedCharacter.test(character)
+      ? character
+      : encodeCharacter(character))
+    .join('');
+};
+
+const asScalar = (value: unknown, parameterName: string): string => {
+  if (typeof value === 'object' || typeof value === 'function' || typeof value === 'symbol') {
+    throw new SavedResourceCardMigrationError(
+      `parameter "${parameterName}" contains a value that cannot be expanded into its URI template.`
+    );
+  }
+  return String(value);
+};
+
+const formatNamedValue = (
+  name: string,
+  value: string,
+  operator: UriTemplateOperator
+): string => `${name}${value === '' ? operator.emptyValue : `=${value}`}`;
+
+const expandTemplateVariable = (
+  variable: UriTemplateVariable,
+  value: unknown,
+  operator: UriTemplateOperator
+): string => {
+  const encodedName = encodeTemplateValue(variable.name, false);
+  const encode = (item: unknown) => encodeTemplateValue(
+    asScalar(item, variable.name),
+    operator.allowReserved
+  );
+
+  if (!Array.isArray(value) && (typeof value !== 'object' || value === null)) {
+    let scalar = asScalar(value, variable.name);
+    if (variable.prefixLength !== undefined) {
+      scalar = Array.from(scalar).slice(0, variable.prefixLength).join('');
+    }
+    const encodedValue = encodeTemplateValue(scalar, operator.allowReserved);
+    return operator.named
+      ? formatNamedValue(encodedName, encodedValue, operator)
+      : encodedValue;
+  }
+
+  if (variable.prefixLength !== undefined) {
+    throw new SavedResourceCardMigrationError(
+      `parameter "${variable.name}" uses a URI prefix modifier with a composite value.`
+    );
+  }
+
+  if (Array.isArray(value)) {
+    const encodedItems = value.map(encode);
+    if (variable.explode) {
+      return encodedItems
+        .map(item => operator.named ? formatNamedValue(encodedName, item, operator) : item)
+        .join(operator.separator);
+    }
+    const joinedItems = encodedItems.join(',');
+    return operator.named
+      ? formatNamedValue(encodedName, joinedItems, operator)
+      : joinedItems;
+  }
+
+  const encodedEntries = Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+    encodeTemplateValue(key, operator.allowReserved),
+    encode(item),
+  ]);
+  if (variable.explode) {
+    return encodedEntries
+      .map(([key, item]) => formatNamedValue(key, item, operator))
+      .join(operator.separator);
+  }
+  const joinedEntries = encodedEntries.flat().join(',');
+  return operator.named
+    ? formatNamedValue(encodedName, joinedEntries, operator)
+    : joinedEntries;
+};
+
+/**
+ * Converts a saved resource card's URI template and persisted parameters into
+ * the concrete URI required by the standard MCP `resources/read` method.
+ */
+export const getSavedResourceUri = (
+  uriTemplate: string,
+  params: Record<string, unknown> | null | undefined
+): string => {
+  const savedParams = params ?? {};
+  const expressionPattern = /\{([^{}]+)\}/g;
+  const expressions = Array.from(uriTemplate.matchAll(expressionPattern));
+
+  if (expressions.length === 0) {
+    if (Object.keys(savedParams).length > 0) {
+      throw new SavedResourceCardMigrationError(
+        `resource "${uriTemplate}" has saved parameters but is not a URI template. Recreate the card from a resource template.`
+      );
+    }
+    return uriTemplate;
+  }
+
+  const parsedExpressions = expressions.map(match => parseTemplateExpression(match[1]));
+  const templateVariables = new Set(
+    parsedExpressions.flatMap(({ variables }) => variables.map(({ name }) => name))
+  );
+  const unmappedParameters = Object.keys(savedParams)
+    .filter(parameter => !templateVariables.has(parameter));
+  if (unmappedParameters.length > 0) {
+    throw new SavedResourceCardMigrationError(
+      `parameters ${unmappedParameters.map(parameter => `"${parameter}"`).join(', ')} are not present in the saved URI template.`
+    );
+  }
+
+  let expressionIndex = 0;
+  const expandedUri = uriTemplate.replace(expressionPattern, () => {
+    const { operator, variables } = parsedExpressions[expressionIndex++];
+    const values = variables.flatMap(variable => {
+      if (!Object.prototype.hasOwnProperty.call(savedParams, variable.name)) return [];
+      const value = savedParams[variable.name];
+      if (value === null || value === undefined) {
+        throw new SavedResourceCardMigrationError(
+          `parameter "${variable.name}" has no value to expand into the URI template.`
+        );
+      }
+      return [expandTemplateVariable(variable, value, operator)];
+    });
+    return values.length > 0 ? operator.prefix + values.join(operator.separator) : '';
+  });
+
+  if (/[{}]/.test(expandedUri)) {
+    throw new SavedResourceCardMigrationError('the saved URI template is invalid.');
+  }
+  return expandedUri;
+};
+
 /**
  * Builds the connection inputs for a saved dashboard card. Legacy cards did
  * not persist `useProxy`, so they retain the old proxy-by-default behavior

--- a/src/utils/savedCardConnection.ts
+++ b/src/utils/savedCardConnection.ts
@@ -66,9 +66,16 @@ export const getSavedResourceUri = (
 
     const variables: Variables = {};
     for (const [parameterName, value] of Object.entries(savedParams)) {
-      variables[parameterName] = Array.isArray(value)
-        ? value.map(item => asTemplateScalar(item, parameterName))
-        : asTemplateScalar(value, parameterName);
+      // Resource forms use an empty string for an untouched optional field.
+      // Omit unset and empty-list values so RFC 6570 optional expressions do
+      // not become `?name=` and nullish values are never stringified.
+      if (value === null || value === undefined || value === '') continue;
+      if (Array.isArray(value)) {
+        if (value.length === 0) continue;
+        variables[parameterName] = value.map(item => asTemplateScalar(item, parameterName));
+      } else {
+        variables[parameterName] = asTemplateScalar(value, parameterName);
+      }
     }
     return template.expand(variables);
   } catch (error) {

--- a/src/utils/savedCardConnection.ts
+++ b/src/utils/savedCardConnection.ts
@@ -1,0 +1,56 @@
+export interface SavedCardConnectionOptions {
+  serverUrl: string;
+  useProxy?: boolean;
+  oauthToken?: string | null;
+  proxyUrl?: string;
+  proxyAuthToken?: string;
+}
+
+export interface SavedCardConnectionPlan {
+  connectionUrl: string;
+  authToken?: string;
+  targetHeaders?: HeadersInit;
+  usesProxy: boolean;
+}
+
+/**
+ * Builds the connection inputs for a saved dashboard card. Legacy cards did
+ * not persist `useProxy`, so they retain the old proxy-by-default behavior
+ * when no target OAuth token is available.
+ */
+export const getSavedCardConnectionPlan = ({
+  serverUrl,
+  useProxy,
+  oauthToken,
+  proxyUrl,
+  proxyAuthToken,
+}: SavedCardConnectionOptions): SavedCardConnectionPlan => {
+  const targetUrl = new URL(serverUrl).toString();
+  const usesProxy = Boolean(
+    proxyUrl && (useProxy !== undefined ? useProxy : !oauthToken)
+  );
+
+  if (!usesProxy) {
+    return {
+      connectionUrl: targetUrl,
+      authToken: oauthToken || undefined,
+      usesProxy: false,
+    };
+  }
+
+  if (!proxyAuthToken) {
+    throw new Error('Sign in is required to execute a saved card through the CORS proxy.');
+  }
+
+  const connectionUrl = new URL(proxyUrl as string);
+  connectionUrl.searchParams.set('target', targetUrl);
+
+  return {
+    connectionUrl: connectionUrl.toString(),
+    authToken: proxyAuthToken,
+    targetHeaders: oauthToken
+      ? { Authorization: `Bearer ${oauthToken}` }
+      : undefined,
+    usesProxy: true,
+  };
+};

--- a/src/utils/savedCardConnection.ts
+++ b/src/utils/savedCardConnection.ts
@@ -1,3 +1,5 @@
+import { UriTemplate, type Variables } from '@modelcontextprotocol/client';
+
 export interface SavedCardConnectionOptions {
   serverUrl: string;
   useProxy?: boolean;
@@ -13,31 +15,6 @@ export interface SavedCardConnectionPlan {
   usesProxy: boolean;
 }
 
-interface UriTemplateOperator {
-  prefix: string;
-  separator: string;
-  named: boolean;
-  emptyValue: string;
-  allowReserved: boolean;
-}
-
-interface UriTemplateVariable {
-  name: string;
-  explode: boolean;
-  prefixLength?: number;
-}
-
-const URI_TEMPLATE_OPERATORS: Record<string, UriTemplateOperator> = {
-  '': { prefix: '', separator: ',', named: false, emptyValue: '', allowReserved: false },
-  '+': { prefix: '', separator: ',', named: false, emptyValue: '', allowReserved: true },
-  '#': { prefix: '#', separator: ',', named: false, emptyValue: '', allowReserved: true },
-  '.': { prefix: '.', separator: '.', named: false, emptyValue: '', allowReserved: false },
-  '/': { prefix: '/', separator: '/', named: false, emptyValue: '', allowReserved: false },
-  ';': { prefix: ';', separator: ';', named: true, emptyValue: '', allowReserved: false },
-  '?': { prefix: '?', separator: '&', named: true, emptyValue: '=', allowReserved: false },
-  '&': { prefix: '&', separator: '&', named: true, emptyValue: '=', allowReserved: false },
-};
-
 export class SavedResourceCardMigrationError extends Error {
   constructor(message: string) {
     super(`Saved resource card migration required: ${message}`);
@@ -45,119 +22,19 @@ export class SavedResourceCardMigrationError extends Error {
   }
 }
 
-const parseTemplateExpression = (expression: string): {
-  operator: UriTemplateOperator;
-  variables: UriTemplateVariable[];
-} => {
-  const operatorKey = Object.prototype.hasOwnProperty.call(
-    URI_TEMPLATE_OPERATORS,
-    expression[0]
-  )
-    ? expression[0]
-    : '';
-  const variableList = operatorKey ? expression.slice(1) : expression;
-  if (!variableList) {
-    throw new SavedResourceCardMigrationError('the saved URI template is invalid.');
-  }
-
-  const variables = variableList.split(',').map(variable => {
-    const match = /^([A-Za-z0-9_.%]+)(?::([1-9][0-9]{0,3})|(\*))?$/.exec(variable);
-    if (!match) {
-      throw new SavedResourceCardMigrationError(
-        `the URI template variable "${variable}" is not supported.`
-      );
-    }
-    return {
-      name: match[1],
-      explode: Boolean(match[3]),
-      prefixLength: match[2] ? Number(match[2]) : undefined,
-    };
-  });
-
-  return { operator: URI_TEMPLATE_OPERATORS[operatorKey], variables };
-};
-
-const encodeTemplateValue = (value: string, allowReserved: boolean): string => {
-  const encodeCharacter = (character: string) => encodeURIComponent(character)
-    .replace(/[!'()*]/g, match => `%${match.charCodeAt(0).toString(16).toUpperCase()}`);
-  const reservedCharacter = /[:/?#\[\]@!$&'()*+,;=]/;
-
-  return Array.from(value)
-    .map(character => allowReserved && reservedCharacter.test(character)
-      ? character
-      : encodeCharacter(character))
-    .join('');
-};
-
-const asScalar = (value: unknown, parameterName: string): string => {
-  if (typeof value === 'object' || typeof value === 'function' || typeof value === 'symbol') {
+const asTemplateScalar = (value: unknown, parameterName: string): string => {
+  if (
+    value === null
+    || value === undefined
+    || typeof value === 'object'
+    || typeof value === 'function'
+    || typeof value === 'symbol'
+  ) {
     throw new SavedResourceCardMigrationError(
       `parameter "${parameterName}" contains a value that cannot be expanded into its URI template.`
     );
   }
   return String(value);
-};
-
-const formatNamedValue = (
-  name: string,
-  value: string,
-  operator: UriTemplateOperator
-): string => `${name}${value === '' ? operator.emptyValue : `=${value}`}`;
-
-const expandTemplateVariable = (
-  variable: UriTemplateVariable,
-  value: unknown,
-  operator: UriTemplateOperator
-): string => {
-  const encodedName = encodeTemplateValue(variable.name, false);
-  const encode = (item: unknown) => encodeTemplateValue(
-    asScalar(item, variable.name),
-    operator.allowReserved
-  );
-
-  if (!Array.isArray(value) && (typeof value !== 'object' || value === null)) {
-    let scalar = asScalar(value, variable.name);
-    if (variable.prefixLength !== undefined) {
-      scalar = Array.from(scalar).slice(0, variable.prefixLength).join('');
-    }
-    const encodedValue = encodeTemplateValue(scalar, operator.allowReserved);
-    return operator.named
-      ? formatNamedValue(encodedName, encodedValue, operator)
-      : encodedValue;
-  }
-
-  if (variable.prefixLength !== undefined) {
-    throw new SavedResourceCardMigrationError(
-      `parameter "${variable.name}" uses a URI prefix modifier with a composite value.`
-    );
-  }
-
-  if (Array.isArray(value)) {
-    const encodedItems = value.map(encode);
-    if (variable.explode) {
-      return encodedItems
-        .map(item => operator.named ? formatNamedValue(encodedName, item, operator) : item)
-        .join(operator.separator);
-    }
-    const joinedItems = encodedItems.join(',');
-    return operator.named
-      ? formatNamedValue(encodedName, joinedItems, operator)
-      : joinedItems;
-  }
-
-  const encodedEntries = Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-    encodeTemplateValue(key, operator.allowReserved),
-    encode(item),
-  ]);
-  if (variable.explode) {
-    return encodedEntries
-      .map(([key, item]) => formatNamedValue(key, item, operator))
-      .join(operator.separator);
-  }
-  const joinedEntries = encodedEntries.flat().join(',');
-  return operator.named
-    ? formatNamedValue(encodedName, joinedEntries, operator)
-    : joinedEntries;
 };
 
 /**
@@ -169,50 +46,38 @@ export const getSavedResourceUri = (
   params: Record<string, unknown> | null | undefined
 ): string => {
   const savedParams = params ?? {};
-  const expressionPattern = /\{([^{}]+)\}/g;
-  const expressions = Array.from(uriTemplate.matchAll(expressionPattern));
 
-  if (expressions.length === 0) {
-    if (Object.keys(savedParams).length > 0) {
-      throw new SavedResourceCardMigrationError(
-        `resource "${uriTemplate}" has saved parameters but is not a URI template. Recreate the card from a resource template.`
-      );
-    }
+  // Older mcptest versions persisted the already-expanded URI alongside its
+  // original arguments. It is complete and must not be expanded a second time.
+  if (!UriTemplate.isTemplate(uriTemplate)) {
     return uriTemplate;
   }
 
-  const parsedExpressions = expressions.map(match => parseTemplateExpression(match[1]));
-  const templateVariables = new Set(
-    parsedExpressions.flatMap(({ variables }) => variables.map(({ name }) => name))
-  );
-  const unmappedParameters = Object.keys(savedParams)
-    .filter(parameter => !templateVariables.has(parameter));
-  if (unmappedParameters.length > 0) {
+  try {
+    const template = new UriTemplate(uriTemplate);
+    const templateVariables = new Set(template.variableNames);
+    const unmappedParameters = Object.keys(savedParams)
+      .filter(parameter => !templateVariables.has(parameter));
+    if (unmappedParameters.length > 0) {
+      throw new SavedResourceCardMigrationError(
+        `parameters ${unmappedParameters.map(parameter => `"${parameter}"`).join(', ')} are not present in the saved URI template.`
+      );
+    }
+
+    const variables: Variables = {};
+    for (const [parameterName, value] of Object.entries(savedParams)) {
+      variables[parameterName] = Array.isArray(value)
+        ? value.map(item => asTemplateScalar(item, parameterName))
+        : asTemplateScalar(value, parameterName);
+    }
+    return template.expand(variables);
+  } catch (error) {
+    if (error instanceof SavedResourceCardMigrationError) throw error;
+    const reason = error instanceof Error ? error.message : String(error);
     throw new SavedResourceCardMigrationError(
-      `parameters ${unmappedParameters.map(parameter => `"${parameter}"`).join(', ')} are not present in the saved URI template.`
+      `resource "${uriTemplate}" has an invalid URI template: ${reason}`
     );
   }
-
-  let expressionIndex = 0;
-  const expandedUri = uriTemplate.replace(expressionPattern, () => {
-    const { operator, variables } = parsedExpressions[expressionIndex++];
-    const values = variables.flatMap(variable => {
-      if (!Object.prototype.hasOwnProperty.call(savedParams, variable.name)) return [];
-      const value = savedParams[variable.name];
-      if (value === null || value === undefined) {
-        throw new SavedResourceCardMigrationError(
-          `parameter "${variable.name}" has no value to expand into the URI template.`
-        );
-      }
-      return [expandTemplateVariable(variable, value, operator)];
-    });
-    return values.length > 0 ? operator.prefix + values.join(operator.separator) : '';
-  });
-
-  if (/[{}]/.test(expandedUri)) {
-    throw new SavedResourceCardMigrationError('the saved URI template is invalid.');
-  }
-  return expandedUri;
 };
 
 /**

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CANDIDATE_GROUP_TIMEOUT_MS,
+  TransportConnectionError,
   attemptParallelConnections,
   getRequestHeadersForCandidate,
   getTransportCandidates,
@@ -78,7 +79,8 @@ describe('transport candidate generation', () => {
 
   it('varies the target rather than the proxy endpoint', () => {
     const candidates = getTransportCandidates(
-      'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fcustom%2Fendpoint'
+      'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fcustom%2Fendpoint',
+      true
     );
 
     expect(candidates).toHaveLength(4);
@@ -86,6 +88,22 @@ describe('transport candidate generation', () => {
     expect(candidates.every(({ url }) => (
       new URL(url).searchParams.get('target')?.startsWith('https://example.com/custom/endpoint')
     ))).toBe(true);
+  });
+
+  it.each([
+    ['URL-valued', 'https://tenant.example/account'],
+    ['ordinary', 'production'],
+  ])('preserves a direct custom endpoint with a %s target parameter', (_, target) => {
+    const endpoint = new URL('https://mcp.example/custom/endpoint');
+    endpoint.searchParams.set('target', target);
+    endpoint.searchParams.set('tenant', 'acme');
+
+    const candidates = getTransportCandidates(endpoint.toString(), false);
+
+    expect(candidates[0].url).toBe(endpoint.toString());
+    expect(candidates.every(({ url }) => new URL(url).origin === endpoint.origin)).toBe(true);
+    expect(candidates.every(({ url }) => new URL(url).searchParams.get('target') === target)).toBe(true);
+    expect(candidates.every(({ url }) => new URL(url).searchParams.get('tenant') === 'acme')).toBe(true);
   });
 
   it('prefers a declared terminal SSE endpoint before its HTTP sibling', () => {
@@ -158,16 +176,44 @@ describe('transport candidate generation', () => {
   it('keeps target Authorization separate from proxy authentication', () => {
     const proxyHeaders = getRequestHeadersForCandidate(
       'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fmcp',
-      { Authorization: 'Bearer target-secret', 'x-api-key': 'api-secret' }
+      { Authorization: 'Bearer target-secret', 'x-api-key': 'api-secret' },
+      true
     );
     const directHeaders = getRequestHeadersForCandidate(
-      'https://example.com/mcp',
-      { Authorization: 'Bearer target-secret' }
+      'https://example.com/custom?target=https%3A%2F%2Ftenant.example',
+      { Authorization: 'Bearer target-secret' },
+      false
     );
 
     expect(proxyHeaders.get('authorization')).toBeNull();
     expect(proxyHeaders.get('x-mcp-authorization')).toBe('Bearer target-secret');
     expect(proxyHeaders.get('x-api-key')).toBe('api-secret');
     expect(directHeaders.get('authorization')).toBe('Bearer target-secret');
+  });
+
+  it('retains structured HTTP failures from candidate attempts', async () => {
+    const targetAuthError = Object.assign(new Error('Target requires authentication'), {
+      status: 401,
+    });
+    connectionMocks.connect = async () => {
+      throw targetAuthError;
+    };
+
+    let connectionError: unknown;
+    try {
+      await attemptParallelConnections('https://example.com/custom');
+    } catch (error) {
+      connectionError = error;
+    }
+
+    expect(connectionError).toBeInstanceOf(TransportConnectionError);
+    const containsTargetError = (error: unknown): boolean => (
+      error === targetAuthError
+      || (
+        error instanceof TransportConnectionError
+        && error.errors.some(containsTargetError)
+      )
+    );
+    expect(containsTargetError(connectionError)).toBe(true);
   });
 });

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -186,6 +186,43 @@ describe('transport candidate generation', () => {
     });
   });
 
+  it('preserves a settled authentication error when its slash sibling times out', async () => {
+    vi.useFakeTimers();
+    const targetAuthError = Object.assign(new Error('Target requires authentication'), {
+      status: 401,
+    });
+    connectionMocks.connect = async ({ endpoint }) => {
+      if (endpoint.pathname === '/mcp') throw targetAuthError;
+      if (endpoint.pathname === '/mcp/') await new Promise(() => {});
+      throw new Error('Fallback endpoint failed');
+    };
+
+    const connectionPromise = attemptParallelConnections('https://example.com/mcp');
+    const connectionOutcome = connectionPromise.catch((error) => error);
+    await vi.advanceTimersByTimeAsync(CANDIDATE_GROUP_TIMEOUT_MS);
+
+    const connectionError: unknown = await connectionOutcome;
+
+    const findAuthenticationCandidate = (error: unknown): { candidateUrl: string } | undefined => {
+      if (!(error instanceof TransportConnectionError)) return undefined;
+      const match = error.candidateFailures.find(({ error: candidateError }) => (
+        (candidateError as { status?: number }).status === 401
+      ));
+      if (match) return match;
+      for (const nestedError of error.errors) {
+        const nestedMatch = findAuthenticationCandidate(nestedError);
+        if (nestedMatch) return nestedMatch;
+      }
+      return undefined;
+    };
+
+    expect(connectionError).toBeInstanceOf(TransportConnectionError);
+    expect(findAuthenticationCandidate(connectionError)).toMatchObject({
+      candidateUrl: 'https://example.com/mcp',
+      error: targetAuthError,
+    });
+  });
+
   it('keeps target Authorization separate from proxy authentication', () => {
     const proxyHeaders = getRequestHeadersForCandidate(
       'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fmcp',

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -270,4 +270,26 @@ describe('transport candidate generation', () => {
       responseSource: 'target',
     });
   });
+
+  it('retains proxy response provenance for requests made after connection', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Unauthorized', {
+      status: 401,
+      headers: { 'X-MCP-Proxy-Response-Source': 'target' },
+    })));
+
+    const connection = await attemptParallelConnections(
+      'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fcustom',
+      undefined,
+      'firebase-jwt',
+      undefined,
+      true
+    );
+    await connection.transport.fetch?.(connection.url);
+
+    expect(connection.takeAuthenticationChallenge()).toEqual({
+      status: 401,
+      source: 'target',
+    });
+    expect(connection.takeAuthenticationChallenge()).toBeUndefined();
+  });
 });

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CANDIDATE_GROUP_TIMEOUT_MS,
+  ProxiedAuthenticationError,
   TransportConnectionError,
   attemptParallelConnections,
   getRequestHeadersForCandidate,
@@ -8,7 +9,10 @@ import {
 } from './transportDetection';
 
 const connectionMocks = vi.hoisted(() => ({
-  connect: async (_transport: { endpoint: URL }) => {},
+  connect: async (_transport: {
+    endpoint: URL;
+    fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  }) => {},
 }));
 
 vi.mock('./mcpClient', () => {
@@ -29,13 +33,21 @@ vi.mock('./mcpClient', () => {
 
 vi.mock('./corsAwareTransport', () => ({
   CorsAwareStreamableHTTPTransport: class {
-    constructor(readonly endpoint: URL) {}
+    readonly fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+    constructor(readonly endpoint: URL, options?: { fetch?: typeof fetch }) {
+      this.fetch = options?.fetch;
+    }
   },
 }));
 
 vi.mock('./corsAwareSseTransport', () => ({
   CorsAwareSSETransport: class {
-    constructor(readonly endpoint: URL) {}
+    readonly fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+    constructor(readonly endpoint: URL, options?: { fetch?: typeof fetch }) {
+      this.fetch = options?.fetch;
+    }
   },
 }));
 
@@ -45,6 +57,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe('transport candidate generation', () => {
@@ -215,5 +228,46 @@ describe('transport candidate generation', () => {
       )
     );
     expect(containsTargetError(connectionError)).toBe(true);
+  });
+
+  it('preserves a target authentication challenge observed through the proxy', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Forbidden', {
+      status: 403,
+      headers: { 'X-MCP-Proxy-Response-Source': 'target' },
+    })));
+    connectionMocks.connect = async ({ endpoint, fetch }) => {
+      const response = await fetch?.(endpoint);
+      throw Object.assign(new Error('Connection rejected'), { status: response?.status });
+    };
+
+    let connectionError: unknown;
+    try {
+      await attemptParallelConnections(
+        'https://proxy.mcptest.io/?target=https%3A%2F%2Fexample.com%2Fcustom',
+        undefined,
+        'firebase-jwt',
+        undefined,
+        true
+      );
+    } catch (error) {
+      connectionError = error;
+    }
+
+    const findProxiedAuthenticationError = (
+      error: unknown
+    ): ProxiedAuthenticationError | undefined => {
+      if (error instanceof ProxiedAuthenticationError) return error;
+      if (error instanceof TransportConnectionError) {
+        for (const nestedError of error.errors) {
+          const match = findProxiedAuthenticationError(nestedError);
+          if (match) return match;
+        }
+      }
+      return undefined;
+    };
+    expect(findProxiedAuthenticationError(connectionError)).toMatchObject({
+      status: 403,
+      responseSource: 'target',
+    });
   });
 });

--- a/src/utils/transportDetection.test.ts
+++ b/src/utils/transportDetection.test.ts
@@ -308,6 +308,56 @@ describe('transport candidate generation', () => {
     });
   });
 
+  it('preserves a direct authentication challenge from the HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Unauthorized', {
+      status: 401,
+    })));
+    connectionMocks.connect = async ({ endpoint, fetch }) => {
+      await fetch?.(endpoint);
+      throw new Error('Connection rejected');
+    };
+
+    let connectionError: unknown;
+    try {
+      await attemptParallelConnections('https://example.com/custom');
+    } catch (error) {
+      connectionError = error;
+    }
+
+    const findAuthenticationError = (
+      error: unknown
+    ): ProxiedAuthenticationError | undefined => {
+      if (error instanceof ProxiedAuthenticationError) return error;
+      if (error instanceof TransportConnectionError) {
+        for (const nestedError of error.errors) {
+          const match = findAuthenticationError(nestedError);
+          if (match) return match;
+        }
+      }
+      return undefined;
+    };
+
+    expect(findAuthenticationError(connectionError)).toMatchObject({
+      status: 401,
+      responseSource: 'target',
+    });
+  });
+
+  it('retains direct target provenance for requests made after connection', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Forbidden', {
+      status: 403,
+    })));
+
+    const connection = await attemptParallelConnections('https://example.com/custom');
+    await connection.transport.fetch?.(connection.url);
+
+    expect(connection.takeAuthenticationChallenge()).toEqual({
+      status: 403,
+      source: 'target',
+    });
+    expect(connection.takeAuthenticationChallenge()).toBeUndefined();
+  });
+
   it('retains proxy response provenance for requests made after connection', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('Unauthorized', {
       status: 401,

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -25,6 +25,11 @@ export class TransportConnectionError extends Error {
 
 export type ProxyAuthenticationSource = 'proxy' | 'target';
 
+export interface ObservedAuthenticationChallenge {
+  status: 401 | 403;
+  source: ProxyAuthenticationSource;
+}
+
 export class ProxiedAuthenticationError extends Error {
   readonly cause: unknown;
 
@@ -168,6 +173,7 @@ type ConnectedCandidate = {
   transportType: TransportType;
   client: Client;
   url: string;
+  takeAuthenticationChallenge: () => ObservedAuthenticationChallenge | undefined;
 };
 
 const firstSuccessful = <T,>(promises: Promise<T>[]): Promise<T> => {
@@ -256,10 +262,7 @@ export async function attemptParallelConnections(
       : createNegotiatingMcpClient('mcptest-web');
     clients.push(client);
     const endpoint = new URL(candidate.url);
-    let proxyAuthChallenge: {
-      status: 401 | 403;
-      source: ProxyAuthenticationSource;
-    } | undefined;
+    let proxyAuthChallenge: ObservedAuthenticationChallenge | undefined;
     const transportOpts = transportOptionsFor(candidate.url, (status, source) => {
       proxyAuthChallenge = { status, source };
     });
@@ -279,7 +282,17 @@ export async function attemptParallelConnections(
       }
       throw error;
     }
-    return { ...candidate, client, transport };
+    proxyAuthChallenge = undefined;
+    return {
+      ...candidate,
+      client,
+      transport,
+      takeAuthenticationChallenge: () => {
+        const challenge = proxyAuthChallenge;
+        proxyAuthChallenge = undefined;
+        return challenge;
+      },
+    };
   };
 
   let removeAbortListener = () => {};

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -13,6 +13,16 @@ export interface TransportCandidate {
   transportType: TransportType;
 }
 
+export class TransportConnectionError extends Error {
+  constructor(readonly errors: readonly unknown[]) {
+    super(`All connections failed: ${errors.map((error) => (
+      (error instanceof Error ? error.message : String(error))
+        .replace(/^All connections failed: /, '')
+    )).join(', ')}`);
+    this.name = 'TransportConnectionError';
+  }
+}
+
 export const CANDIDATE_GROUP_TIMEOUT_MS = 5_000;
 
 const slashVariants = (value: URL): URL[] => {
@@ -79,14 +89,21 @@ const directCandidates = (endpoint: URL): TransportCandidate[] => {
 };
 
 /**
- * Builds connection candidates while preserving exact custom endpoints. For
- * proxy URLs, only the encoded target is varied; the proxy URL itself remains
- * untouched.
+ * Builds connection candidates while preserving exact custom endpoints. A URL
+ * is interpreted using the proxy `target` convention only when its caller has
+ * explicitly selected the configured proxy route.
  */
-export const getTransportCandidates = (serverUrl: string): TransportCandidate[] => {
+export const getTransportCandidates = (
+  serverUrl: string,
+  usesProxy = false
+): TransportCandidate[] => {
   const outerUrl = new URL(serverUrl);
+  if (!usesProxy) return directCandidates(outerUrl);
+
   const targetValue = outerUrl.searchParams.get('target');
-  if (!targetValue) return directCandidates(outerUrl);
+  if (!targetValue) {
+    throw new Error('Proxy connection URL is missing its target endpoint.');
+  }
 
   const targetUrl = new URL(targetValue);
   return directCandidates(targetUrl).map((candidate) => {
@@ -97,13 +114,13 @@ export const getTransportCandidates = (serverUrl: string): TransportCandidate[] 
 };
 
 export const getRequestHeadersForCandidate = (
-  candidateUrl: string,
-  requestHeaders?: HeadersInit
+  _candidateUrl: string,
+  requestHeaders?: HeadersInit,
+  usesProxy = false
 ): Headers => {
   const headers = new Headers(requestHeaders);
-  const candidate = new URL(candidateUrl);
 
-  if (candidate.searchParams.has('target') && headers.has('Authorization')) {
+  if (usesProxy && headers.has('Authorization')) {
     headers.set('X-MCP-Authorization', headers.get('Authorization') || '');
     headers.delete('Authorization');
   }
@@ -120,26 +137,27 @@ type ConnectedCandidate = {
 
 const firstSuccessful = <T,>(promises: Promise<T>[]): Promise<T> => {
   return new Promise((resolve, reject) => {
-    const errors: Error[] = [];
+    const errors: unknown[] = [];
     let remaining = promises.length;
 
     for (const promise of promises) {
       promise.then(resolve).catch((error) => {
-        errors.push(error instanceof Error ? error : new Error(String(error)));
+        errors.push(error);
         remaining -= 1;
         if (remaining === 0) {
-          reject(new Error(
-            `All connections failed: ${errors.map(({ message }) => message).join(', ')}`
-          ));
+          reject(new TransportConnectionError(errors));
         }
       });
     }
   });
 };
 
-const candidateGroupKey = (candidate: TransportCandidate): string => {
+const candidateGroupKey = (
+  candidate: TransportCandidate,
+  usesProxy: boolean
+): string => {
   const outerUrl = new URL(candidate.url);
-  const targetValue = outerUrl.searchParams.get('target');
+  const targetValue = usesProxy ? outerUrl.searchParams.get('target') : null;
   const endpoint = targetValue ? new URL(targetValue) : outerUrl;
   endpoint.pathname = endpoint.pathname.replace(/\/+$/, '') || '/';
 
@@ -147,7 +165,8 @@ const candidateGroupKey = (candidate: TransportCandidate): string => {
 };
 
 const groupCandidatesByPriority = (
-  candidates: TransportCandidate[]
+  candidates: TransportCandidate[],
+  usesProxy: boolean
 ): TransportCandidate[][] => {
   const groups: TransportCandidate[][] = [];
 
@@ -155,7 +174,7 @@ const groupCandidatesByPriority = (
     const currentGroup = groups[groups.length - 1];
     if (
       !currentGroup
-      || candidateGroupKey(currentGroup[0]) !== candidateGroupKey(candidate)
+      || candidateGroupKey(currentGroup[0], usesProxy) !== candidateGroupKey(candidate, usesProxy)
     ) {
       groups.push([candidate]);
     } else {
@@ -170,12 +189,13 @@ export async function attemptParallelConnections(
   serverUrl: string,
   abortSignal?: AbortSignal,
   authToken?: string,
-  requestHeaders?: HeadersInit
+  requestHeaders?: HeadersInit,
+  usesProxy = false
 ): Promise<ConnectedCandidate & { protocolEra: ProtocolEra; protocolVersion?: string }> {
-  const candidates = getTransportCandidates(serverUrl);
+  const candidates = getTransportCandidates(serverUrl, usesProxy);
   const clients: Client[] = [];
   const transportOptionsFor = (candidateUrl: string) => {
-    const headers = getRequestHeadersForCandidate(candidateUrl, requestHeaders);
+    const headers = getRequestHeadersForCandidate(candidateUrl, requestHeaders, usesProxy);
 
     return {
       ...(authToken ? { authProvider: { token: async () => authToken } } : {}),
@@ -217,7 +237,7 @@ export async function attemptParallelConnections(
   try {
     const failures: Error[] = [];
 
-    for (const candidateGroup of groupCandidatesByPriority(candidates)) {
+    for (const candidateGroup of groupCandidatesByPriority(candidates, usesProxy)) {
       if (abortSignal?.aborted) {
         throw new Error('Connection aborted by user');
       }
@@ -266,11 +286,7 @@ export async function attemptParallelConnections(
       };
     }
 
-    throw new Error(
-      `All connections failed: ${failures.map(({ message }) => (
-        message.replace(/^All connections failed: /, '')
-      )).join(', ')}`
-    );
+    throw new TransportConnectionError(failures);
   } catch (error) {
     await Promise.allSettled(clients.map((client) => client.close()));
     throw error;

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -13,8 +13,16 @@ export interface TransportCandidate {
   transportType: TransportType;
 }
 
+export interface TransportCandidateFailure {
+  candidateUrl: string;
+  error: unknown;
+}
+
 export class TransportConnectionError extends Error {
-  constructor(readonly errors: readonly unknown[]) {
+  constructor(
+    readonly errors: readonly unknown[],
+    readonly candidateFailures: readonly TransportCandidateFailure[] = []
+  ) {
     super(`All connections failed: ${errors.map((error) => (
       (error instanceof Error ? error.message : String(error))
         .replace(/^All connections failed: /, '')
@@ -176,17 +184,21 @@ type ConnectedCandidate = {
   takeAuthenticationChallenge: () => ObservedAuthenticationChallenge | undefined;
 };
 
-const firstSuccessful = <T,>(promises: Promise<T>[]): Promise<T> => {
+const firstSuccessful = <T,>(
+  attempts: Array<{ promise: Promise<T>; candidateUrl: string }>,
+  candidateFailures: TransportCandidateFailure[]
+): Promise<T> => {
   return new Promise((resolve, reject) => {
     const errors: unknown[] = [];
-    let remaining = promises.length;
+    let remaining = attempts.length;
 
-    for (const promise of promises) {
+    for (const { promise, candidateUrl } of attempts) {
       promise.then(resolve).catch((error) => {
         errors.push(error);
+        candidateFailures.push({ candidateUrl, error });
         remaining -= 1;
         if (remaining === 0) {
-          reject(new TransportConnectionError(errors));
+          reject(new TransportConnectionError(errors, [...candidateFailures]));
         }
       });
     }
@@ -313,17 +325,28 @@ export async function attemptParallelConnections(
 
       let successful: ConnectedCandidate;
       const firstGroupClientIndex = clients.length;
+      const candidateFailures: TransportCandidateFailure[] = [];
       let groupTimeoutId: ReturnType<typeof setTimeout> | undefined;
       const groupTimeout = new Promise<never>((_, reject) => {
         groupTimeoutId = setTimeout(() => {
-          reject(new Error(
+          const timeoutError = new Error(
             `Connection candidates timed out after ${CANDIDATE_GROUP_TIMEOUT_MS / 1000} seconds`
+          );
+          reject(new TransportConnectionError(
+            [...candidateFailures.map(({ error }) => error), timeoutError],
+            [...candidateFailures]
           ));
         }, CANDIDATE_GROUP_TIMEOUT_MS);
       });
       try {
         successful = await Promise.race([
-          firstSuccessful(candidateGroup.map(attemptConnection)),
+          firstSuccessful(
+            candidateGroup.map((candidate) => ({
+              promise: attemptConnection(candidate),
+              candidateUrl: candidate.url,
+            })),
+            candidateFailures
+          ),
           abortPromise,
           groupTimeout,
         ]);

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -1,4 +1,4 @@
-import type { Client, ProtocolEra } from '@modelcontextprotocol/client';
+import type { Client, FetchLike, ProtocolEra } from '@modelcontextprotocol/client';
 import { TransportType } from '../types';
 import { CorsAwareStreamableHTTPTransport } from './corsAwareTransport';
 import { CorsAwareSSETransport } from './corsAwareSseTransport';
@@ -22,6 +22,41 @@ export class TransportConnectionError extends Error {
     this.name = 'TransportConnectionError';
   }
 }
+
+export type ProxyAuthenticationSource = 'proxy' | 'target';
+
+export class ProxiedAuthenticationError extends Error {
+  readonly cause: unknown;
+
+  constructor(
+    readonly status: 401 | 403,
+    readonly responseSource: ProxyAuthenticationSource,
+    cause: unknown
+  ) {
+    super(
+      responseSource === 'target'
+        ? `MCP target returned HTTP ${status} through the authenticated proxy`
+        : `Authenticated proxy returned HTTP ${status}`
+    );
+    this.name = 'ProxiedAuthenticationError';
+    this.cause = cause;
+  }
+}
+
+const PROXY_RESPONSE_SOURCE_HEADER = 'X-MCP-Proxy-Response-Source';
+
+const observeProxyAuthenticationResponses = (
+  onChallenge: (status: 401 | 403, source: ProxyAuthenticationSource) => void
+): FetchLike => async (input, init) => {
+  const response = await fetch(input, init);
+  if (response.status === 401 || response.status === 403) {
+    const responseSource = response.headers.get(PROXY_RESPONSE_SOURCE_HEADER) === 'target'
+      ? 'target'
+      : 'proxy';
+    onChallenge(response.status, responseSource);
+  }
+  return response;
+};
 
 export const CANDIDATE_GROUP_TIMEOUT_MS = 5_000;
 
@@ -194,12 +229,16 @@ export async function attemptParallelConnections(
 ): Promise<ConnectedCandidate & { protocolEra: ProtocolEra; protocolVersion?: string }> {
   const candidates = getTransportCandidates(serverUrl, usesProxy);
   const clients: Client[] = [];
-  const transportOptionsFor = (candidateUrl: string) => {
+  const transportOptionsFor = (
+    candidateUrl: string,
+    onProxyAuthChallenge: (status: 401 | 403, source: ProxyAuthenticationSource) => void
+  ) => {
     const headers = getRequestHeadersForCandidate(candidateUrl, requestHeaders, usesProxy);
 
     return {
       ...(authToken ? { authProvider: { token: async () => authToken } } : {}),
       ...(Array.from(headers.keys()).length > 0 ? { headers } : {}),
+      ...(usesProxy ? { fetch: observeProxyAuthenticationResponses(onProxyAuthChallenge) } : {}),
     };
   };
 
@@ -217,12 +256,29 @@ export async function attemptParallelConnections(
       : createNegotiatingMcpClient('mcptest-web');
     clients.push(client);
     const endpoint = new URL(candidate.url);
-    const transportOpts = transportOptionsFor(candidate.url);
+    let proxyAuthChallenge: {
+      status: 401 | 403;
+      source: ProxyAuthenticationSource;
+    } | undefined;
+    const transportOpts = transportOptionsFor(candidate.url, (status, source) => {
+      proxyAuthChallenge = { status, source };
+    });
     const transport = candidate.transportType === 'legacy-sse'
       ? new CorsAwareSSETransport(endpoint, transportOpts)
       : new CorsAwareStreamableHTTPTransport(endpoint, transportOpts);
 
-    await client.connect(transport);
+    try {
+      await client.connect(transport);
+    } catch (error) {
+      if (proxyAuthChallenge) {
+        throw new ProxiedAuthenticationError(
+          proxyAuthChallenge.status,
+          proxyAuthChallenge.source,
+          error
+        );
+      }
+      throw error;
+    }
     return { ...candidate, client, transport };
   };
 

--- a/src/utils/transportDetection.ts
+++ b/src/utils/transportDetection.ts
@@ -48,7 +48,7 @@ export class ProxiedAuthenticationError extends Error {
   ) {
     super(
       responseSource === 'target'
-        ? `MCP target returned HTTP ${status} through the authenticated proxy`
+        ? `MCP target returned HTTP ${status}`
         : `Authenticated proxy returned HTTP ${status}`
     );
     this.name = 'ProxiedAuthenticationError';
@@ -58,14 +58,17 @@ export class ProxiedAuthenticationError extends Error {
 
 const PROXY_RESPONSE_SOURCE_HEADER = 'X-MCP-Proxy-Response-Source';
 
-const observeProxyAuthenticationResponses = (
+const observeAuthenticationResponses = (
+  usesProxy: boolean,
   onChallenge: (status: 401 | 403, source: ProxyAuthenticationSource) => void
 ): FetchLike => async (input, init) => {
   const response = await fetch(input, init);
   if (response.status === 401 || response.status === 403) {
-    const responseSource = response.headers.get(PROXY_RESPONSE_SOURCE_HEADER) === 'target'
+    const responseSource = !usesProxy
       ? 'target'
-      : 'proxy';
+      : response.headers.get(PROXY_RESPONSE_SOURCE_HEADER) === 'target'
+        ? 'target'
+        : 'proxy';
     onChallenge(response.status, responseSource);
   }
   return response;
@@ -249,14 +252,14 @@ export async function attemptParallelConnections(
   const clients: Client[] = [];
   const transportOptionsFor = (
     candidateUrl: string,
-    onProxyAuthChallenge: (status: 401 | 403, source: ProxyAuthenticationSource) => void
+    onAuthenticationChallenge: (status: 401 | 403, source: ProxyAuthenticationSource) => void
   ) => {
     const headers = getRequestHeadersForCandidate(candidateUrl, requestHeaders, usesProxy);
 
     return {
       ...(authToken ? { authProvider: { token: async () => authToken } } : {}),
       ...(Array.from(headers.keys()).length > 0 ? { headers } : {}),
-      ...(usesProxy ? { fetch: observeProxyAuthenticationResponses(onProxyAuthChallenge) } : {}),
+      fetch: observeAuthenticationResponses(usesProxy, onAuthenticationChallenge),
     };
   };
 
@@ -274,9 +277,9 @@ export async function attemptParallelConnections(
       : createNegotiatingMcpClient('mcptest-web');
     clients.push(client);
     const endpoint = new URL(candidate.url);
-    let proxyAuthChallenge: ObservedAuthenticationChallenge | undefined;
+    let authenticationChallenge: ObservedAuthenticationChallenge | undefined;
     const transportOpts = transportOptionsFor(candidate.url, (status, source) => {
-      proxyAuthChallenge = { status, source };
+      authenticationChallenge = { status, source };
     });
     const transport = candidate.transportType === 'legacy-sse'
       ? new CorsAwareSSETransport(endpoint, transportOpts)
@@ -285,23 +288,23 @@ export async function attemptParallelConnections(
     try {
       await client.connect(transport);
     } catch (error) {
-      if (proxyAuthChallenge) {
+      if (authenticationChallenge) {
         throw new ProxiedAuthenticationError(
-          proxyAuthChallenge.status,
-          proxyAuthChallenge.source,
+          authenticationChallenge.status,
+          authenticationChallenge.source,
           error
         );
       }
       throw error;
     }
-    proxyAuthChallenge = undefined;
+    authenticationChallenge = undefined;
     return {
       ...candidate,
       client,
       transport,
       takeAuthenticationChallenge: () => {
-        const challenge = proxyAuthChallenge;
-        proxyAuthChallenge = undefined;
+        const challenge = authenticationChallenge;
+        authenticationChallenge = undefined;
         return challenge;
       },
     };


### PR DESCRIPTION
## Summary

- evaluate remote MCP servers with the official SDK negotiation path, supporting current stateless Streamable HTTP and legacy stateful HTTP+SSE
- preserve exact custom endpoints while trying conventional terminal-path fallbacks only when needed
- keep proxy authentication separate from target-server OAuth credentials
- modernize saved dashboard cards and resource reads to use the negotiated transport and standard MCP methods
- normalize report scoring dynamically and make report/history controls accessible
- remove speculative OAuth discovery before report execution so authentication is offered only after a real server response

## Verification

- `npm test` — 63 tests passed
- `npx tsc --noEmit`
- `npm run build` — Vite production build plus 26 generated SEO server profiles
- desktop and 390px report-route browser audits — no overflow, nested interactive controls, or unlabeled buttons
- `git diff --check`
