### PR TITLE
Fix OAuth-required server report state

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,7 +7,7 @@ const Footer: React.FC = () => {
         <div className="row align-items-center">
           <div className="col-12 col-md-8">
             <p className="text-muted small mb-1">
-              &copy; {new Date().getFullYear()} <a href="/docs/contact" className="text-muted">Unchained Development OÜ</a>. All rights reserved.
+              Copyright {new Date().getFullYear()} <a href="/docs/contact" className="text-muted">Unchained Development OÜ</a>. All rights reserved.
             </p>
             <p className="text-muted small mb-0">
               Your application data, including server connections and history, is stored only in your browser's local storage. No data is gathered or stored on our servers.

--- a/src/components/ReportAuthorizationGate.test.tsx
+++ b/src/components/ReportAuthorizationGate.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import ReportAuthorizationGate from './ReportAuthorizationGate';
+
+describe('ReportAuthorizationGate', () => {
+  it('presents OAuth as an unscored prerequisite with both authorization paths', () => {
+    const markup = renderToStaticMarkup(
+      <ReportAuthorizationGate
+        serverUrl="https://mcp.figma.com/"
+        onAuthorize={vi.fn()}
+        onConfigureClient={vi.fn()}
+      />
+    );
+    const container = document.createElement('div');
+    container.innerHTML = markup;
+
+    expect(container.textContent).toContain('Authorization required');
+    expect(container.textContent).toContain('Not scored');
+    expect(container.textContent).toContain('not a failed report');
+    expect(container.textContent).toContain('Authorize and run report');
+    expect(container.textContent).toContain('Enter client credentials');
+    expect(container.textContent).not.toContain('Final Score');
+    expect(container.textContent).not.toContain('MCP negotiation failed');
+  });
+});

--- a/src/components/ReportAuthorizationGate.tsx
+++ b/src/components/ReportAuthorizationGate.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+interface ReportAuthorizationGateProps {
+  serverUrl: string;
+  error?: string | null;
+  isAuthorizing?: boolean;
+  isPreparingClient?: boolean;
+  onAuthorize: () => void;
+  onConfigureClient: () => void;
+}
+
+const displayHost = (value: string): string => {
+  try {
+    return new URL(value).host;
+  } catch {
+    return value;
+  }
+};
+
+const ReportAuthorizationGate: React.FC<ReportAuthorizationGateProps> = ({
+  serverUrl,
+  error,
+  isAuthorizing = false,
+  isPreparingClient = false,
+  onAuthorize,
+  onConfigureClient,
+}) => (
+  <section className="report-auth-gate" aria-labelledby="report-auth-title">
+    <div className="report-auth-heading">
+      <div className="report-auth-icon" aria-hidden="true">
+        <i className="bi bi-shield-lock-fill"></i>
+      </div>
+      <div>
+        <div className="d-flex flex-wrap align-items-center gap-2 mb-2">
+          <h3 id="report-auth-title" className="mb-0">Authorization required</h3>
+          <span className="badge text-bg-warning">Not scored</span>
+        </div>
+        <p className="mb-0">
+          <strong>{displayHost(serverUrl)}</strong> is a protected MCP server. Its protocol,
+          capabilities, transport, and performance cannot be evaluated until you authorize
+          mcptest.io to access it.
+        </p>
+      </div>
+    </div>
+
+    <div className="report-auth-note">
+      This is an authorization gate, not a failed report. No grade or zero score has been assigned.
+    </div>
+
+    {error && <div className="alert alert-danger mb-0" role="alert">{error}</div>}
+
+    <div className="report-auth-options" aria-label="OAuth authorization options">
+      <div className="report-auth-option">
+        <div>
+          <h4>Continue with OAuth</h4>
+          <p>
+            Use server discovery and PKCE. You will be redirected to the provider's authorization
+            page to approve access, then the report will run again automatically.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={onAuthorize}
+          disabled={isAuthorizing || isPreparingClient}
+        >
+          {isAuthorizing ? (
+            <><span className="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>Preparing OAuth...</>
+          ) : (
+            <><i className="bi bi-box-arrow-up-right me-2" aria-hidden="true"></i>Authorize and run report</>
+          )}
+        </button>
+      </div>
+
+      <div className="report-auth-option">
+        <div>
+          <h4>Use a registered OAuth client</h4>
+          <p>
+            Choose this when the provider gave you a client ID, or when it does not allow
+            automatic client registration. Client credentials stay in this browser tab.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          onClick={onConfigureClient}
+          disabled={isAuthorizing || isPreparingClient}
+        >
+          {isPreparingClient ? (
+            <><span className="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>Discovering provider...</>
+          ) : (
+            <><i className="bi bi-key me-2" aria-hidden="true"></i>Enter client credentials</>
+          )}
+        </button>
+      </div>
+    </div>
+  </section>
+);
+
+export default ReportAuthorizationGate;

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -2,17 +2,25 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import OAuthConfig from './OAuthConfig';
+import ReportAuthorizationGate from './ReportAuthorizationGate';
 import {
   beginOAuthFlow,
   isOAuthClientConfigurationRequired,
   loadOAuthAuthorization,
+  prepareManualOAuthClient,
 } from '../utils/oauthFlow';
 import {
   evaluateServer,
   getEvaluationMaxScore,
   getEvaluationPercentage,
+  isAuthenticationRequired,
   type EvaluationReport,
 } from '../utils/evaluation';
+import {
+  createTestedServerHistoryEntry,
+  getTestedServerResultLabel,
+  type TestedServerHistoryEntry,
+} from '../utils/reportPresentation';
 
 // Helper functions for score display
 const getScoreColor = (score: number): string => {
@@ -29,12 +37,6 @@ const getScoreGrade = (score: number): string => {
   if (score >= 60) return 'D';
   return 'F';
 };
-
-interface TestedServer {
-  url: string;
-  score: number;
-  timestamp: number;
-}
 
 const ReportView: React.FC = () => {
   const navigate = useNavigate();
@@ -65,8 +67,10 @@ const ReportView: React.FC = () => {
   const [progress, setProgress] = useState<string[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
-  const [testedServers, setTestedServers] = useState<TestedServer[]>([]);
+  const [testedServers, setTestedServers] = useState<TestedServerHistoryEntry[]>([]);
   const [oauthConfigServerUrl, setOAuthConfigServerUrl] = useState<string | null>(null);
+  const [oauthAction, setOAuthAction] = useState<'authorize' | 'configure' | null>(null);
+  const [oauthError, setOAuthError] = useState<string | null>(null);
 
   // Track if initial report has been triggered
   const [hasInitialized, setHasInitialized] = useState(false);
@@ -206,9 +210,9 @@ const ReportView: React.FC = () => {
     });
   };
 
-  const addOrUpdateServer = (url: string, score: number) => {
-    const newServer = { url, score, timestamp: Date.now() };
-    const updatedServers = [newServer, ...testedServers.filter(s => s.url !== url)];
+  const addOrUpdateServer = (reportData: EvaluationReport) => {
+    const newServer = createTestedServerHistoryEntry(reportData);
+    const updatedServers = [newServer, ...testedServers.filter(s => s.url !== reportData.serverUrl)];
     setTestedServers(updatedServers);
     localStorage.setItem('mcpTestedServers', JSON.stringify(updatedServers));
   };
@@ -255,12 +259,10 @@ const ReportView: React.FC = () => {
       const reportData = await evaluateServer(urlToTest, token, onProgress, oauthAccessToken);
       setReport(reportData);
       
-      // A resolved evaluation always has a typed score; failures reject instead.
-      addOrUpdateServer(urlToTest, Math.round(getEvaluationPercentage(reportData)));
+      addOrUpdateServer(reportData);
       
-      // If authentication is required, show a button to authenticate
-      if (reportData && reportData.sections && reportData.sections.auth) {
-        setProgress(prev => [...prev, 'Authentication required. Please authenticate with the server and run the report again.']);
+      if (isAuthenticationRequired(reportData)) {
+        setProgress(prev => [...prev, 'OAuth authorization is required before this server can be scored.']);
       }
     } catch (error) {
       console.error('Report error:', error);
@@ -278,6 +280,8 @@ const ReportView: React.FC = () => {
   }, [handleRunReport]);
 
   const startOAuth = useCallback(async (authenticationUrl: string) => {
+    setOAuthAction('authorize');
+    setOAuthError(null);
     sessionStorage.setItem('oauth_return_view', JSON.stringify({
       activeView: 'report',
       serverUrl: authenticationUrl,
@@ -295,15 +299,32 @@ const ReportView: React.FC = () => {
         return;
       }
       const message = error instanceof Error ? error.message : 'Unknown OAuth error';
-      setProgress(prev => [...prev, `OAuth authorization failed: ${message}`]);
+      setOAuthError(`OAuth authorization could not start: ${message}`);
+    } finally {
+      setOAuthAction(null);
     }
   }, []);
 
-  const scoredSections = report
+  const configureOAuthClient = useCallback(async (authenticationUrl: string) => {
+    setOAuthAction('configure');
+    setOAuthError(null);
+    try {
+      await prepareManualOAuthClient(authenticationUrl);
+      setOAuthConfigServerUrl(authenticationUrl);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown OAuth discovery error';
+      setOAuthError(`OAuth provider discovery failed: ${message}`);
+    } finally {
+      setOAuthAction(null);
+    }
+  }, []);
+
+  const reportRequiresAuthorization = report ? isAuthenticationRequired(report) : false;
+  const scoredSections = report && !reportRequiresAuthorization
     ? Object.entries(report.sections).filter(([key]) => key !== 'auth')
     : [];
-  const reportMaxScore = report ? getEvaluationMaxScore(report) : 0;
-  const reportPercentage = report ? getEvaluationPercentage(report) : 0;
+  const reportMaxScore = report && !reportRequiresAuthorization ? getEvaluationMaxScore(report) : 0;
+  const reportPercentage = report && !reportRequiresAuthorization ? getEvaluationPercentage(report) : 0;
 
   return (
     <div className="container-fluid h-100 d-flex flex-column" style={{ paddingBottom: '2rem' }}>
@@ -344,7 +365,7 @@ const ReportView: React.FC = () => {
                   >
                     <div className="fw-bold">{server.url}</div>
                     <small className="text-muted">
-                      Score: {server.score}% • Tested {new Date(server.timestamp).toLocaleString()}
+                      {getTestedServerResultLabel(server)}. Tested {new Date(server.timestamp).toLocaleString()}
                     </small>
                   </button>
                   <button
@@ -392,29 +413,31 @@ const ReportView: React.FC = () => {
         <div className="card mb-4">
           <div className="card-header">
             <h4>Report for: {report.serverUrl}</h4>
-            <h3 className={`text-${getScoreColor(reportPercentage)}`}>
-              Final Score: {report.finalScore} / {reportMaxScore} ({Math.round(reportPercentage)}% · {getScoreGrade(reportPercentage)})
-            </h3>
-            {!report.sections.security && (
-              <small className="text-muted">
-                OAuth security metadata was not included in this run; the base report is scored out of {reportMaxScore} points.
-              </small>
+            {!reportRequiresAuthorization && (
+              <>
+                <h3 className={`text-${getScoreColor(reportPercentage)}`}>
+                  Final Score: {report.finalScore} / {reportMaxScore} ({Math.round(reportPercentage)}%, grade {getScoreGrade(reportPercentage)})
+                </h3>
+                {!report.sections.security && (
+                  <small className="text-muted">
+                    OAuth security metadata was not included in this run; the base report is scored out of {reportMaxScore} points.
+                  </small>
+                )}
+              </>
             )}
           </div>
           <div className="card-body">
-            {report.sections && report.sections.auth && (
-              <div className="alert alert-warning mb-3">
-                <h5>OAuth Authentication Required</h5>
-                <p>This server requires OAuth authentication before it can be evaluated.</p>
-                <button 
-                  className="btn btn-primary"
-                  onClick={() => startOAuth(report.authenticationUrl || report.serverUrl)}
-                >
-                  Authenticate with Server
-                </button>
-              </div>
-            )}
-            <div className="row g-3">
+            {reportRequiresAuthorization ? (
+              <ReportAuthorizationGate
+                serverUrl={report.serverUrl}
+                error={oauthError}
+                isAuthorizing={oauthAction === 'authorize'}
+                isPreparingClient={oauthAction === 'configure'}
+                onAuthorize={() => startOAuth(report.authenticationUrl || report.serverUrl)}
+                onConfigureClient={() => configureOAuthClient(report.authenticationUrl || report.serverUrl)}
+              />
+            ) : (
+              <div className="row g-3">
               {scoredSections.map(([key, section]) => {
                 const sectionPercentage = section.maxScore > 0
                   ? section.score / section.maxScore * 100
@@ -505,7 +528,8 @@ const ReportView: React.FC = () => {
                 </div>
                 );
               })}
-            </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/ReportView.tsx
+++ b/src/components/ReportView.tsx
@@ -20,6 +20,7 @@ import {
   createTestedServerHistoryEntry,
   getTestedServerResultLabel,
   type TestedServerHistoryEntry,
+  upsertTestedServerHistoryEntry,
 } from '../utils/reportPresentation';
 
 // Helper functions for score display
@@ -210,12 +211,14 @@ const ReportView: React.FC = () => {
     });
   };
 
-  const addOrUpdateServer = (reportData: EvaluationReport) => {
+  const addOrUpdateServer = useCallback((reportData: EvaluationReport) => {
     const newServer = createTestedServerHistoryEntry(reportData);
-    const updatedServers = [newServer, ...testedServers.filter(s => s.url !== reportData.serverUrl)];
-    setTestedServers(updatedServers);
-    localStorage.setItem('mcpTestedServers', JSON.stringify(updatedServers));
-  };
+    setTestedServers((currentServers) => {
+      const updatedServers = upsertTestedServerHistoryEntry(currentServers, newServer);
+      localStorage.setItem('mcpTestedServers', JSON.stringify(updatedServers));
+      return updatedServers;
+    });
+  }, []);
 
   const removeServer = useCallback((urlToRemove: string) => {
     const updatedServers = testedServers.filter(s => s.url !== urlToRemove);
@@ -235,6 +238,7 @@ const ReportView: React.FC = () => {
 
     setIsRunning(true);
     isRunningRef.current = true;
+    setOAuthError(null);
     setProgress(['Starting evaluation...']);
     setReport(null);
     

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -451,7 +451,7 @@ const SideNav: React.FC<SideNavProps> = ({
       <div className="mt-auto pt-3 border-top small">
         <div className="px-2 text-center">
           <p className="text-muted mb-1">
-            &copy; {new Date().getFullYear()} <Link to="/docs/contact" className="text-muted">Unchained Development OÜ</Link>.
+            Copyright {new Date().getFullYear()} <Link to="/docs/contact" className="text-muted">Unchained Development OÜ</Link>.
           </p>
           <div className="mb-2">
             <Link to="/docs/contact" className="text-muted me-2" style={{ fontSize: '0.8rem' }}>

--- a/src/index.css
+++ b/src/index.css
@@ -3459,3 +3459,102 @@ pre.bg-light code {
     min-height: 520px;
   }
 }
+
+/* OAuth-gated reports are prerequisites, not failed scorecards. */
+.report-auth-gate {
+  display: grid;
+  gap: 1.25rem;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: clamp(1.1rem, 3vw, 2rem);
+  border: 1px solid color-mix(in srgb, var(--warning-color) 42%, var(--border-color));
+  border-radius: 0.9rem;
+  background:
+    radial-gradient(circle at 100% 0, color-mix(in srgb, var(--warning-color) 12%, transparent), transparent 42%),
+    var(--card-bg);
+}
+
+.report-auth-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.report-auth-heading h3 {
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  letter-spacing: -0.035em;
+}
+
+.report-auth-heading p,
+.report-auth-option p {
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.report-auth-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--warning-color) 42%, var(--border-color));
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--warning-color) 12%, var(--card-bg));
+  color: color-mix(in srgb, var(--warning-color) 72%, var(--text-color));
+  font-size: 1.25rem;
+}
+
+.report-auth-note {
+  padding: 0.8rem 0.9rem;
+  border-left: 3px solid var(--warning-color);
+  background: color-mix(in srgb, var(--warning-color) 8%, var(--card-bg-secondary));
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.report-auth-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.report-auth-option {
+  display: flex;
+  min-width: 0;
+  min-height: 230px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--card-bg-secondary) 68%, var(--card-bg));
+}
+
+.report-auth-option h4 {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.report-auth-option p {
+  margin-bottom: 0;
+  font-size: 0.88rem;
+}
+
+.report-auth-option .btn {
+  min-height: 2.75rem;
+}
+
+@media (max-width: 767.98px) {
+  .report-auth-heading {
+    grid-template-columns: 1fr;
+  }
+
+  .report-auth-options {
+    grid-template-columns: 1fr;
+  }
+
+  .report-auth-option {
+    min-height: 0;
+  }
+}

--- a/src/utils/evaluation.test.ts
+++ b/src/utils/evaluation.test.ts
@@ -16,6 +16,7 @@ import {
   getEvaluationProxyHeaders,
   getEvaluationTargetUrl,
   getEvaluationTransportProbeUrl,
+  isAuthenticationRequired,
 } from './evaluation';
 import {
   ProxiedAuthenticationError,
@@ -249,16 +250,19 @@ describe('dual-era server evaluation', () => {
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
+    expect(report.outcome).toBe('authorization-required');
+    expect(isAuthenticationRequired(report)).toBe(true);
     expect(report.sections.auth).toBeDefined();
-    expect(report.sections.auth.details[0].context).toContain('Direct target returned HTTP 401');
+    expect(report.sections.auth.details[0].context).toBe(
+      'The MCP endpoint returned HTTP 401 during unauthenticated negotiation.'
+    );
     expect(report.sections.auth.details[0].metadata).toEqual({
       route: 'direct',
       status: 401,
       endpoint: 'https://mcp.example/mcp',
     });
-    expect(report.sections.protocol.score).toBe(0);
-    expect(report.sections.protocol.details[0].text).toContain('Direct target:');
-    expect(report.sections.protocol.details[0].text).toContain('Authenticated proxy:');
+    expect(Object.keys(report.sections)).toEqual(['auth']);
+    expect(getEvaluationMaxScore(report)).toBe(0);
     expect(JSON.stringify(report)).not.toContain('/mcp/v1/');
   });
 
@@ -312,8 +316,11 @@ describe('dual-era server evaluation', () => {
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
+    expect(report.outcome).toBe('authorization-required');
     expect(report.sections.auth).toBeDefined();
-    expect(report.sections.auth.details[0].context).toContain('MCP target returned HTTP 403');
+    expect(report.sections.auth.details[0].context).toBe(
+      'The MCP endpoint returned HTTP 403 during unauthenticated negotiation.'
+    );
     expect(report.sections.auth.details[0].metadata).toEqual({
       route: 'proxy',
       status: 403,
@@ -343,9 +350,10 @@ describe('dual-era server evaluation', () => {
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
+    expect(report.outcome).toBe('authorization-required');
     expect(report.sections.auth).toBeDefined();
     expect(report.sections.auth.details[0]).toMatchObject({
-      context: 'tools/list returned HTTP 401',
+      context: 'The MCP endpoint returned HTTP 401 for tools/list.',
       metadata: {
         method: 'tools/list',
         route: 'direct',
@@ -353,7 +361,7 @@ describe('dual-era server evaluation', () => {
         authenticationSource: 'target',
       },
     });
-    expect(report.sections.capabilities.score).toBe(6);
+    expect(Object.keys(report.sections)).toEqual(['auth']);
     expect(client.listResources).toHaveBeenCalledOnce();
     expect(client.listPrompts).toHaveBeenCalledOnce();
   });
@@ -461,13 +469,14 @@ describe('dual-era server evaluation', () => {
 
     const report = await evaluateServer('https://mcp.example/mcp', 'firebase-jwt', vi.fn());
 
+    expect(report.outcome).toBe('authorization-required');
     expect(report.sections.auth.details[0].metadata).toMatchObject({
       method: 'resources/list',
       route: 'proxy',
       status: 403,
       authenticationSource: 'target',
     });
-    expect(report.sections.capabilities.score).toBe(7);
+    expect(Object.keys(report.sections)).toEqual(['auth']);
   });
 
   it('includes OAuth security posture when protected-resource metadata is supported', async () => {

--- a/src/utils/evaluation.ts
+++ b/src/utils/evaluation.ts
@@ -89,9 +89,14 @@ interface EvaluationSection {
 export interface EvaluationReport {
   serverUrl: string;
   authenticationUrl?: string;
+  outcome?: 'scored' | 'authorization-required';
   finalScore: number;
   sections: Record<string, EvaluationSection>;
 }
+
+export const isAuthenticationRequired = (report: EvaluationReport): boolean => (
+  report.outcome === 'authorization-required' || Boolean(report.sections.auth)
+);
 
 export const getEvaluationMaxScore = (report: EvaluationReport): number => (
   Object.entries(report.sections)
@@ -716,7 +721,12 @@ export async function evaluateServer(
 ): Promise<EvaluationReport> {
   const serverUrl = normalizeServerUrl(inputUrl);
   const oauthToken = oauthAccessToken || null;
-  const report: EvaluationReport = { serverUrl, finalScore: 0, sections: {} };
+  const report: EvaluationReport = {
+    serverUrl,
+    outcome: 'scored',
+    finalScore: 0,
+    sections: {},
+  };
   let connection: ConnectedEvaluation | null = null;
   const connectionStartedAt = Date.now();
 
@@ -735,6 +745,28 @@ export async function evaluateServer(
       (failure.httpStatus === 401 || failure.httpStatus === 403)
       && failure.authenticationSource === 'target'
     ));
+    if (targetAuthFailure) {
+      report.outcome = 'authorization-required';
+      report.authenticationUrl = targetAuthFailure.candidateUrl || serverUrl;
+      report.sections.auth = {
+        name: 'Authorization Required',
+        description: 'OAuth authorization is required before this server can be evaluated',
+        score: 0,
+        maxScore: 0,
+        details: [{
+          text: '⚠ Authorize with the server before running its report.',
+          context: `The MCP endpoint returned HTTP ${targetAuthFailure.httpStatus || 401} during unauthenticated negotiation.`,
+          metadata: {
+            route: targetAuthFailure.route,
+            status: targetAuthFailure.httpStatus,
+            endpoint: report.authenticationUrl,
+          },
+        }],
+      };
+      onProgress('OAuth authorization is required before evaluation can continue.');
+      return report;
+    }
+
     report.sections.protocol = makeSkippedSection(
       'Core Protocol Adherence',
       'Validates MCP lifecycle and JSON-RPC negotiation',
@@ -765,24 +797,6 @@ export async function evaluateServer(
       15,
       'Performance was not scored because negotiation failed.'
     );
-    if (targetAuthFailure) {
-      report.authenticationUrl = targetAuthFailure.candidateUrl || serverUrl;
-      report.sections.auth = {
-        name: 'Authentication Required',
-        description: 'The MCP endpoint rejected unauthenticated negotiation',
-        score: 0,
-        maxScore: 1,
-        details: [{
-          text: '⚠ Authenticate with the server and run the report again.',
-          context: targetAuthFailure.message,
-          metadata: {
-            route: targetAuthFailure.route,
-            status: targetAuthFailure.httpStatus,
-            endpoint: report.authenticationUrl,
-          },
-        }],
-      };
-    }
     report.finalScore = report.sections.cors.score;
     onProgress('Evaluation finished without an MCP connection.');
     return report;
@@ -823,16 +837,17 @@ export async function evaluateServer(
     const capabilityEvaluation = await evaluateCapabilities(connection);
     report.sections.capabilities = capabilityEvaluation.section;
     if (capabilityEvaluation.targetAuthenticationFailures.length > 0) {
+      report.outcome = 'authorization-required';
       report.authenticationUrl = capabilityEvaluation.targetAuthenticationFailures[0].candidateUrl
         || getEvaluationTargetUrl(connection.url, connection.usedProxy);
-      report.sections.auth = {
-        name: 'Authentication Required',
-        description: 'The MCP endpoint rejected standardized capability requests',
+      report.sections = { auth: {
+        name: 'Authorization Required',
+        description: 'OAuth authorization is required before this server can be evaluated',
         score: 0,
-        maxScore: 1,
+        maxScore: 0,
         details: capabilityEvaluation.targetAuthenticationFailures.map((failure) => ({
-          text: `⚠ Authenticate with the server and retry ${failure.method}.`,
-          context: failure.message,
+          text: `⚠ Authorize with the server before calling ${failure.method}.`,
+          context: `The MCP endpoint returned HTTP ${failure.httpStatus || 401} for ${failure.method}.`,
           metadata: {
             method: failure.method,
             route: failure.route,
@@ -841,7 +856,10 @@ export async function evaluateServer(
             endpoint: failure.candidateUrl || report.authenticationUrl,
           },
         })),
-      };
+      } };
+      report.finalScore = 0;
+      onProgress('OAuth authorization is required before evaluation can continue.');
+      return report;
     }
 
     const modernTransport = connection.transportType === 'streamable-http';

--- a/src/utils/oauthFlow.test.ts
+++ b/src/utils/oauthFlow.test.ts
@@ -10,6 +10,7 @@ import {
   completeOAuthFlow,
   isOAuthClientConfigurationRequired,
   loadOAuthAuthorization,
+  prepareManualOAuthClient,
   saveManualOAuthClient,
 } from './oauthFlow';
 
@@ -208,6 +209,28 @@ describe('BrowserOAuthProvider', () => {
       issuer: ISSUER_A,
     });
     expect(provider.clientInformation({ issuer: ISSUER_B })).toBeUndefined();
+  });
+
+  it('prepares provider discovery before showing manual client configuration', async () => {
+    const discover = vi.fn().mockResolvedValue({
+      authorizationServerUrl: ISSUER_A,
+      authorizationServerMetadata: {
+        issuer: ISSUER_A,
+        authorization_endpoint: `${ISSUER_A}authorize`,
+        token_endpoint: `${ISSUER_A}token`,
+        response_types_supported: ['code'],
+      },
+    });
+
+    await prepareManualOAuthClient(SERVER_URL, { discover, redirect: vi.fn() });
+    saveManualOAuthClient(SERVER_URL, 'manual-client');
+
+    const provider = new BrowserOAuthProvider(SERVER_URL, { redirect: vi.fn() });
+    expect(discover).toHaveBeenCalledWith(SERVER_URL);
+    expect(provider.clientInformation({ issuer: ISSUER_A })).toMatchObject({
+      client_id: 'manual-client',
+      issuer: ISSUER_A,
+    });
   });
 
   it('rehydrates the UI token bridge when the SDK already has authorization', async () => {

--- a/src/utils/oauthFlow.ts
+++ b/src/utils/oauthFlow.ts
@@ -1,5 +1,6 @@
 import {
   auth,
+  discoverOAuthServerInfo,
   RegistrationRejectedError,
   type AuthOptions,
   type AuthResult,
@@ -62,6 +63,10 @@ export interface OAuthFlowOptions extends BrowserOAuthProviderOptions {
 export interface CompletedOAuthFlow {
   serverUrl: string;
   issuer?: string;
+}
+
+export interface PrepareManualOAuthClientOptions extends BrowserOAuthProviderOptions {
+  discover?: typeof discoverOAuthServerInfo;
 }
 
 export interface OAuthAuthorization {
@@ -429,6 +434,17 @@ export const beginOAuthFlow = async (
   });
   if (result === 'AUTHORIZED') provider.syncLegacyTokens();
   return result;
+};
+
+export const prepareManualOAuthClient = async (
+  serverUrl: string,
+  options: PrepareManualOAuthClientOptions = {}
+): Promise<void> => {
+  const normalizedServerUrl = normalizeOAuthServerUrl(serverUrl);
+  const { discover = discoverOAuthServerInfo, ...providerOptions } = options;
+  const provider = new BrowserOAuthProvider(normalizedServerUrl, providerOptions);
+  const discovery = provider.discoveryState() || await discover(normalizedServerUrl);
+  provider.saveDiscoveryState(discovery);
 };
 
 export const completeOAuthFlow = async (

--- a/src/utils/reportPresentation.test.ts
+++ b/src/utils/reportPresentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createTestedServerHistoryEntry,
   getTestedServerResultLabel,
+  upsertTestedServerHistoryEntry,
 } from './reportPresentation';
 
 describe('report presentation', () => {
@@ -49,5 +50,30 @@ describe('report presentation', () => {
 
     expect(entry.score).toBe(50);
     expect(getTestedServerResultLabel(entry)).toBe('Score: 50%');
+  });
+
+  it('replaces legacy raw URLs with the normalized authorization-required entry', () => {
+    const legacyEntry = {
+      url: 'mcp.example',
+      score: 92,
+      timestamp: 100,
+    };
+    const authorizationEntry = {
+      url: 'https://mcp.example/',
+      score: null,
+      timestamp: 200,
+      outcome: 'authorization-required' as const,
+    };
+
+    expect(upsertTestedServerHistoryEntry([legacyEntry], authorizationEntry)).toEqual([
+      authorizationEntry,
+    ]);
+  });
+
+  it('uses a safe string identity for malformed legacy URLs', () => {
+    const staleEntry = { url: ' invalid url ', score: 70, timestamp: 100 };
+    const replacement = { url: 'invalid url', score: null, timestamp: 200 };
+
+    expect(upsertTestedServerHistoryEntry([staleEntry], replacement)).toEqual([replacement]);
   });
 });

--- a/src/utils/reportPresentation.test.ts
+++ b/src/utils/reportPresentation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTestedServerHistoryEntry,
+  getTestedServerResultLabel,
+} from './reportPresentation';
+
+describe('report presentation', () => {
+  it('stores an OAuth-gated evaluation as not scored', () => {
+    const entry = createTestedServerHistoryEntry({
+      serverUrl: 'https://mcp.example/mcp',
+      authenticationUrl: 'https://mcp.example/mcp',
+      outcome: 'authorization-required',
+      finalScore: 0,
+      sections: {
+        auth: {
+          name: 'Authorization Required',
+          description: '',
+          score: 0,
+          maxScore: 0,
+          details: [],
+        },
+      },
+    }, 123);
+
+    expect(entry).toEqual({
+      url: 'https://mcp.example/mcp',
+      score: null,
+      timestamp: 123,
+      outcome: 'authorization-required',
+    });
+    expect(getTestedServerResultLabel(entry)).toBe('Authorization required - not scored');
+  });
+
+  it('keeps a completed evaluation score in history', () => {
+    const entry = createTestedServerHistoryEntry({
+      serverUrl: 'https://mcp.example/mcp',
+      outcome: 'scored',
+      finalScore: 35,
+      sections: {
+        protocol: {
+          name: 'Protocol',
+          description: '',
+          score: 35,
+          maxScore: 70,
+          details: [],
+        },
+      },
+    }, 456);
+
+    expect(entry.score).toBe(50);
+    expect(getTestedServerResultLabel(entry)).toBe('Score: 50%');
+  });
+});

--- a/src/utils/reportPresentation.ts
+++ b/src/utils/reportPresentation.ts
@@ -11,6 +11,18 @@ export interface TestedServerHistoryEntry {
   outcome?: 'scored' | 'authorization-required';
 }
 
+const getServerUrlIdentity = (value: string): string => {
+  const trimmedValue = value.trim();
+  try {
+    const withProtocol = /^https?:\/\//i.test(trimmedValue)
+      ? trimmedValue
+      : `https://${trimmedValue}`;
+    return new URL(withProtocol).toString();
+  } catch {
+    return trimmedValue;
+  }
+};
+
 export const createTestedServerHistoryEntry = (
   report: EvaluationReport,
   timestamp = Date.now()
@@ -39,4 +51,15 @@ export const getTestedServerResultLabel = (
     return 'Authorization required - not scored';
   }
   return typeof server.score === 'number' ? `Score: ${server.score}%` : 'Not scored';
+};
+
+export const upsertTestedServerHistoryEntry = (
+  servers: readonly TestedServerHistoryEntry[],
+  newServer: TestedServerHistoryEntry
+): TestedServerHistoryEntry[] => {
+  const newServerIdentity = getServerUrlIdentity(newServer.url);
+  return [
+    newServer,
+    ...servers.filter((server) => getServerUrlIdentity(server.url) !== newServerIdentity),
+  ];
 };

--- a/src/utils/reportPresentation.ts
+++ b/src/utils/reportPresentation.ts
@@ -1,0 +1,42 @@
+import {
+  getEvaluationPercentage,
+  isAuthenticationRequired,
+  type EvaluationReport,
+} from './evaluation';
+
+export interface TestedServerHistoryEntry {
+  url: string;
+  score: number | null;
+  timestamp: number;
+  outcome?: 'scored' | 'authorization-required';
+}
+
+export const createTestedServerHistoryEntry = (
+  report: EvaluationReport,
+  timestamp = Date.now()
+): TestedServerHistoryEntry => {
+  if (isAuthenticationRequired(report)) {
+    return {
+      url: report.serverUrl,
+      score: null,
+      timestamp,
+      outcome: 'authorization-required',
+    };
+  }
+
+  return {
+    url: report.serverUrl,
+    score: Math.round(getEvaluationPercentage(report)),
+    timestamp,
+    outcome: 'scored',
+  };
+};
+
+export const getTestedServerResultLabel = (
+  server: TestedServerHistoryEntry
+): string => {
+  if (server.outcome === 'authorization-required') {
+    return 'Authorization required - not scored';
+  }
+  return typeof server.score === 'number' ? `Score: ${server.score}%` : 'Not scored';
+};


### PR DESCRIPTION
## Summary

- treat target 401/403 responses as an authorization prerequisite instead of a failed, zero-point evaluation
- replace the error-filled scorecard with a focused OAuth gate offering automatic discovery/PKCE and registered-client configuration
- keep authorization-required runs unscored in report history and avoid replacement-character-prone score/copyright text
- prepare OAuth discovery before manual client configuration so credentials bind to the discovered issuer

## Validation

- npm test (138 tests)
- npm run build:workers
- npm run build
- browser audit against https://mcp.figma.com/mcp: discovery resolved to https://api.figma.com and the gate rendered without failure cards, final score, overflow, or browser errors
